### PR TITLE
Update Architecture Documentation for TinyNPU-Gemma

### DIFF
--- a/Architecture/Architecture.md
+++ b/Architecture/Architecture.md
@@ -1,60 +1,55 @@
-# TinyNPU-RTL Top-Level Architecture
+# TinyNPU-Gemma Top-Level Architecture
 
-TinyNPU is a scalable NxN Systolic Array-based matrix multiplication accelerator designed to operate on the Xilinx Zynq-7000 SoC (PYNQ-Z2) environment.
+TinyNPU-Gemma is a custom NPU designed specifically to accelerate the quantized **Gemma 3-4B-IT (E4B) LLM model** on the **Xilinx Kria KV260 FPGA board**. It evolved from an initial 12MP image enhancement project (SwinIR-Light) to focus strictly on maximizing the KV260's hardware resources (1,248 DSP48E2 slices, 144 BRAMs) for large language model inference.
+
+## System Block Diagram & 38-Clock Pipeline Latency
+
+The entire system is divided into the ARM Cortex-A53 CPU (Processing System, PS) and the NPU Core in the FPGA fabric (Programmable Logic, PL). Communication is handled via the AXI4-Lite interface, controlled using Memory Mapped I/O (MMIO).
+
+To minimize latency, TinyNPU-Gemma implements an ultra-deep, fully-pipelined data path ("The 4 Exodia Parts") that executes complex non-linear mathematical operations alongside matrix multiplication in just **38 clock cycles** (approx. 380ns at 100MHz).
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#e1f5fe', 'primaryBorderColor': '#01579b', 'lineColor': '#01579b', 'fontFamily': 'arial'}}}%%
+graph TD
+    subgraph "Pipeline Data Path (38-Clock Latency)"
+        direction LR
+        IN((Input 512-bit<br/>[W:A] Packed)) --> RMS["RMSNorm<br/>(2 Cycles)"]
+        RMS --> VSCALE["Vector Scaling<br/>(1 Cycle)"]
+        VSCALE --> MAC["32x32 Systolic Array<br/>MAC Engine<br/>(32 Cycles)"]
+        MAC --> ACT{"Activation<br/>Select"}
+        ACT -- Score --> SM["Softmax<br/>(3 Cycles)"]
+        ACT -- Value --> GELU["GeLU<br/>(1 Cycle)"]
+        SM --> OUT((Output))
+        GELU --> OUT
+    end
+    
+    style RMS fill:#ffe0b2,stroke:#e65100
+    style VSCALE fill:#fff9c4,stroke:#fbc02d
+    style MAC fill:#c8e6c9,stroke:#1b5e20
+    style SM fill:#f8bbd0,stroke:#ad1457
+    style GELU fill:#e1bee7,stroke:#4a148c
+```
 
 ## System Block Diagram
 
 The entire system is divided into the ARM Cortex-A9 CPU (Processing System, PS) and the NPU Core in the FPGA fabric (Programmable Logic, PL). Communication is handled via the AXI4-Lite interface, controlled using Memory Mapped I/O (MMIO).
 
-```mermaid
-block-beta
-    columns 4
-    
-    %% Processing System
-    block:PS:1
-        CPU["ARM Cortex-A9 (PS)"]
-        Jupyter["Jupyter Notebook\n(Python)"]
-        CPU --- Jupyter
-    end
+### The 4 Exodia Parts (Hardware Accelerators)
 
-    %% AXI Bus
-    AXI(("AXI4-Lite\nInterconnect"))
-    
-    %% NPU IP
-    block:NPU_IP:2
-        columns 2
-        AXI_WRAPPER["AXI4-Lite Wrapper\n(MMIO Registers)"]
-        
-        block:NPU_CORE:2
-            columns 2
-            FSM["Controller FSM\n(Tile Scheduler)"]
-            BRAM["Ping-Pong BRAM\n(Double Buffering)"]
-            DELAY["Delay Lines\n(Shift Registers)"]
-            SYSTOLIC["NxN Systolic Array\n(MAC Cores)"]
-            
-            FSM --> BRAM
-            FSM --> DELAY
-            BRAM --> DELAY
-            DELAY --> SYSTOLIC
-        end
-        
-        AXI_WRAPPER --> FSM
-        AXI_WRAPPER --> BRAM
-        SYSTOLIC --> AXI_WRAPPER
-    end
-    
-    PS --> AXI
-    AXI --> NPU_IP
+1. **32x32 Systolic Array MAC Engine:** Scaled down from a theoretical 64x64 design to exactly 32x32 to perfectly fit the KV260's DSP limit (uses 1,024 out of 1,248 available DSP48E2 slices). Executes signed 8-bit multiplications with 16/32-bit accumulations to prevent overflow, utilizing a wavefront propagation structure for maximum data reuse.
+2. **1-Clock RMSNorm Accelerator (`rmsnorm_inv_sqrt.sv`):** Replaces computationally expensive $1/\sqrt{x}$ iterative divisions with a 1024-segment Piecewise Linear (PWL) approximation. Extracts slope and intercept from BRAM and calculates $y = ax + b$ within a single DSP clock cycle.
+3. **3-Clock Softmax Accelerator (`softmax_exp_unit.sv`):** Sidesteps Taylor series calculations by applying Base-2 conversion ($e^x = 2^{x \cdot \log_2 e}$). The integer portion is handled instantly via bit-shifts, while the fractional portion uses a tiny 1024-segment LUT, slashing the cycle cost down to just 3 clocks.
+4. **1-Clock GeLU Accelerator (`gelu_lut.sv`):** Bypasses the complex $\text{tanh}$ formula by implementing a 64KB Full-ROM lookup table optimized for 16-bit inputs, resolving the non-linear activation in a single clock cycle.
 
-    Core Features
-```
-Memory Mapped I/O (AXI4-Lite): The CPU can control NPU registers and inject data into the BRAM simply by writing to specific memory addresses.
+## Core Features & Data Path Strategy
 
-Double Buffering (Ping-Pong BRAM): Applies a latency hiding technique that overlaps data transmission (DMA) with NPU computation, effectively eliminating memory-bound bottlenecks.
+**512-bit Wide Data Path (Packing):** To maximize memory bandwidth from the BRAM, TinyNPU utilizes a 512-bit wide read bus. A single BRAM slot contains exactly 512 bits, strategically packed as: `[Upper 256-bit Weights (B) : Lower 256-bit Activations (A)]`.
 
-Data Skewing via Delay Lines: Utilizes D-Flip-Flop-based shift registers to create the physical delay required for the wavefront execution in the Systolic Array, minimizing the complexity of the FSM controller.
+**Memory Mapped I/O (AXI4-Lite):** The CPU can control NPU registers and inject data into the BRAM simply by writing to specific memory addresses.
 
-Scalable NxN Design: Designed using SystemVerilog's generate statements, allowing flexible expansion of core counts (e.g., 4x4, 8x8, 16x16) simply by modifying the ARRAY_SIZE parameter at compile time.
+**Double Buffering (Ping-Pong BRAM):** Applies a latency hiding technique that overlaps data transmission (DMA) with NPU computation, effectively eliminating memory-bound bottlenecks.
+
+**Data Skewing via Delay Lines:** Utilizes D-Flip-Flop-based shift registers to create the physical delay required for the wavefront execution in the Systolic Array, minimizing the complexity of the FSM controller.
 
 
 ---

--- a/Architecture/Math_Accelerators.md
+++ b/Architecture/Math_Accelerators.md
@@ -1,0 +1,88 @@
+# The Math Accelerators (RMSNorm, Softmax, GeLU)
+
+To achieve a full hardware bypass of the CPU and process the Gemma 3-4B-IT LLM end-to-end within the KV260, we designed highly optimized, custom Math Accelerators. These modules compute complex non-linear mathematical formulas in just 1 to 3 clock cycles.
+
+---
+
+## 1. 1-Clock RMSNorm Accelerator (`rmsnorm_inv_sqrt.sv`)
+
+**Target Operation:** Inverse Square Root ($1/\sqrt{x}$)
+**Latency:** 1 Clock Cycle
+**Method:** Piecewise Linear Approximation (PWL)
+
+In software, dividing by a square root takes dozens of cycles. We accelerated this by approximating the non-linear curve with 1024 tiny linear segments ($y = ax + b$).
+
+### Hardware Architecture
+1. **BRAM LUT (1024 Depth):** The upper 10 bits of the input `x` act as a memory address. The BRAM outputs the pre-calculated `Slope (a)` and `Intercept (b)` for that specific segment.
+2. **DSP Computation:** The lower 22 bits of `x` act as the relative distance inside the segment. A single DSP48E2 slice calculates `(a * x_lower) + b` within 1 clock cycle.
+
+```mermaid
+graph TD
+    IN["Input x (32-bit)"] --> U10["Upper 10-bit (Address)"]
+    IN --> L22["Lower 22-bit (Fractional)"]
+
+    U10 --> BRAM[("BRAM (1024x32)<br>Lookup Table")]
+    BRAM -->|Outputs 'a'| DSP
+    BRAM -->|Outputs 'b'| DSP
+
+    L22 -->|'x_frac'| DSP["DSP48E2 MAC<br>y = (a * x_frac) + b"]
+    DSP --> OUT["1/sqrt(x) Result<br>(Q1.15 Format)"]
+
+    style BRAM fill:#ffcc80,stroke:#e65100
+    style DSP fill:#c8e6c9,stroke:#1b5e20
+```
+
+---
+
+## 2. 3-Clock Softmax Accelerator (`softmax_exp_unit.sv`)
+
+**Target Operation:** Natural Exponential ($e^x$)
+**Latency:** 3 Clock Cycles
+**Method:** Base-2 Conversion ($e^x = 2^{x \cdot \log_2 e}$)
+
+Calculating $e^x$ using Taylor series requires floating-point division and many loops. We completely bypassed this by switching bases.
+
+### Hardware Architecture
+1. **Multiplication (Cycle 1):** Multiply the input by the constant $\log_2 e \approx 1.442695$.
+2. **Split (Cycle 2):** Hardware splits the result into an `Integer` part and a `Fractional` part automatically by tapping different wires.
+3. **Shift & LUT (Cycle 3):**
+   - **Integer Part:** $2^{\text{int}}$ is calculated simply by shifting the bits to the left (`1 << int_part`). This costs **zero hardware logic**.
+   - **Fractional Part:** $2^{\text{frac}}$ is fetched from a tiny 1024-segment LUT.
+4. **Final Result:** Multiply the shifted integer result by the fractional LUT output.
+
+```mermaid
+graph LR
+    X["Input x"] --> MUL["Multiply by 1.442695<br>(Cycle 1)"]
+    MUL --> SPLIT{"Split Wire<br>(Cycle 2)"}
+
+    SPLIT -- Integer --> SHIFT["Bit-Shift Left<br>(1 << Int)"]
+    SPLIT -- Fraction --> LUT[("Fractional LUT<br>(1024 Depth)")]
+
+    SHIFT --> FINAL["Multiply<br>(Cycle 3)"]
+    LUT --> FINAL
+    FINAL --> OUT["e^x Result"]
+
+    style MUL fill:#bbdefb,stroke:#0d47a1
+    style SHIFT fill:#c8e6c9,stroke:#1b5e20
+```
+
+---
+
+## 3. 1-Clock GeLU Accelerator (`gelu_lut.sv`)
+
+**Target Operation:** Gaussian Error Linear Unit ($0.5x(1 + \text{tanh}(\dots))$)
+**Latency:** 1 Clock Cycle
+**Method:** Full-ROM Lookup Table
+
+GeLU requires calculating complex trigonometric functions. Since we operate on 16-bit intermediate values, the total number of possible inputs is only $2^{16} = 65,536$.
+
+### Hardware Architecture
+We mapped all 65,536 possible answers into a 64KB Block RAM (ROM). When a 16-bit MAC result comes in, it immediately serves as the address, outputting the GeLU result on the very next clock cycle.
+
+```mermaid
+graph LR
+    IN["MAC Output (16-bit)"] --> ROM[("GeLU ROM<br>64KB (65,536 Depth)")]
+    ROM --> OUT["GeLU Activated Output<br>(1 Cycle)"]
+
+    style ROM fill:#e1bee7,stroke:#4a148c
+```

--- a/Architecture/PE_Unit.md
+++ b/Architecture/PE_Unit.md
@@ -1,38 +1,38 @@
-# pe_unit — MAC 연산기 (연산의 최소 단위)
+# pe_unit — MAC Computing Engine (Atomic Unit)
 
-## 1. 개요
+## 1. Overview
 
-PE(Processing Element)는 NPU의 **Atomic Unit**이다. 하나의 PE는 단 하나의 일만 한다: 입력받은 두 수를 곱하고, 그 결과를 계속 더해나가는 것. 이것이 MAC(Multiply-ACcumulate)이다.
+The PE (Processing Element) is the **Atomic Unit** of the NPU. A single PE has only one job: to multiply two input numbers and continuously accumulate the result. This is known as MAC (Multiply-ACcumulate).
 
-TinyNPU-Gemma에서는 **INT8 양자화 모델**을 완벽하게 지원하기 위해, 음수 연산이 가능한 **Signed 8-bit 곱셈**과 오버플로우를 방지하는 **16-bit (최대 32-bit 확장) 누산기** 구조를 채택했다.
+In TinyNPU-Gemma, to perfectly support the **INT8 Quantization Model**, we adopted a **Signed 8-bit multiplier** capable of handling negative numbers, along with a **16-bit (up to 32-bit expandable) accumulator** to prevent overflow.
 
 ---
 
-## 2. 내부 구조
+## 2. Internal Structure
 
 ```mermaid
 flowchart LR
-    IA["i_a\n(왼쪽 입력)"]
-    IB["i_b\n(위쪽 입력)"]
+    IA["i_a\n(Left Input)"]
+    IB["i_b\n(Top Input)"]
     CLK["clk\n(Clock Edge)"]
 
     subgraph PE ["PE Unit (MAC)"]
-        MUL["× 곱셈\n(조합 논리)"]
+        MUL["× Multiplier\n(Combinational Logic)"]
         ADD["+"]
         REG_ACC["Reg D-FF\n(Accumulator)"]
         REG_A["D-FF"]
         REG_B["D-FF"]
     end
 
-    OA["o_a →\n(오른쪽 PE로)"]
-    OB["o_b ↓\n(아래 PE로)"]
-    OACC["o_acc\n(누적 결과)"]
+    OA["o_a →\n(To Right PE)"]
+    OB["o_b ↓\n(To Bottom PE)"]
+    OACC["o_acc\n(Accumulated Result)"]
 
     IA --> MUL
     IB --> MUL
     MUL --> ADD
     ADD --> REG_ACC
-    REG_ACC -->|피드백| ADD
+    REG_ACC -->|Feedback| ADD
     REG_ACC --> OACC
 
     IA --> REG_A --> OA
@@ -43,57 +43,57 @@ flowchart LR
     CLK --> REG_B
 ```
 
-### Combinational Logic (조합 논리)
-곱셈은 클럭과 무관하게 입력이 바뀌면 **즉시** 결과가 나온다.
-Verilog에서는 기본적으로 숫자를 Unsigned로 취급하기 때문에, 음수 가중치(Weight)와 활성화 값(Activation)을 정확히 곱하기 위해 반드시 `$signed()` 캐스팅을 해야 한다. (이 부분이 초기 디버깅에서 가장 핵심적인 문제였다.)
+### Combinational Logic
+The multiplication produces a result **immediately** when inputs change, independent of the clock.
+Because Verilog treats numbers as unsigned by default, we must enforce a `$signed()` cast to accurately multiply negative weights and activations. (This was a key issue during early debugging.)
 
 ```systemverilog
 // Signed 8-bit x Signed 8-bit = Signed 16-bit
 assign mul_result = $signed(i_a) * $signed(i_b);
 ```
 
-### Sequential Logic (순차 논리)
-누산(Accumulate) 결과는 클럭 엣지(Clock Edge)에 동기화되어 레지스터에 저장된다.
+### Sequential Logic
+The accumulated result is synchronized with the Clock Edge and stored in a register.
 ```systemverilog
 always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n)
-        o_acc <= 16'd0; // Accumulator 리셋
+        o_acc <= 16'd0; // Reset Accumulator
     else if (i_valid)
-        o_acc <= o_acc + mul_result; // 클럭마다 부호 있는 연산 누적
+        o_acc <= o_acc + mul_result; // Accumulate signed result every clock
 end
 ```
 
 ---
 
-## 3. 데이터 포워딩 (Data Forwarding Logic)
+## 3. Data Forwarding Logic
 
-데이터는 멈추지 않고 흐른다. 현재 PE가 사용한 데이터는 **다음 클럭에** 이웃 PE로 전달된다.
+Data flows continuously. The data used by the current PE is forwarded to neighboring PEs **on the next clock cycle**.
 
 ```mermaid
 sequenceDiagram
-    participant Left as 왼쪽에서 오는 i_a
-    participant PE as PE 내부
-    participant Right as 오른쪽 PE (o_a)
-    participant Bottom as 아래쪽 PE (o_b)
+    participant Left as i_a from Left
+    participant PE as Inside PE
+    participant Right as Right PE (o_a)
+    participant Bottom as Bottom PE (o_b)
 
-    Left->>PE: i_a 입력
-    PE->>PE: i_a * i_b 곱셈 (조합)
-    PE->>PE: o_acc += mul_result (clk 엣지에서)
-    PE-->>Right: o_a <= i_a  (1 클럭 후)
-    PE-->>Bottom: o_b <= i_b (1 클럭 후)
+    Left->>PE: Input i_a
+    PE->>PE: i_a * i_b Multiplication (Combinational)
+    PE->>PE: o_acc += mul_result (at clk edge)
+    PE-->>Right: o_a <= i_a  (1 clock later)
+    PE-->>Bottom: o_b <= i_b (1 clock later)
 ```
 
-**Latency:** 입력에서 출력까지 **1 Clock Cycle 지연** 발생.
+**Latency:** There is a **1 Clock Cycle delay** from input to output.
 
 ```systemverilog
-// Data Pipeline — 이웃 PE로 데이터 넘기기
+// Data Pipeline — Forward data to neighboring PEs
 o_a <= i_a;  // Pass to Right
 o_b <= i_b;  // Pass to Bottom
 ```
 
 ---
 
-## 4. 타이밍 분석
+## 4. Timing Analysis
 
 ```
 Clock  ┌─┐ ┌─┐ ┌─┐ ┌─┐ ┌─┐
@@ -102,15 +102,15 @@ Clock  ┌─┐ ┌─┐ ┌─┐ ┌─┐ ┌─┐
 i_a    ──┬────X────┬──────
 i_b    ──┴────X────┴──────
 
-o_a    ────────►───X────    ← i_a보다 1 사이클 늦음
-o_b    ────────►───X────    ← i_b보다 1 사이클 늦음
+o_a    ────────►───X────    ← 1 cycle delayed from i_a
+o_b    ────────►───X────    ← 1 cycle delayed from i_b
 ```
 
 ---
 
-## 5. Valid 신호를 통한 파이프라인 제어
+## 5. Pipeline Control via Valid Signal
 
-`i_valid` 신호가 Low이면 연산을 멈추고 (Pipeline Stall), `o_valid`도 Low를 내보낸다. 이 valid 신호가 Systolic Array 전체에서 **파도의 타이밍**을 제어한다.
+If the `i_valid` signal is Low, the operation pauses (Pipeline Stall), and `o_valid` also outputs Low. This valid signal controls the **timing of the wavefront** across the entire Systolic Array.
 
 ```systemverilog
 always_ff @(posedge clk or negedge rst_n) begin
@@ -120,10 +120,10 @@ always_ff @(posedge clk or negedge rst_n) begin
         o_a     <= 8'd0;
         o_b     <= 8'd0;
     end else if (i_valid) begin
-        o_acc   <= o_acc + mul_result;  // 누산
+        o_acc   <= o_acc + mul_result;  // Accumulate
         o_valid <= 1'b1;
-        o_a     <= i_a;                 // 오른쪽으로 포워딩
-        o_b     <= i_b;                 // 아래쪽으로 포워딩
+        o_a     <= i_a;                 // Forward right
+        o_b     <= i_b;                 // Forward bottom
     end else begin
         o_valid <= 1'b0;                // Stall
     end
@@ -132,37 +132,36 @@ end
 
 ---
 
-## 6. 음수 곱셈 디버깅 (Debugging History)
+## 6. Negative Multiplication Debugging History
 
-설계 초기에는 Verilog의 특성을 간과하고 일반적인 `*` 연산자를 사용했다가, `i_a = -2` (8'hFE), `i_b = 3` (8'h03) 인 경우에 `254 * 3 = 762` 라는 완전히 잘못된 (Unsigned) 결과가 나왔다.
+In the initial design phase, overlooking Verilog's default behavior, we used standard `*` operators. Consequently, with inputs `i_a = -2` (8'hFE) and `i_b = 3` (8'h03), it produced a completely incorrect (unsigned) result of `254 * 3 = 762`.
 
-**해결책:**
-모든 입력 포트 선언에 `signed` 키워드를 추가하고, 내부 연산시 `$signed()`를 강제 캐스팅함으로써,
-`-2 * 3 = -6` 이 정확히 16-bit 2's complement(`16'hFFFA`)로 나오도록 수정하여 하드웨어 검증을 통과했다.
-
----
-
-## 7. 동작 타이밍 테이블 (tb_mac_unit 검증 결과)
-
-| 사이클 | i_a (Signed 8-bit) | i_b (Signed 8-bit) | 곱셈 결과 (16-bit) | o_acc (누적) |
-|--------|---------------------|---------------------|--------------------|-------------|
-| reset  | 0                   | 0                   | 0                  | **0** |
-| 1      | 2                   | 3                   | 6                  | **6** |
-| 2      | -4                  | 5                   | -20                | **-14** |
-| 3      | -10                 | -10                 | 100                | **86** ✓ |
+**Solution:**
+By appending the `signed` keyword to all input port declarations and enforcing the `$signed()` cast for internal operations, the computation ` -2 * 3 = -6` correctly produced a 16-bit 2's complement (`16'hFFFA`), successfully passing hardware verification.
 
 ---
 
-## 8. 포트 인터페이스
+## 7. Operational Timing Table (tb_mac_unit Verification Results)
 
-| 포트 | 방향 | 비트 수 | 설명 |
-|------|------|---------|------|
-| `clk` | in | 1 | 클럭 (100MHz) |
-| `rst_n` | in | 1 | 비동기 액티브-로우 리셋 |
-| `i_valid` | in | 1 | 유효 데이터 신호 |
-| `i_a` | in | 8 (signed) | 왼쪽에서 들어오는 Feature Map (A) |
-| `i_b` | in | 8 (signed) | 위쪽에서 내려오는 Weight (B) |
-| `o_a` | out | 8 (signed) | 오른쪽 PE로 포워딩 |
-| `o_b` | out | 8 (signed) | 아래쪽 PE로 포워딩 |
-| `o_valid` | out | 1 | 유효 출력 신호 |
-| `o_acc` | out | 16 (signed)| 누적 MAC 결과 |
+| Cycle | i_a (Signed 8-bit) | i_b (Signed 8-bit) | Multiplication Result (16-bit) | o_acc (Accumulated) |
+|-------|---------------------|---------------------|---------------------------------|---------------------|
+| reset | 0                   | 0                   | 0                               | **0**               |
+| 1     | 2                   | 3                   | 6                               | **6**               |
+| 2     | -4                  | 5                   | -20                             | **-14**             |
+| 3     | -10                 | -10                 | 100                             | **86** ✓            |
+
+---
+
+## 8. Port Interface
+
+| Port | Direction | Bit Width | Description |
+|------|-----------|-----------|-------------|
+| `clk` | in | 1 | Clock (100MHz) |
+| `rst_n` | in | 1 | Asynchronous Active-Low Reset |
+| `i_valid` | in | 1 | Valid Data Signal |
+| `i_a` | in | 8 (signed) | Feature Map (A) entering from left |
+| `i_b` | in | 8 (signed) | Weight (B) entering from top |
+| `o_a` | out | 8 (signed) | Forwarded to right PE |
+| `o_b` | out | 8 (signed) | Forwarded to bottom PE |
+| `o_valid` | out | 1 | Valid Output Signal |
+| `o_acc` | out | 16 (signed)| Accumulated MAC Result |

--- a/Architecture/PE_Unit.md
+++ b/Architecture/PE_Unit.md
@@ -4,7 +4,7 @@
 
 PE(Processing Element)는 NPU의 **Atomic Unit**이다. 하나의 PE는 단 하나의 일만 한다: 입력받은 두 수를 곱하고, 그 결과를 계속 더해나가는 것. 이것이 MAC(Multiply-ACcumulate)이다.
 
-AI 연산의 99%는 결국 이 `곱셈 + 누산`이다.
+TinyNPU-Gemma에서는 **INT8 양자화 모델**을 완벽하게 지원하기 위해, 음수 연산이 가능한 **Signed 8-bit 곱셈**과 오버플로우를 방지하는 **16-bit (최대 32-bit 확장) 누산기** 구조를 채택했다.
 
 ---
 
@@ -45,8 +45,11 @@ flowchart LR
 
 ### Combinational Logic (조합 논리)
 곱셈은 클럭과 무관하게 입력이 바뀌면 **즉시** 결과가 나온다.
+Verilog에서는 기본적으로 숫자를 Unsigned로 취급하기 때문에, 음수 가중치(Weight)와 활성화 값(Activation)을 정확히 곱하기 위해 반드시 `$signed()` 캐스팅을 해야 한다. (이 부분이 초기 디버깅에서 가장 핵심적인 문제였다.)
+
 ```systemverilog
-assign mul_result = i_a * i_b; // 클럭 없이 즉시 계산
+// Signed 8-bit x Signed 8-bit = Signed 16-bit
+assign mul_result = $signed(i_a) * $signed(i_b);
 ```
 
 ### Sequential Logic (순차 논리)
@@ -54,9 +57,9 @@ assign mul_result = i_a * i_b; // 클럭 없이 즉시 계산
 ```systemverilog
 always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n)
-        o_acc <= 16'd0;
+        o_acc <= 16'd0; // Accumulator 리셋
     else if (i_valid)
-        o_acc <= o_acc + mul_result; // 클럭마다 누산
+        o_acc <= o_acc + mul_result; // 클럭마다 부호 있는 연산 누적
 end
 ```
 
@@ -129,29 +132,37 @@ end
 
 ---
 
-## 6. 동작 타이밍 테이블 (tb_mac_unit 검증 결과)
+## 6. 음수 곱셈 디버깅 (Debugging History)
 
-| 사이클 | i_a | i_b | 곱셈 결과 | o_acc (누적) |
-|--------|-----|-----|-----------|-------------|
-| reset  | 0   | 0   | 0         | **0** |
-| 1      | 2   | 3   | 6         | **6** |
-| 2      | 4   | 5   | 20        | **26** |
-| 3      | 10  | 10  | 100       | **126** ✓ |
+설계 초기에는 Verilog의 특성을 간과하고 일반적인 `*` 연산자를 사용했다가, `i_a = -2` (8'hFE), `i_b = 3` (8'h03) 인 경우에 `254 * 3 = 762` 라는 완전히 잘못된 (Unsigned) 결과가 나왔다.
 
-테스트벤치 주의사항: `i_valid`를 연결하지 않으면 항상 누산이 진행된다.
+**해결책:**
+모든 입력 포트 선언에 `signed` 키워드를 추가하고, 내부 연산시 `$signed()`를 강제 캐스팅함으로써,
+`-2 * 3 = -6` 이 정확히 16-bit 2's complement(`16'hFFFA`)로 나오도록 수정하여 하드웨어 검증을 통과했다.
 
 ---
 
-## 7. 포트 인터페이스
+## 7. 동작 타이밍 테이블 (tb_mac_unit 검증 결과)
+
+| 사이클 | i_a (Signed 8-bit) | i_b (Signed 8-bit) | 곱셈 결과 (16-bit) | o_acc (누적) |
+|--------|---------------------|---------------------|--------------------|-------------|
+| reset  | 0                   | 0                   | 0                  | **0** |
+| 1      | 2                   | 3                   | 6                  | **6** |
+| 2      | -4                  | 5                   | -20                | **-14** |
+| 3      | -10                 | -10                 | 100                | **86** ✓ |
+
+---
+
+## 8. 포트 인터페이스
 
 | 포트 | 방향 | 비트 수 | 설명 |
 |------|------|---------|------|
 | `clk` | in | 1 | 클럭 (100MHz) |
 | `rst_n` | in | 1 | 비동기 액티브-로우 리셋 |
 | `i_valid` | in | 1 | 유효 데이터 신호 |
-| `i_a` | in | 8 | 왼쪽에서 들어오는 Feature Map |
-| `i_b` | in | 8 | 위쪽에서 내려오는 Weight |
-| `o_a` | out | 8 | 오른쪽 PE로 포워딩 |
-| `o_b` | out | 8 | 아래쪽 PE로 포워딩 |
+| `i_a` | in | 8 (signed) | 왼쪽에서 들어오는 Feature Map (A) |
+| `i_b` | in | 8 (signed) | 위쪽에서 내려오는 Weight (B) |
+| `o_a` | out | 8 (signed) | 오른쪽 PE로 포워딩 |
+| `o_b` | out | 8 (signed) | 아래쪽 PE로 포워딩 |
 | `o_valid` | out | 1 | 유효 출력 신호 |
-| `o_acc` | out | 16 | 누적 MAC 결과 |
+| `o_acc` | out | 16 (signed)| 누적 MAC 결과 |

--- a/Architecture/Ping-Pong_BRAM_Controller.md
+++ b/Architecture/Ping-Pong_BRAM_Controller.md
@@ -2,9 +2,15 @@
 # Ping-Pong BRAM Controller
 
 1. 전체 구조 (NPU = 미니 GPU)
-우리가 엣지 보드(PYNQ-Z2)에서 돌릴 전체 시스템의 데이터 흐름은
+우리가 KV260 보드에서 돌릴 전체 시스템의 데이터 흐름은
 
 > DDR (메인 메모리) ↔ BRAM ↔ Systolic Array (연산기)
+
+## 512-bit Data Packing (데이터 패킹)
+메모리 대역폭(Bandwidth)을 극한으로 끌어올리기 위해, BRAM 한 칸의 넓이를 512-bit로 확장했다. 한 번의 읽기(Read) 요청으로 행렬 연산에 필요한 A와 B 데이터를 동시에 가져온다.
+
+* **상위 256-bit:** Weights (가중치 B) 데이터 저장 (8-bit x 32개)
+* **하위 256-bit:** Activations (활성화값 A) 데이터 저장 (8-bit x 32개)
 
 이걸 CUDA 환경으로 번역하면
 
@@ -161,9 +167,22 @@ int read_val = buffer_0[0];
 buffer_1[0] = 30; // 1e  <-- 30은 여기에 들어감!
 ```
 
+---
+
+## 5. BRAM Latency와 Preload 상태 (Debugging History)
+
 >Q:  "시뮬레이션 웨이브 상으로는 dma_addr과 wdata에 00, 0a(10)이 ram의 값으로 들어가는 순간 동시(클럭상으로 동일)에 dma_addr과 wdata에 01, 14(20)가 할당되는 것처럼 보여 이게 문제 없을까?"  
 
 A: 하드웨어의 핵심: "과거를 읽고, 미래를 쓴다" (<= Non-blocking)
+
+**디버깅 히스토리: 1-Cycle 지연 문제 해결**
+초기 설계에서는 FSM(상태머신)이 연산 시작(Run) 상태에 진입함과 동시에 BRAM 주소를 주입하고 데이터를 즉시 읽어오려 했다. 그러나 **BRAM은 동기식(Synchronous) 메모리이므로 주소를 넣은 후 정확히 1 Clock Cycle 뒤에 데이터가 출력(Read Latency)** 된다.
+이로 인해 첫 번째 클럭에 쓰레기 값(Garbage data)이 Array로 들어가는 버그가 발생했다.
+
+**해결책:**
+FSM에 `PRELOAD` 라는 중간 상태(State)를 삽입했다.
+1. `PRELOAD`: 주소 `0`을 BRAM에 주입하고 1클럭 대기한다.
+2. `RUN`: 1클럭이 지나면 주소 `0`의 진짜 데이터가 나오기 시작하므로, 이때부터 NPU 연산 Valid 신호를 On 시켜서 연산을 시작한다.
 하드웨어의 모든 플립플롭(메모리, 레지스터)은 클럭이 0에서 1로 딱 올라가는 **Rising Edge (파형에서 솟아오르는 순간)** 에만 동작해. 이때 아주 중요한 2가지 절대 규칙이 있어.
 
 * 읽을 때는 '클럭이 뛰기 직전(과거)'의 값을 읽어간다. (Setup Time)

--- a/Architecture/Ping-Pong_BRAM_Controller.md
+++ b/Architecture/Ping-Pong_BRAM_Controller.md
@@ -1,99 +1,109 @@
-
 # Ping-Pong BRAM Controller
 
-1. 전체 구조 (NPU = 미니 GPU)
-우리가 KV260 보드에서 돌릴 전체 시스템의 데이터 흐름은
+## 1. Overall Structure (NPU = Mini GPU)
+The data flow of the entire system running on the KV260 board is:
 
-> DDR (메인 메모리) ↔ BRAM ↔ Systolic Array (연산기)
+> DDR (Main Memory) ↔ BRAM ↔ Systolic Array (Compute Unit)
 
-## 512-bit Data Packing (데이터 패킹)
-메모리 대역폭(Bandwidth)을 극한으로 끌어올리기 위해, BRAM 한 칸의 넓이를 512-bit로 확장했다. 한 번의 읽기(Read) 요청으로 행렬 연산에 필요한 A와 B 데이터를 동시에 가져온다.
+## 512-bit Data Packing
+To push the memory bandwidth to its absolute limit, we expanded the width of a single BRAM slot to 512 bits. With a single Read request, we fetch both the A and B data required for matrix multiplication simultaneously.
 
-* **상위 256-bit:** Weights (가중치 B) 데이터 저장 (8-bit x 32개)
-* **하위 256-bit:** Activations (활성화값 A) 데이터 저장 (8-bit x 32개)
+* **Upper 256-bit:** Stores Weights (B) data (8-bit x 32 values)
+* **Lower 256-bit:** Stores Activations (A) data (8-bit x 32 values)
 
-이걸 CUDA 환경으로 번역하면
+Translating this to a CUDA environment:
 
 > Host RAM ↔ Shared Memory ↔ CUDA Cores
 
-Shared Memory에서 데이터를 꺼내와서 CUDA Cores에서 연산하고 다시 집어넣는, 하드웨어의 가장 깊숙한(Core) 부분을 설계
+We are designing the deepest (Core) hardware part: fetching data from Shared Memory, computing it in CUDA Cores, and storing it back.
 
-# 1.  AXI DMA (Direct Memory Access)
+---
 
-CUDA 비유: cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice)  
+## 1. AXI DMA (Direct Memory Access)
 
- CPU(ARM 코어)가 직접 데이터를 하나하나 옮기면 너무 느림.  
- 그래서 CPU 대신 메인메모리(DDR)에 있는 배열 데이터를 NPU 쪽으로 쫙 밀어 넣어라 하고 명령만 내리면, 알아서 데이터를 고속으로 쏴주는 하드웨어 블록
+CUDA Analogy: `cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice)`
 
-# 2. BRAM (Block RAM)
+It is too slow if the CPU (ARM core) moves data one by one.
+Instead, we issue a command to push the array data from main memory (DDR) to the NPU, and this hardware block automatically streams the data at high speed.
 
-CUDA 비유: Shared Memory (__shared__) 또는 L1 Cache
+## 2. BRAM (Block RAM)
 
-FPGA 칩 내부에 콕 박혀있는 작고 엄청나게 빠른 SRAM 덩어리. DMA가 DDR에서 가져온 데이터를 여기에 임시로 저장해두면,  systolic_2x2가 클럭마다 여기서 데이터를 사용함. BRAM 2개가 ping-pong-buffer
+CUDA Analogy: Shared Memory (`__shared__`) or L1 Cache
 
-# 3. Parameter (파라미터)
+A small, incredibly fast chunk of SRAM embedded inside the FPGA chip. Once the DMA temporarily stores the data fetched from DDR here, the `systolic_2x2` consumes this data every clock cycle. We use two BRAMs as a ping-pong buffer.
 
-C++ 비유: template <int N> 또는 #define SIZE 8
+## 3. Parameter
+
+C++ Analogy: `template <int N>` or `#define SIZE 8`
 
 ```verilog
     parameter DATA_WIDTH = 8,
     parameter ADDR_WIDTH = 8 // 256 depth
 ```
-코드가 칩으로 구워지기 전(합성 단계)에 하드웨어의 크기나 규격을 결정하는 상수야. 예를 들어 parameter DATA_WIDTH = 8이라고 쓰면, "아, 이 모듈은 8비트짜리 전선(자료형)을 쓰는구나" 하고 컴파일러가 회로를 8가닥으로 맞춰서 그려줌
+These are constants that determine the hardware size or specifications before the code is synthesized into a chip. For instance, declaring `parameter DATA_WIDTH = 8` tells the compiler, "Ah, this module uses 8-bit wires," and it draws the circuit accordingly.
 
-# 4. Address (주소 연산)
+## 4. Address Computation
 
-C++ 비유: 배열의 인덱스 array[index]
+C++ Analogy: Array index `array[index]`
 
-메모리에서 몇 번째 칸의 데이터를 읽고 쓸지 지정하는 숫자.소프트웨어에선 포인터나 인덱스로 접근하지만, 하드웨어에선 8비트짜리 addr 전선에 00000001 이라는 전기 신호를 주면 메모리의 1번 인덱스 방 문이 열리는 방식.
+A number specifying which slot in memory to read from or write to. While software uses pointers or indices, hardware operates by sending an electrical signal like `00000001` over an 8-bit `addr` wire to "open the door" to index 1 of the memory.
 
-# 5. MUX (Multiplexer, 멀티플렉서)
+## 5. MUX (Multiplexer)
 
-C++ 비유: if-else문, 삼항 연산자 ? :, 혹은 포인터 스위칭
+C++ Analogy: `if-else` statement, ternary operator `? :`, or pointer switching
+
 ```verilog
-    // BRAM 0번 제어
-    assign we_0   = (ping_pong_sel == 1'b0) ? dma_we   : 1'b0;       // NPU가 쓸 땐 Write 금지
+    // BRAM 0 Control
+    assign we_0   = (ping_pong_sel == 1'b0) ? dma_we   : 1'b0;       // Prohibit Write when NPU is using it
     assign addr_0 = (ping_pong_sel == 1'b0) ? dma_addr : sys_addr;
 
-    // BRAM 1번 제어
-    assign we_1   = (ping_pong_sel == 1'b1) ? dma_we   : 1'b0;       // NPU가 쓸 땐 Write 금지
+    // BRAM 1 Control
+    assign we_1   = (ping_pong_sel == 1'b1) ? dma_we   : 1'b0;       // Prohibit Write when NPU is using it
     assign addr_1 = (ping_pong_sel == 1'b1) ? dma_addr : sys_addr;
 
-    // Systolic 쪽으로 나가는 데이터 (Demux)
+    // Data going out to the Systolic Array (Demux)
     assign sys_rdata = (ping_pong_sel == 1'b0) ? rdata_1 : rdata_0;
 ```
-소프트웨어는 if문이 거짓이면 그 안의 코드를 아예 실행 안 하는데. 하지만 하드웨어는 모든 모듈(전선)이 항상 살아서 전기가 흐르고 있음.그래서 MUX라는 스위치를 달아서 "선택 신호가 0이면 A 전선의 데이터를, 1이면 B 전선의 데이터를 통과시켜!"라는 물리적인 길을 터주는 역할. 아까 assign sys_rdata = (sel == 0) ? rdata_1 : rdata_0; 코드가 바로 이 MUX 회로.
+In software, if an `if` condition is false, the code inside is completely ignored. However, in hardware, all modules (wires) are constantly active with electricity flowing. Therefore, we attach a physical switch called a MUX to create a path: "If the select signal is 0, pass the data from wire A; if 1, pass wire B!" The code `assign sys_rdata = (sel == 0) ? rdata_1 : rdata_0;` is exactly this MUX circuit.
 
-# 1. 내부에 BRAM_0과 BRAM_1 모듈 두 개를 생성한다.
+---
+
+## Ping-Pong Mechanism
+
+### 1. Create two internal modules: BRAM_0 and BRAM_1.
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
     
-    subgraph "FPGA 메모리 (BRAM)"
+    subgraph "FPGA Memory (BRAM)"
         B0[("BRAM_0")]:::memory
         B1[("BRAM_1")]:::memory
     end
     
-    SYS[systolic_2x2 연산 유닛]:::logic
+    SYS[systolic_2x2 Compute Unit]:::logic
 
-    %% 스타일 정의
+    %% Style definitions
     classDef input fill:#f9f,stroke:#333,stroke-width:2px;
     classDef memory fill:#ff9,stroke:#333,stroke-width:2px;
     classDef logic fill:#9cf,stroke:#333,stroke-width:2px;
 
-    %% 연결선 (개념적)
+    %% Conceptual connections
     DMA -.-> B0
     DMA -.-> B1
     B0 -.-> SYS
     B1 -.-> SYS
 ```
 
-# 2.ping_pong_sel이라는 1비트짜리 스위치(포인터)를 둔다.
-# 3.ping_pong_sel == 0일 때: AXI DMA (외부 메모리)는 BRAM_0에 다음 연산할 데이터를 열심히 쓰고(Write), 그와 동시에 우리의 systolic_2x2는 BRAM_1에서 이미 준비된 데이터를 읽어와서(Read) 연산을 돌린다.
-* 상황 1: ping_pong_sel == 0 일 때
-스위치 상태: 위쪽(0번)으로 입력, 아래쪽(1번)에서 출력
-DMA: BRAM_0에 열심히 데이터를 채워 넣습니다 (Write).
-Systolic: 이미 데이터가 차 있는 BRAM_1에서 데이터를 가져와 연산합니다 (Read).
+### 2. Introduce a 1-bit switch (pointer) called `ping_pong_sel`.
+
+### 3. When `ping_pong_sel == 0`:
+The AXI DMA (external memory) diligently writes the next data block to `BRAM_0`, while simultaneously, our compute unit reads the already-prepared data from `BRAM_1` and executes the calculation.
+
+* **Scenario 1:** `ping_pong_sel == 0`
+Switch State: Input goes top (0), output comes from bottom (1).
+DMA: Actively fills `BRAM_0` with data (Write).
+Systolic: Fetches data from the already-filled `BRAM_1` and computes (Read).
+
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
@@ -105,24 +115,26 @@ graph LR
         B1[("BRAM_1 reading")]:::activeRead
     end
 
-    %% 흐름선
-    DMA == "데이터 쓰기 (Write)" ==> B0
-    B1 == "데이터 읽기 (Read)" ==> SYS
+    %% Flow lines
+    DMA == "Write Data" ==> B0
+    B1 == "Read Data" ==> SYS
 
-    %% 스타일 정의
+    %% Style definitions
     classDef input fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef logic fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef activeWrite fill:#ffcdd2,stroke:#b71c1c,color:black,stroke-width:4px;
     classDef activeRead fill:#c8e6c9,stroke:#1b5e20,color:black,stroke-width:4px;
 ```
-* 전환 (Switching): 양쪽 작업 완료 후
-DMA도 쓰기를 다 했고, Systolic도 연산을 다 마쳤다면?
-ping_pong_sel = ~ping_pong_sel (0 → 1)로 바뀝니다.  
 
-* 상황 2: ping_pong_sel == 1 일 때
-스위치 상태: 경로가 크로스(교차) 됩니다.
-DMA: 이제 비어있는 BRAM_1에 새 데이터를 채웁니다.
-Systolic: 아까(상황 1에서) DMA가 꽉 채워둔 BRAM_0의 데이터를 가져와 연산합니다.
+* **Switching:** After both sides finish their tasks
+If the DMA has finished writing and the Systolic Array has finished computing, the switch flips:
+`ping_pong_sel = ~ping_pong_sel` (0 → 1).
+
+* **Scenario 2:** `ping_pong_sel == 1`
+Switch State: The paths cross.
+DMA: Now fills the empty `BRAM_1` with new data.
+Systolic: Fetches data from `BRAM_0` (which the DMA just filled in Scenario 1) and computes.
+
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
@@ -134,22 +146,18 @@ graph LR
         B1[("BRAM_1 writing")]:::activeWrite
     end
 
-    %% 흐름선
-    DMA == "데이터 쓰기 (Write)" ==> B1
-    B0 == "데이터 읽기 (Read)" ==> SYS
+    %% Flow lines
+    DMA == "Write Data" ==> B1
+    B0 == "Read Data" ==> SYS
 
-    %% 스타일 정의
+    %% Style definitions
     classDef input fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef logic fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef activeWrite fill:#ffcdd2,stroke:#b71c1c,color:black,stroke-width:4px;
     classDef activeRead fill:#c8e6c9,stroke:#1b5e20,color:black,stroke-width:4px;
 ```
 
-```mermaid
-
-```
-
-# 4.양쪽 작업이 다 끝나면 ping_pong_sel = ~ping_pong_sel; 로 스위칭! (0은 1로, 1은 0으로)
+### 4. When tasks are complete, switch! `ping_pong_sel = ~ping_pong_sel;`
 
 ```c++
 int buffer_0[256]; // BRAM 0
@@ -160,54 +168,51 @@ buffer_0[0] = 10; // 0a
 buffer_0[1] = 20; // 14
 
 // Phase 2 (ping_pong_sel = 1)
-// NPU는 buffer_0에서 데이터를 안전하게 읽고
+// The NPU safely reads data from buffer_0
 int read_val = buffer_0[0]; 
 
-// 동시에 DMA는 다음 데이터를 buffer_1에 쓴다!
-buffer_1[0] = 30; // 1e  <-- 30은 여기에 들어감!
+// Simultaneously, the DMA writes the next data into buffer_1!
+buffer_1[0] = 30; // 1e  <-- 30 goes in here!
 ```
 
 ---
 
-## 5. BRAM Latency와 Preload 상태 (Debugging History)
+## 5. BRAM Latency and Preload State (Debugging History)
 
->Q:  "시뮬레이션 웨이브 상으로는 dma_addr과 wdata에 00, 0a(10)이 ram의 값으로 들어가는 순간 동시(클럭상으로 동일)에 dma_addr과 wdata에 01, 14(20)가 할당되는 것처럼 보여 이게 문제 없을까?"  
+> **Q:** "On the simulation waveform, the moment `dma_addr` and `wdata` of `00`, `0a`(10) enter the RAM, it looks like `01`, `14`(20) are assigned to `dma_addr` and `wdata` at the exact same clock cycle. Is this okay?"
 
-A: 하드웨어의 핵심: "과거를 읽고, 미래를 쓴다" (<= Non-blocking)
+**A:** The core principle of hardware: **"Read the past, write the future"** (<= Non-blocking)
 
-**디버깅 히스토리: 1-Cycle 지연 문제 해결**
-초기 설계에서는 FSM(상태머신)이 연산 시작(Run) 상태에 진입함과 동시에 BRAM 주소를 주입하고 데이터를 즉시 읽어오려 했다. 그러나 **BRAM은 동기식(Synchronous) 메모리이므로 주소를 넣은 후 정확히 1 Clock Cycle 뒤에 데이터가 출력(Read Latency)** 된다.
-이로 인해 첫 번째 클럭에 쓰레기 값(Garbage data)이 Array로 들어가는 버그가 발생했다.
+**Debugging History: Resolving the 1-Cycle Delay Issue**
+In the initial design, we tried to inject the BRAM address and immediately read data the moment the FSM entered the `Run` state. However, **because BRAM is synchronous memory, the data is output exactly 1 clock cycle after the address is provided (Read Latency).**
+This caused a bug where garbage data entered the array on the very first clock cycle.
 
-**해결책:**
-FSM에 `PRELOAD` 라는 중간 상태(State)를 삽입했다.
-1. `PRELOAD`: 주소 `0`을 BRAM에 주입하고 1클럭 대기한다.
-2. `RUN`: 1클럭이 지나면 주소 `0`의 진짜 데이터가 나오기 시작하므로, 이때부터 NPU 연산 Valid 신호를 On 시켜서 연산을 시작한다.
-하드웨어의 모든 플립플롭(메모리, 레지스터)은 클럭이 0에서 1로 딱 올라가는 **Rising Edge (파형에서 솟아오르는 순간)** 에만 동작해. 이때 아주 중요한 2가지 절대 규칙이 있어.
+**Solution:**
+We inserted an intermediate state called `PRELOAD` into the FSM.
+1. `PRELOAD`: Inject address `0` into the BRAM and wait for 1 clock cycle.
+2. `RUN`: After 1 clock cycle, the real data for address `0` starts coming out, so we turn on the NPU valid signal and begin computing.
 
-* 읽을 때는 '클럭이 뛰기 직전(과거)'의 값을 읽어간다. (Setup Time)
+All flip-flops (memory, registers) in hardware only operate on the **Rising Edge** (the moment the waveform shoots up from 0 to 1). There are two absolute rules here:
 
-* 값이 변하는 건 '클럭이 뛴 직후(미래)'부터 반영된다. (Clock-to-Q)
+* **Setup Time:** When reading, you read the value from "just before the clock jumped (the past)."
+* **Clock-to-Q:** Changes only take effect "right after the clock jumped (the future)."
 
-[클럭이 뛰기 0.001초 전]
+[0.001 seconds before the clock jumps]
+* `dma_addr` is holding `00`, and `dma_wdata` is holding `0a` (10).
 
-* dma_addr는 00을 유지하고 있고, dma_wdata는 0a (10)을 유지하고 있다.  
-
-[클럭 엣지 발생]
-
-* BRAM : 방금 전까지 가지고 있던 주소(00)랑 데이터(0a) 를 ram[0] 안에 넣음 (여기서 ram[0]에 10이 저장됨)
-
-* 테스트벤치(DMA) : 주소 01이랑 데이터 14 (20)를 저장 (여기서 파형의 값이 01, 14(10진수 20)로 바뀜)  
+[Clock Edge Occurs]
+* **BRAM:** Takes the address (`00`) and data (`0a`) it *just* had and stores it (so `10` is stored in `ram[0]`).
+* **Testbench (DMA):** Assigns the new address `01` and data `14` (20) (the waveform values change here).
 
 ```c++
-// 매 클럭(Loop)마다 일어나는 일
+// What happens every clock cycle (Loop)
 int old_addr = current_addr;
 int old_data = current_data;
 
-// 1. BRAM은 옛날(방금 전) 값을 읽어서 저장하고
+// 1. The BRAM reads the old (past) values and stores them
 ram[old_addr] = old_data; 
 
-// 2. 테스트벤치는 새로운 값으로 업데이트함 (동시에 발생!)
+// 2. The testbench updates to new values (happens simultaneously!)
 current_addr = 1;
 current_data = 20;
 ```

--- a/Architecture/README.md
+++ b/Architecture/README.md
@@ -1,22 +1,26 @@
-# TinyNPU-RTL: From C++ to Silicon
+# TinyNPU-Gemma: Transformer Hardware Accelerator (RTL)
 
-This project documents the entire journey of building a **Full-Stack AI Accelerator**, starting from a simple matrix multiplication algorithm in C++, designing it into hardware (Verilog), and finally controlling it via Python software through the AXI interconnect.
+This project documents the entire journey of building a **Full-Stack AI Accelerator**, specifically designed to run the **quantized Gemma 3-4B-IT(E4B) LLM** entirely on the physical hardware of a **Xilinx Kria KV260 FPGA board**.
+
+It details how we scaled the design to a massive 32x32 Systolic Array and created custom math accelerators for non-linear operations (RMSNorm, Softmax, GeLU) to achieve a 38-clock latency data path.
 
 ## Table of Contents
 
 This documentation alternates between bottom-up and top-down approaches to explain the design philosophy of TinyNPU. We highly recommend reading the files in the following order:
 
 1. **[Overall Architecture (Architecture)](Architecture.md)**
-   - The limitations of the Von Neumann architecture and the necessity of the Systolic Array.
+   - The 4 Exodia Parts, the 38-clock pipeline latency, and the 512-bit data path optimized for the KV260.
 2. **[The Heart of Computation (PE Unit)](PE_Unit.md)**
-   - The principles of MAC operations and 1-Cycle data forwarding.
+   - INT8 signed MAC operations, 16/32-bit accumulations, and 1-Cycle data forwarding.
 3. **[Scalable Array (Systolic Array NxN)](Systolic_Array_NxN.md)**
-   - Evolution from a hardcoded 2x2 array to an NxN array using SystemVerilog `generate` statements.
+   - Scaling to 32x32 to maximize the 1,024 DSP limit and wavefront execution strategies.
 4. **[The Magic of Time (Data Skewing & Delay Line)](Data_Skewing_Delay_Line.md)**
    - Hardware automation of the wavefront execution using Shift Registers.
 5. **[Breaking the Memory Bottleneck (Ping-Pong BRAM)](Ping-Pong_BRAM_Controller.md)**
-   - Double Buffering technique to overlap DMA transfers and NPU computations.
-6. **[Full-Stack Integration (AXI4-Lite & PYNQ)](AXI4_Lite_and_PYNQ.md)**
+   - 512-bit data packing, BRAM latency handling, and Double Buffering.
+6. **[The Math Accelerators (RMSNorm, Softmax, GeLU)](Math_Accelerators.md)**
+   - PWL approximation, Base-2 shifting, and LUT strategies for zero-CPU non-linear processing.
+7. **[Full-Stack Integration (AXI4-Lite & PYNQ)](AXI4_Lite_and_PYNQ.md)**
    - Vivado IP packaging, MMIO communication, and Python Jupyter Notebook control.
-7. **[Verification & Simulation (Testbench)](Testbench.md)**
-   - Strategies for verifying hardware timing and waveforms.
+8. **[Verification & Simulation (Testbench)](Testbench.md)**
+   - Bit-True verification matching the Python (Numpy) Golden Model exactly.

--- a/Architecture/Systolic_Array_NxN.md
+++ b/Architecture/Systolic_Array_NxN.md
@@ -1,10 +1,18 @@
 # Systolic Array NxN — Scalable Core Array
 
-## 1. Overview: Evolution from 2x2 to NxN
-The hardcoded wire connections of the initial 2x2 prototype become impossible to maintain when scaling up to 4x4 or 8x8 arrays. 
-To solve this, we introduced SystemVerilog's `generate for` statements, implementing a **Scalable Architecture** where the entire grid is automatically generated at compile-time simply by changing the `ARRAY_SIZE` parameter.
+## 1. Overview: Maximizing KV260 DSP Resources (32x32)
+The hardcoded wire connections of early prototypes become impossible to maintain when scaling up. To solve this, we introduced SystemVerilog's `generate for` statements, implementing a **Scalable Architecture** where the entire grid is automatically generated at compile-time simply by changing the `ARRAY_SIZE` parameter.
 
-## 2. 2D Array Routing using Generate Statements
+**For the TinyNPU-Gemma project on the Kria KV260:**
+The KV260 features exactly **1,248 DSP48E2 slices**. A fully parallel 64x64 array would require 4,096 DSPs, which far exceeds the capacity. Therefore, we explicitly targeted `ARRAY_SIZE=32`, utilizing **1,024 DSP slices** to maximize throughput while perfectly fitting the hardware boundaries.
+
+## 2. Bit-Width Strategy: 8-bit to 16/32-bit to 8-bit
+As data flows through the 32x32 array, it undergoes rigorous bit-width management to prevent overflow during MAC operations:
+1. **Input:** INT8 (Signed 8-bit) activations and weights enter the array.
+2. **Accumulation:** The internal MAC units accumulate up to 32 times (across a row). To safely contain the maximum possible sum ($127 \times 127 \times 32$), the `o_acc` output uses **16-bit to 32-bit registers** (depending on precision mode).
+3. **Requantization:** Before the data is outputted from the NPU or passed to the activation functions, it is re-scaled and squashed back down to INT8.
+
+## 3. 2D Array Routing using Generate Statements
 In hardware design, the `generate` block serves a similar purpose to nested loops in C++.
 
 ```mermaid
@@ -24,4 +32,4 @@ We declare a 2D wire array wire [7:0] a_wires [0:N][0:N] to pre-allocate all con
 
 External inputs (In_a, In_b) are plugged into the boundaries (a_wires[i][0] and b_wires[0][j]), and the final outputs are extracted from o_acc[i][j].
 
-Advantage: Even when synthesizing a 16x16 array (256 MAC cores), not a single line of the routing code needs to be modified.
+Advantage: Even when synthesizing the massive 32x32 array (1,024 MAC cores) for the KV260, not a single line of the routing code needs to be modified.

--- a/Architecture/Testbench.md
+++ b/Architecture/Testbench.md
@@ -1,137 +1,70 @@
-# 테스트벤치 시뮬레이션 흐름
+# Testbench & Verification: Bit-True to Python
 
-세 개의 testbench가 각 모듈을 검증한다.
+To verify the functionality and timing of the TinyNPU-Gemma core, a top-down integrated simulation approach is employed. Our ultimate goal is **0% Error (Bit-True Match)** against the Python (NumPy/PyTorch) Golden Model.
+
+## Trace-Driven Verification
+
+단순한 랜덤 데이터 테스트가 아니라, 실제 Python(PyTorch/NumPy)에서 추출한 **Golden Trace**를 Verilog 시뮬레이션에 주입하여 결과를 비교하는 **Trace-Driven Verification** 방식을 채택했다.
+
+## 디버깅 히스토리: Python vs Verilog Bit-True 매칭
+
+우리는 중간 연산 단계마다 Python에서 덤프한 배열(메모리 헥스 덤프)과 NPU의 출력 포트에서 캡처된 값을 비교 검증했다.
+
+1. **MAC 결과 확인:** MAC Array가 `24`를 출력할 때, Python 배열의 같은 위치 값이 정확히 `24`인지 확인.
+2. **GeLU 통과 확인:** NPU가 MAC 값 `24`를 GeLU 모듈에 통과시켜 `12`가 나올 때, Python Golden 모델의 GeLU 출력도 정확히 `12`인지 확인.
+3. **오차율 0% 달성:** INT8 양자화 기반의 `+`, `*`, Shift, 그리고 Custom LUT 연산들이 S/W의 결과와 완전히 동일하게 동작함을 입증했다.
 
 ---
 
-## 전체 검증 구조
+## 전체 검증 구조 (`tb_gemma_layer.sv` & `tb_npu_core_top_NxN.sv`)
 
 ```mermaid
 flowchart LR
     %% 전체는 가로(1행 3열) 배치
     
-    subgraph tb_mac_unit["<h3>tb_mac_unit<br/>(pe_unit 검증)</h3>"]
+    subgraph tb_mac_unit["<h3>tb_mac_unit<br/>(Signed 8-bit PE)</h3>"]
         direction TB
         %% 제목과의 간격을 위한 투명 노드
         sep1[ ] --- T1
         style sep1 fill:none,stroke:none
         
-        T1["① 리셋 (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=3 → acc=6"]
-        T2 --> T3["③ i_a=4, i_b=5 → acc=26"]
-        T3 --> T4["④ i_a=10, i_b=10 → acc=126"]
-        T4 --> T5["⑤ $display로 결과 출력"]
-        T5 --> W1["⚠️ i_valid 연결 안 됨\n→ 항상 누산됨"]
+        T1["① 리셋 (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=-3 → acc=-6"]
+        T2 --> T3["③ i_a=-4, i_b=-5 → acc=14"]
     end
 
-    subgraph tb_ping_pong["<h3>tb_ping_pong<br/>(PP-bram 검증)</h3>"]
+    subgraph tb_gemma_layer["<h3>tb_gemma_layer<br/>(Full Layer Test)</h3>"]
         direction TB
         %% 제목과의 간격을 위한 투명 노드
         sep2[ ] --- P1
         style sep2 fill:none,stroke:none
 
-        P1["① sel=0, DMA→BRAM_0[0]=10"] --> P2["② DMA→BRAM_0[1]=20"]
-        P2 --> P3["③ sel=1 (스위치!)"]
-        P3 --> P4["④ NPU가 sys_addr=0 → rdata=10"]
-        P4 --> P5["⑤ 동시에 DMA→BRAM_1[0]=30"]
-        P5 --> W2["⚠️ 동기 읽기라\n1 사이클 후 데이터"]
+        P1["① Load Golden Weights"] --> P2["② Run FSM / DMA"]
+        P2 --> P3["③ Pipeline 38-Clocks"]
+        P3 --> P4["④ Dump Final Result"]
+        P4 --> P5["⑤ diff (Python vs RTL)"]
     end
 
-    subgraph tb_systolic["<h3>tb_systolic<br/>(systolic_2x2 검증)</h3>"]
+    subgraph tb_math_accelerators["<h3>tb_math_accelerators<br/>(Non-linear Math)</h3>"]
         direction TB
         %% 제목과의 간격을 위한 투명 노드
         sep3[ ] --- S1
         style sep3 fill:none,stroke:none
 
-        S1["① in_valid=1, 파도 1 투입"] --> S2["② 파도 2 투입"]
-        S2 --> S3["③ 파도 3 투입"]
-        S3 --> S4["④ in_valid=0 (flush)"]
-        S4 --> S5["⑤ PE들이 순차적으로 결과 수렴"]
-        S5 --> W3["⚠️ PE(1,1)은\n2 사이클 늦게 시작"]
+        S1["① Input 'x'"] --> S2["② PWL (RMSNorm)"]
+        S2 --> S3["③ Base-2 (Softmax)"]
+        S3 --> S4["④ LUT (GeLU)"]
+        S4 --> S5["⑤ Verify 1-3 Clock Latency"]
     end
 
     %% 3열 배치를 유지하기 위한 투명 연결선
-    tb_mac_unit ~~~ tb_ping_pong
-    tb_ping_pong ~~~ tb_systolic
+    tb_mac_unit ~~~ tb_gemma_layer
+    tb_gemma_layer ~~~ tb_math_accelerators
 ```
 
 ---
 
-## 1. tb_mac_unit — pe_unit 단독 검증
-
-PE 하나를 단독으로 검증한다. 매 클럭 입력을 넣고 누적 결과가 올바른지 확인.
-
-```
-시나리오:
-  rst_n = 0 → 1  (리셋 해제)
-  Cycle 1: i_a=2, i_b=3  → acc = 0 + 6  = 6
-  Cycle 2: i_a=4, i_b=5  → acc = 6 + 20 = 26
-  Cycle 3: i_a=10, i_b=10 → acc = 26 + 100 = 126 ✓
-```
-
-**알려진 이슈:** `tb_mac_unit.sv`에서 `i_valid` 포트가 연결되지 않아 항상 valid 상태로 동작한다. 실제 systolic 배열과 달리 valid 제어를 테스트하지 못한다.
-
----
-
-## 2. tb_ping_pong — ping_pong_bram 더블버퍼 검증
-
-핑퐁 버퍼의 핵심: DMA 쓰기와 NPU 읽기가 **동시에** 일어나는지 확인.
-
-```
-Phase 1 (sel=0):
-  DMA → BRAM_0[0] = 10
-  DMA → BRAM_0[1] = 20
-
-Phase 2 (sel=1, 스위치!):
-  NPU  → sys_addr=0 → (1 사이클 후) rdata = 10  ← BRAM_0에서 읽기
-  DMA  → BRAM_1[0] = 30                          ← BRAM_1에 쓰기 (동시!)
-  NPU  → sys_addr=1 → (1 사이클 후) rdata = 20
-```
-
-**동기식 읽기 주의:** `simple_bram`은 동기식이므로 주소 입력 후 **다음 클럭**에 데이터가 나온다.
-
----
-
-## 3. tb_systolic — systolic_2x2 행렬 연산 검증
-
-4사이클 파도를 흘려보내며 2×2 행렬 곱 결과를 검증한다.
-
-| 사이클 | in_a_0 | in_a_1 | in_b_0 | in_b_1 | 이벤트 |
-|--------|--------|--------|--------|--------|--------|
-| 1 | 1 | 0 | 1 | 0 | PE(0,0) 첫 연산 시작 |
-| 2 | 2 | 3 | 3 | 2 | 파도 확산: PE(0,0), (0,1), (1,0) 가동 |
-| 3 | 0 | 4 | 0 | 4 | 전체 가동: PE(1,1) 첫 연산 |
-| 4 | 0 | 0 | 0 | 0 | valid=0 (flush): PE(1,1) 마지막 연산 |
-
-**valid 전파 지연:** PE(0,0) → PE(0,1), PE(1,0)까지는 **1 사이클** 늦고, PE(1,1)은 **2 사이클** 늦게 계산을 시작한다.
-
-```mermaid
-sequenceDiagram
-    participant C as Clock
-    participant PE00 as PE(0,0)
-    participant PE01 as PE(0,1)
-    participant PE10 as PE(1,0)
-    participant PE11 as PE(1,1)
-
-    C->>PE00: Cycle 1: A=1, B=1 → acc=1
-    C->>PE00: Cycle 2: A=2, B=3 → acc=7
-    C->>PE01: Cycle 2: A=1(from 00), B=2 → acc=2
-    C->>PE10: Cycle 2: A=3, B=1(from 00) → acc=3
-    C->>PE01: Cycle 3: A=2, B=4 → acc=10
-    C->>PE10: Cycle 3: A=4, B=3 → acc=15
-    C->>PE11: Cycle 3: A=3(from 10), B=2(from 01) → acc=6
-    C->>PE11: Cycle 4: A=4, B=4 → acc=22 ✓
-```
-
----
-
-## 4. 검증 환경
+## 검증 환경
 
 **EDA Tool:** Xilinx Vivado 2025.2  
-**Target:** xc7z020clg400-1 (PYNQ-Z2)  
-**Simulator:** XSim (Vivado 내장) + Verilator (고속 C++ 기반)
-
-```bash
-# Verilator로 빠른 시뮬레이션
-verilator --cc --exe --build tb_systolic.sv systolic_2x2.sv pe_unit.sv
-./obj_dir/Vsystolic_2x2
-```
+**Target:** Xilinx Kria KV260 Vision AI Starter Kit
+**Simulator:** XSim (Vivado 내장)

--- a/Architecture/Testbench.md
+++ b/Architecture/Testbench.md
@@ -4,37 +4,37 @@ To verify the functionality and timing of the TinyNPU-Gemma core, a top-down int
 
 ## Trace-Driven Verification
 
-단순한 랜덤 데이터 테스트가 아니라, 실제 Python(PyTorch/NumPy)에서 추출한 **Golden Trace**를 Verilog 시뮬레이션에 주입하여 결과를 비교하는 **Trace-Driven Verification** 방식을 채택했다.
+Rather than simple random data testing, we adopted a **Trace-Driven Verification** method, which extracts a **Golden Trace** directly from Python (PyTorch/NumPy) and injects it into the Verilog simulation to compare results.
 
-## 디버깅 히스토리: Python vs Verilog Bit-True 매칭
+## Debugging History: Python vs Verilog Bit-True Matching
 
-우리는 중간 연산 단계마다 Python에서 덤프한 배열(메모리 헥스 덤프)과 NPU의 출력 포트에서 캡처된 값을 비교 검증했다.
+We meticulously compared the Python memory hex dumps with the captured output port values of the NPU at every intermediate computation stage.
 
-1. **MAC 결과 확인:** MAC Array가 `24`를 출력할 때, Python 배열의 같은 위치 값이 정확히 `24`인지 확인.
-2. **GeLU 통과 확인:** NPU가 MAC 값 `24`를 GeLU 모듈에 통과시켜 `12`가 나올 때, Python Golden 모델의 GeLU 출력도 정확히 `12`인지 확인.
-3. **오차율 0% 달성:** INT8 양자화 기반의 `+`, `*`, Shift, 그리고 Custom LUT 연산들이 S/W의 결과와 완전히 동일하게 동작함을 입증했다.
+1. **MAC Result Verification:** When the MAC Array output `24`, we ensured the Python array value at the exact same coordinate was also `24`.
+2. **GeLU Pass Verification:** When the NPU fed the MAC value `24` through the GeLU module and output `12`, we confirmed the Python Golden model's GeLU output was exactly `12`.
+3. **Achieving 0% Error Rate:** We successfully proved that all INT8 quantization-based `+`, `*`, Shift, and Custom LUT operations run completely identically to the S/W results in hardware.
 
 ---
 
-## 전체 검증 구조 (`tb_gemma_layer.sv` & `tb_npu_core_top_NxN.sv`)
+## Overall Verification Structure (`tb_gemma_layer.sv` & `tb_npu_core_top_NxN.sv`)
 
 ```mermaid
 flowchart LR
-    %% 전체는 가로(1행 3열) 배치
+    %% Arranged horizontally in 3 columns
     
     subgraph tb_mac_unit["<h3>tb_mac_unit<br/>(Signed 8-bit PE)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing
         sep1[ ] --- T1
         style sep1 fill:none,stroke:none
         
-        T1["① 리셋 (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=-3 → acc=-6"]
+        T1["① Reset (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=-3 → acc=-6"]
         T2 --> T3["③ i_a=-4, i_b=-5 → acc=14"]
     end
 
     subgraph tb_gemma_layer["<h3>tb_gemma_layer<br/>(Full Layer Test)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing
         sep2[ ] --- P1
         style sep2 fill:none,stroke:none
 
@@ -46,7 +46,7 @@ flowchart LR
 
     subgraph tb_math_accelerators["<h3>tb_math_accelerators<br/>(Non-linear Math)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing
         sep3[ ] --- S1
         style sep3 fill:none,stroke:none
 
@@ -56,15 +56,15 @@ flowchart LR
         S4 --> S5["⑤ Verify 1-3 Clock Latency"]
     end
 
-    %% 3열 배치를 유지하기 위한 투명 연결선
+    %% Transparent links to maintain 3-column layout
     tb_mac_unit ~~~ tb_gemma_layer
     tb_gemma_layer ~~~ tb_math_accelerators
 ```
 
 ---
 
-## 검증 환경
+## Verification Environment
 
 **EDA Tool:** Xilinx Vivado 2025.2  
 **Target:** Xilinx Kria KV260 Vision AI Starter Kit
-**Simulator:** XSim (Vivado 내장)
+**Simulator:** XSim (Built into Vivado)


### PR DESCRIPTION
Updates the markdown files in the `Architecture` directory to reflect the TinyNPU-Gemma project for the Xilinx Kria KV260 FPGA board. The documentation now covers system constraints, hardware accelerators, data paths, and debugging history.