### PR TITLE
Fix Architecture Documentation Markdown and Translation

### DIFF
--- a/Architecture/AXI4-Lite_REG_FPGA-CPU.md
+++ b/Architecture/AXI4-Lite_REG_FPGA-CPU.md
@@ -1,27 +1,27 @@
 # AXI LITE Register FPGA <-> CPU
 
-`0x00` (Control Register - 쓰기 전용)  
+`0x00` (Control Register - Write Only)
 
-* `Bit[0]` : START (1 넣으면 NPU 연산 킥! CUDA Kernel Launch)
+* `Bit[0]` : START (Setting 1 kicks off NPU computation! CUDA Kernel Launch)
 
-* `Bit[1]` : ACC_CLEAR (1 넣으면 Systolic Array 내부 누산기 0으로 초기화)
+* `Bit[1]` : ACC_CLEAR (Setting 1 resets internal accumulators in the Systolic Array to 0)
     
-`0x04` (Status Register - 읽기 전용)
+`0x04` (Status Register - Read Only)
 
-* `Bit[0]` : DONE (1이면 연산 완료. CPU가 이거 폴링하면서 대기함)
+* `Bit[0]` : DONE (1 means computation complete. CPU polls this while waiting)
 
-`0x08` (RMSNorm Param - 쓰기 전용)
+`0x08` (RMSNorm Param - Write Only)
 
-* `Bit[31:0]` : mean_sq 값 (분모 계산용 32비트 스칼라 꽂아넣기)
+* `Bit[31:0]` : `mean_sq` value (Plugs in a 32-bit scalar for denominator calculation)
 
-`0x0C` (Ping-Pong MUX - 쓰기 전용)
+`0x0C` (Ping-Pong MUX - Write Only)
 
-* `Bit[0]` : 0이면 DMA->Ping / 1이면 DMA->Pong
+* `Bit[0]` : 0 means DMA->Ping / 1 means DMA->Pong
 
-`0x10` (Mode / Command - 쓰기 전용)
+`0x10` (Mode / Command - Write Only)
 
-* `Bit[0]` : GeLU_EN (1이면 출력 전에 1-Cycle GeLU 태움)
+* `Bit[0]` : `GeLU_EN` (1 applies 1-Cycle GeLU before output)
 
-* `Bit[1]` : Softmax_EN (1이면 출력 전에 Softmax 태움)
+* `Bit[1]` : `Softmax_EN` (1 applies Softmax before output)
 
-`0x14` (Reserved / Debug) : 예비용 (일단 비워둠)
+`0x14` (Reserved / Debug) : Reserved (currently empty)

--- a/Architecture/AXI4_Lite_and_PYNQ.md
+++ b/Architecture/AXI4_Lite_and_PYNQ.md
@@ -1,4 +1,3 @@
-
 # Full-Stack Integration: AXI4-Lite & PYNQ (Software Control)
 
 This covers the process of wrapping our pure logic circuit (Verilog) with a standard interface, allowing the ARM CPU (Zynq PS) to communicate with it in the real world.
@@ -11,12 +10,12 @@ sequenceDiagram
     participant PY as Python (Jupyter)
     participant AXI as AXI Bus (0x4000_0000)
     participant HW as NPU Hardware
-    
+
     Note over PY, HW: DMA Data Write
     PY->>AXI: npu.write(0x04, 1) (dma_we = 1)
     PY->>AXI: npu.write(0x0C, 15) (dma_wdata = 15)
     AXI->>HW: Saves 15 into BRAM
-    
+
     Note over PY, HW: Trigger Computation
     PY->>AXI: npu.write(0x00, 1) (start_mac = 1)
     AXI->>HW: FSM State: IDLE -> RUN

--- a/Architecture/Architecture.md
+++ b/Architecture/Architecture.md
@@ -9,7 +9,7 @@ The entire system is divided into the ARM Cortex-A9 CPU (Processing System, PS) 
 ```mermaid
 block-beta
     columns 4
-    
+
     %% Processing System
     block:PS:1
         CPU["ARM Cortex-A9 (PS)"]
@@ -19,54 +19,49 @@ block-beta
 
     %% AXI Bus
     AXI(("AXI4-Lite\nInterconnect"))
-    
+
     %% NPU IP
     block:NPU_IP:2
         columns 2
         AXI_WRAPPER["AXI4-Lite Wrapper\n(MMIO Registers)"]
-        
+
         block:NPU_CORE:2
             columns 2
             FSM["Controller FSM\n(Tile Scheduler)"]
             BRAM["Ping-Pong BRAM\n(Double Buffering)"]
             DELAY["Delay Lines\n(Shift Registers)"]
             SYSTOLIC["NxN Systolic Array\n(MAC Cores)"]
-            
+
             FSM --> BRAM
             FSM --> DELAY
             BRAM --> DELAY
             DELAY --> SYSTOLIC
         end
-        
+
         AXI_WRAPPER --> FSM
         AXI_WRAPPER --> BRAM
         SYSTOLIC --> AXI_WRAPPER
     end
-    
+
     PS --> AXI
     AXI --> NPU_IP
-
-    Core Features
 ```
-Memory Mapped I/O (AXI4-Lite): The CPU can control NPU registers and inject data into the BRAM simply by writing to specific memory addresses.
 
-Double Buffering (Ping-Pong BRAM): Applies a latency hiding technique that overlaps data transmission (DMA) with NPU computation, effectively eliminating memory-bound bottlenecks.
+## Core Features
 
-Data Skewing via Delay Lines: Utilizes D-Flip-Flop-based shift registers to create the physical delay required for the wavefront execution in the Systolic Array, minimizing the complexity of the FSM controller.
-
-Scalable NxN Design: Designed using SystemVerilog's generate statements, allowing flexible expansion of core counts (e.g., 4x4, 8x8, 16x16) simply by modifying the ARRAY_SIZE parameter at compile time.
-
+- **Memory Mapped I/O (AXI4-Lite)**: The CPU can control NPU registers and inject data into the BRAM simply by writing to specific memory addresses.
+- **Double Buffering (Ping-Pong BRAM)**: Applies a latency hiding technique that overlaps data transmission (DMA) with NPU computation, effectively eliminating memory-bound bottlenecks.
+- **Data Skewing via Delay Lines**: Utilizes D-Flip-Flop-based shift registers to create the physical delay required for the wavefront execution in the Systolic Array, minimizing the complexity of the FSM controller.
+- **Scalable NxN Design**: Designed using SystemVerilog's generate statements, allowing flexible expansion of core counts (e.g., 4x4, 8x8, 16x16) simply by modifying the `ARRAY_SIZE` parameter at compile time.
 
 ---
 
-### 2. `Ping-Pong BRAM Controller.md` (Double Buffering)
-
-# Ping-Pong BRAM Controller
+## 2. Ping-Pong BRAM Controller (Double Buffering)
 
 Block RAM (BRAM) acts as an ultra-fast, on-chip L1 Cache, providing data to the NPU Processing Elements (PEs) without a single clock cycle of delay.
 
-## The Necessity of Ping-Pong (Double Buffering)
-The data fetching speed from main memory (DDR) is significantly slower than the NPU's computation speed. If a single BRAM is used, the computation cores will fall into an idle state while waiting for the next data tile. 
+### The Necessity of Ping-Pong (Double Buffering)
+The data fetching speed from main memory (DDR) is significantly slower than the NPU's computation speed. If a single BRAM is used, the computation cores will fall into an idle state while waiting for the next data tile.
 To solve this, a Ping-Pong structure utilizing two alternating BRAMs is adopted.
 
 ```mermaid
@@ -75,36 +70,33 @@ sequenceDiagram
     participant B0 as BRAM 0
     participant B1 as BRAM 1
     participant NPU as Systolic Array
-    
+
     Note over DMA, NPU: Tile 1 Execution
     DMA->>B0: Write Tile 1 Data
     NPU->>B0: (Waiting)
-    
+
     Note over DMA, NPU: Tile 2 Execution (Overlapping!)
     NPU->>B0: Read Tile 1 & Compute
     DMA->>B1: Write Tile 2 Data
-    
+
     Note over DMA, NPU: Tile 3 Execution (Switch!)
     NPU->>B1: Read Tile 2 & Compute
     DMA->>B0: Write Tile 3 Data
 ```
-Hardware Operation Mechanism
-When ping_pong_sel is 0: The external DMA writes to bram_0, while the NPU reads from bram_1.
 
-When ping_pong_sel is 1: The switch toggles; the DMA writes to bram_1, while the NPU reads from bram_0.
+### Hardware Operation Mechanism
+- When `ping_pong_sel` is 0: The external DMA writes to `bram_0`, while the NPU reads from `bram_1`.
+- When `ping_pong_sel` is 1: The switch toggles; the DMA writes to `bram_1`, while the NPU reads from `bram_0`.
 
 This switching is automatically managed by the FSM every time a new tile computation begins.
 
-
 ---
 
-### 3. `systolic_NxN.md` (Scalable Array & Delay Lines)
-
-# Scalable NxN Systolic Array & Delay Lines
+## 3. Scalable NxN Systolic Array & Delay Lines
 
 This is the core computation array of the TinyNPU. Through parameterized design, the number of cores (NxN) can be freely scaled during compile time.
 
-## Data Skewing and Delay Lines (Shift Registers)
+### Data Skewing and Delay Lines (Shift Registers)
 In a Systolic Array, data shifts one step to the right and bottom in each clock cycle. To ensure that data perfectly aligns without overlapping (Wavefront execution), a hardware-level 'departure delay' must be enforced.
 
 To achieve this, **Delay Line** modules—composed of cascaded D-Flip-Flops—are placed before the input ports of the array.
@@ -116,37 +108,33 @@ graph LR
         A1[Row 1: Delay 1] --> D1[FF] --> PE10[PE 1,0]
         A2[Row 2: Delay 2] --> D2[FF] --> D3[FF] --> PE20[PE 2,0]
     end
-    
+
     subgraph Systolic Array
         PE00 --> PE01[PE 0,1]
         PE00 --> PE10
         PE10 --> PE11[PE 1,1]
     end
-    
+
     style D1 fill:#f96,stroke:#333
     style D2 fill:#f96,stroke:#333
     style D3 fill:#f96,stroke:#333
 ```
-FSM Abstraction: The FSM does not need to calculate intricate timings; it simply fires all data simultaneously by asserting fire_valid = 1.
 
-Automated Wavefront: The physical delay circuits (FFs) act as queues, injecting data into the core array with a 1-clock, 2-clock sequential delay.
-
-Hardware For-Loops: Internal 2D-array wire routing is fully automated using SystemVerilog generate for blocks.
-
+- **FSM Abstraction**: The FSM does not need to calculate intricate timings; it simply fires all data simultaneously by asserting `fire_valid = 1`.
+- **Automated Wavefront**: The physical delay circuits (FFs) act as queues, injecting data into the core array with a 1-clock, 2-clock sequential delay.
+- **Hardware For-Loops**: Internal 2D-array wire routing is fully automated using SystemVerilog `generate for` blocks.
 
 ---
 
-### 4. `PE Unit.md` (Processing Element)
-
-# Processing Element (PE Unit)
+## 4. Processing Element (PE Unit)
 
 The PE Unit is the smallest fundamental computation core comprising the Systolic Array. It performs a MAC (Multiply-Accumulate) operation every clock cycle and forwards the incoming data to adjacent PEs.
 
-## Interfaces (Ports)
+### Interfaces (Ports)
 - **Input**: `i_a` (from the left), `i_b` (from the top), `i_valid` (computation trigger).
 - **Output**: `o_a` (passed to the right), `o_b` (passed to the bottom), `o_valid` (trigger for next PEs), `o_acc` (accumulated result).
 
-## Operation Structure (Pipeline)
+### Operation Structure (Pipeline)
 1. Operations are only executed when the `i_valid` signal is High (1).
 2. The `o_acc <= o_acc + (i_a * i_b)` MAC operation is performed within a single clock cycle.
 3. The data received in the current cycle (`i_a`, `i_b`) is stored in internal D-Flip-Flop registers and pushed out to `o_a`, `o_b` at the next clock's positive edge (posedge).
@@ -155,21 +143,20 @@ The PE Unit is the smallest fundamental computation core comprising the Systolic
 graph TD
     IA[Feature Map i_a] --> MAC((MAC Unit<br>+= a*b))
     IB[Weight i_b] --> MAC
-    
+
     MAC -->|Next Clock| OA[o_a to Right PE]
     MAC -->|Next Clock| OB[o_b to Bottom PE]
-    
+
     MAC -.-> ACC[Accumulator o_acc]
 ```
+
 ---
 
-### 5. `Testbench.md` (Verification)
-
-# Testbench & Verification
+## 5. Testbench & Verification
 
 To verify the functionality and timing of the NPU core, a top-down integrated simulation approach is employed.
 
-## Verification Scenarios (`tb_npu_core_top_NxN.sv`)
+### Verification Scenarios (`tb_npu_core_top_NxN.sv`)
 This testbench emulates the exact process of the ARM CPU and DMA controlling the NPU on an actual Zynq board.
 
 1. **Phase 1: DMA Data Load (Host to Device)**
@@ -180,5 +167,5 @@ This testbench emulates the exact process of the ARM CPU and DMA controlling the
 3. **Phase 3: Continuous Streaming (Latency Hiding Verification)**
    - Simulates a Double Buffering scenario where the NPU reads and computes from BRAM_0 while the DMA simultaneously writes the next tile's data to BRAM_1, verifying the absence of memory bottlenecks.
 
-## Waveform Checkpoints
-- By monitoring the simulation scopes, it is confirmed that the data from the fire
+### Waveform Checkpoints
+- By monitoring the simulation scopes, it is confirmed that the data from the fire valid signal aligns perfectly as a diagonal wavefront.

--- a/Architecture/Data_Skewing_Delay_Line.md
+++ b/Architecture/Data_Skewing_Delay_Line.md
@@ -1,5 +1,3 @@
-### 3. `Data_Skewing_Delay_Line.md` (The secret of Wavefront execution)
-
 # Data Skewing & Delay Line (Wavefront Execution)
 
 ## 1. Why Do We Need Delay?
@@ -14,17 +12,17 @@ Calculating these precise timings via software-like FSM counters creates massive
 graph LR
     subgraph "Data Skewing (A Matrix)"
         FSM["FSM (Simultaneous Fire!)"]
-        
+
         FSM -->|Delay 0| PE00["PE (0,0)"]
-        
+
         FSM -->|1 Cycle Delay| FF1["D-FF"]
         FF1 --> PE10["PE (1,0)"]
-        
+
         FSM -->|2 Cycle Delay| FF2_1["D-FF"]
         FF2_1 --> FF2_2["D-FF"]
         FF2_2 --> PE20["PE (2,0)"]
     end
-    
+
     style FF1 fill:#f96,stroke:#333
     style FF2_1 fill:#f96,stroke:#333
     style FF2_2 fill:#f96,stroke:#333

--- a/Architecture/NPU_Circuit.md
+++ b/Architecture/NPU_Circuit.md
@@ -20,8 +20,8 @@ flowchart TB
                 BRAM0["simple_bram #0\n[Port A / Port B]"]
                 BRAM1["simple_bram #1\n[Port A / Port B]"]
             end
-            MUX -->|"DMA → BRAM_0 또는 BRAM_1\n(switch_buffer)"| BRAM0
-            MUX -->|"DMA → BRAM_1 또는 BRAM_0\n(switch_buffer)"| BRAM1
+            MUX -->|"DMA → BRAM_0 or BRAM_1\n(switch_buffer)"| BRAM0
+            MUX -->|"DMA → BRAM_1 or BRAM_0\n(switch_buffer)"| BRAM1
             BRAM0 -->|"rdata_0_a / rdata_0_b"| MUX
             BRAM1 -->|"rdata_1_a / rdata_1_b"| MUX
         end
@@ -52,7 +52,7 @@ flowchart TB
             DELAY_COL -->|"wire_b[0][i]"| MAC_ARRAY
         end
 
-        GELU["⚡ gelu_lut × 1,024\n(32×32 병렬)\ndata_in → data_out"]
+        GELU["⚡ gelu_lut × 1,024\n(32×32 Parallel)\ndata_in → data_out"]
 
         %% Internal connections
         FSM -->|"read_addr"| PING_PONG
@@ -74,7 +74,7 @@ flowchart TB
 
         SCALE["📐 Vector Scaling\n(always_ff)\nx = token × inv_sqrt >> 15"]
 
-        SHIFT["⏱️ 32-Cycle Shift Reg\n(MAC latency 모사)"]
+        SHIFT["⏱️ 32-Cycle Shift Reg\n(MAC latency simulation)"]
 
         SOFT["softmax_exp_unit\n(i_x → o_exp)\nvalid_in → valid_out"]
 

--- a/Architecture/PE_Unit.md
+++ b/Architecture/PE_Unit.md
@@ -1,38 +1,38 @@
-# pe_unit — MAC 연산기 (연산의 최소 단위)
+# `pe_unit` — MAC Unit (Minimum Unit of Computation)
 
-## 1. 개요
+## 1. Overview
 
-PE(Processing Element)는 NPU의 **Atomic Unit**이다. 하나의 PE는 단 하나의 일만 한다: 입력받은 두 수를 곱하고, 그 결과를 계속 더해나가는 것. 이것이 MAC(Multiply-ACcumulate)이다.
+The PE (Processing Element) is the **Atomic Unit** of the NPU. A single PE has only one job: multiply two input numbers and continuously accumulate the result. This is MAC (Multiply-ACcumulate).
 
-AI 연산의 99%는 결국 이 `곱셈 + 누산`이다.
+99% of AI computations eventually come down to this `multiplication + accumulation`.
 
 ---
 
-## 2. 내부 구조
+## 2. Internal Structure
 
 ```mermaid
 flowchart LR
-    IA["i_a\n(왼쪽 입력)"]
-    IB["i_b\n(위쪽 입력)"]
+    IA["i_a\n(Left Input)"]
+    IB["i_b\n(Top Input)"]
     CLK["clk\n(Clock Edge)"]
 
     subgraph PE ["PE Unit (MAC)"]
-        MUL["× 곱셈\n(조합 논리)"]
+        MUL["× Multiply\n(Combinational Logic)"]
         ADD["+"]
         REG_ACC["Reg D-FF\n(Accumulator)"]
         REG_A["D-FF"]
         REG_B["D-FF"]
     end
 
-    OA["o_a →\n(오른쪽 PE로)"]
-    OB["o_b ↓\n(아래 PE로)"]
-    OACC["o_acc\n(누적 결과)"]
+    OA["o_a →\n(To Right PE)"]
+    OB["o_b ↓\n(To Bottom PE)"]
+    OACC["o_acc\n(Accumulated Result)"]
 
     IA --> MUL
     IB --> MUL
     MUL --> ADD
     ADD --> REG_ACC
-    REG_ACC -->|피드백| ADD
+    REG_ACC -->|Feedback| ADD
     REG_ACC --> OACC
 
     IA --> REG_A --> OA
@@ -43,54 +43,54 @@ flowchart LR
     CLK --> REG_B
 ```
 
-### Combinational Logic (조합 논리)
-곱셈은 클럭과 무관하게 입력이 바뀌면 **즉시** 결과가 나온다.
+### Combinational Logic
+Multiplication outputs a result **immediately** when the input changes, regardless of the clock.
 ```systemverilog
-assign mul_result = i_a * i_b; // 클럭 없이 즉시 계산
+assign mul_result = i_a * i_b; // Calculate immediately without clock
 ```
 
-### Sequential Logic (순차 논리)
-누산(Accumulate) 결과는 클럭 엣지(Clock Edge)에 동기화되어 레지스터에 저장된다.
+### Sequential Logic
+The Accumulate result is synchronized to the Clock Edge and stored in a register.
 ```systemverilog
 always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n)
         o_acc <= 16'd0;
     else if (i_valid)
-        o_acc <= o_acc + mul_result; // 클럭마다 누산
+        o_acc <= o_acc + mul_result; // Accumulate every clock
 end
 ```
 
 ---
 
-## 3. 데이터 포워딩 (Data Forwarding Logic)
+## 3. Data Forwarding Logic
 
-데이터는 멈추지 않고 흐른다. 현재 PE가 사용한 데이터는 **다음 클럭에** 이웃 PE로 전달된다.
+Data flows without stopping. The data used by the current PE is forwarded to the neighboring PE on the **next clock**.
 
 ```mermaid
 sequenceDiagram
-    participant Left as 왼쪽에서 오는 i_a
-    participant PE as PE 내부
-    participant Right as 오른쪽 PE (o_a)
-    participant Bottom as 아래쪽 PE (o_b)
+    participant Left as i_a coming from the left
+    participant PE as Inside PE
+    participant Right as Right PE (o_a)
+    participant Bottom as Bottom PE (o_b)
 
-    Left->>PE: i_a 입력
-    PE->>PE: i_a * i_b 곱셈 (조합)
-    PE->>PE: o_acc += mul_result (clk 엣지에서)
-    PE-->>Right: o_a <= i_a  (1 클럭 후)
-    PE-->>Bottom: o_b <= i_b (1 클럭 후)
+    Left->>PE: Input i_a
+    PE->>PE: i_a * i_b Multiply (Combinational)
+    PE->>PE: o_acc += mul_result (at clk edge)
+    PE-->>Right: o_a <= i_a  (1 clock later)
+    PE-->>Bottom: o_b <= i_b (1 clock later)
 ```
 
-**Latency:** 입력에서 출력까지 **1 Clock Cycle 지연** 발생.
+**Latency:** **1 Clock Cycle delay** occurs from input to output.
 
 ```systemverilog
-// Data Pipeline — 이웃 PE로 데이터 넘기기
+// Data Pipeline — Pass data to neighboring PE
 o_a <= i_a;  // Pass to Right
 o_b <= i_b;  // Pass to Bottom
 ```
 
 ---
 
-## 4. 타이밍 분석
+## 4. Timing Analysis
 
 ```
 Clock  ┌─┐ ┌─┐ ┌─┐ ┌─┐ ┌─┐
@@ -99,15 +99,15 @@ Clock  ┌─┐ ┌─┐ ┌─┐ ┌─┐ ┌─┐
 i_a    ──┬────X────┬──────
 i_b    ──┴────X────┴──────
 
-o_a    ────────►───X────    ← i_a보다 1 사이클 늦음
-o_b    ────────►───X────    ← i_b보다 1 사이클 늦음
+o_a    ────────►───X────    ← 1 cycle later than i_a
+o_b    ────────►───X────    ← 1 cycle later than i_b
 ```
 
 ---
 
-## 5. Valid 신호를 통한 파이프라인 제어
+## 5. Pipeline Control via Valid Signal
 
-`i_valid` 신호가 Low이면 연산을 멈추고 (Pipeline Stall), `o_valid`도 Low를 내보낸다. 이 valid 신호가 Systolic Array 전체에서 **파도의 타이밍**을 제어한다.
+If the `i_valid` signal is Low, computation stops (Pipeline Stall), and `o_valid` also outputs Low. This valid signal controls the **wavefront timing** across the entire Systolic Array.
 
 ```systemverilog
 always_ff @(posedge clk or negedge rst_n) begin
@@ -117,10 +117,10 @@ always_ff @(posedge clk or negedge rst_n) begin
         o_a     <= 8'd0;
         o_b     <= 8'd0;
     end else if (i_valid) begin
-        o_acc   <= o_acc + mul_result;  // 누산
+        o_acc   <= o_acc + mul_result;  // Accumulate
         o_valid <= 1'b1;
-        o_a     <= i_a;                 // 오른쪽으로 포워딩
-        o_b     <= i_b;                 // 아래쪽으로 포워딩
+        o_a     <= i_a;                 // Forward to right
+        o_b     <= i_b;                 // Forward to bottom
     end else begin
         o_valid <= 1'b0;                // Stall
     end
@@ -129,29 +129,29 @@ end
 
 ---
 
-## 6. 동작 타이밍 테이블 (tb_mac_unit 검증 결과)
+## 6. Operation Timing Table (`tb_mac_unit` Verification Result)
 
-| 사이클 | i_a | i_b | 곱셈 결과 | o_acc (누적) |
+| Cycle | i_a | i_b | Multiplication Result | o_acc (Accumulated) |
 |--------|-----|-----|-----------|-------------|
 | reset  | 0   | 0   | 0         | **0** |
 | 1      | 2   | 3   | 6         | **6** |
 | 2      | 4   | 5   | 20        | **26** |
 | 3      | 10  | 10  | 100       | **126** ✓ |
 
-테스트벤치 주의사항: `i_valid`를 연결하지 않으면 항상 누산이 진행된다.
+Testbench Caution: If `i_valid` is not connected, accumulation proceeds constantly.
 
 ---
 
-## 7. 포트 인터페이스
+## 7. Port Interface
 
-| 포트 | 방향 | 비트 수 | 설명 |
-|------|------|---------|------|
-| `clk` | in | 1 | 클럭 (100MHz) |
-| `rst_n` | in | 1 | 비동기 액티브-로우 리셋 |
-| `i_valid` | in | 1 | 유효 데이터 신호 |
-| `i_a` | in | 8 | 왼쪽에서 들어오는 Feature Map |
-| `i_b` | in | 8 | 위쪽에서 내려오는 Weight |
-| `o_a` | out | 8 | 오른쪽 PE로 포워딩 |
-| `o_b` | out | 8 | 아래쪽 PE로 포워딩 |
-| `o_valid` | out | 1 | 유효 출력 신호 |
-| `o_acc` | out | 16 | 누적 MAC 결과 |
+| Port | Direction | Bit Width | Description |
+|------|-----------|-----------|-------------|
+| `clk` | in | 1 | Clock (100MHz) |
+| `rst_n` | in | 1 | Asynchronous Active-Low Reset |
+| `i_valid` | in | 1 | Valid Data Signal |
+| `i_a` | in | 8 | Feature Map from the left |
+| `i_b` | in | 8 | Weight from the top |
+| `o_a` | out | 8 | Forward to right PE |
+| `o_b` | out | 8 | Forward to bottom PE |
+| `o_valid` | out | 1 | Valid Output Signal |
+| `o_acc` | out | 16 | Accumulated MAC Result |

--- a/Architecture/Ping-Pong_BRAM_Controller.md
+++ b/Architecture/Ping-Pong_BRAM_Controller.md
@@ -1,151 +1,169 @@
-
 # Ping-Pong BRAM Controller
 
-1. 전체 구조 (NPU = 미니 GPU)
-우리가 엣지 보드(PYNQ-Z2)에서 돌릴 전체 시스템의 데이터 흐름은
+## Overall Structure (NPU = Mini GPU)
+The data flow of the entire system running on the edge board (PYNQ-Z2) is:
 
-> DDR (메인 메모리) ↔ BRAM ↔ Systolic Array (연산기)
+> DDR (Main Memory) ↔ BRAM ↔ Systolic Array (Computation Unit)
 
-이걸 CUDA 환경으로 번역하면
+Translating this to a CUDA environment:
 
 > Host RAM ↔ Shared Memory ↔ CUDA Cores
 
-Shared Memory에서 데이터를 꺼내와서 CUDA Cores에서 연산하고 다시 집어넣는, 하드웨어의 가장 깊숙한(Core) 부분을 설계
+This design implements the deepest hardware core part where data is fetched from Shared Memory, computed in CUDA Cores, and then stored back.
 
-# 1.  AXI DMA (Direct Memory Access)
+---
 
-CUDA 비유: cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice)  
+## 1. AXI DMA (Direct Memory Access)
 
- CPU(ARM 코어)가 직접 데이터를 하나하나 옮기면 너무 느림.  
- 그래서 CPU 대신 메인메모리(DDR)에 있는 배열 데이터를 NPU 쪽으로 쫙 밀어 넣어라 하고 명령만 내리면, 알아서 데이터를 고속으로 쏴주는 하드웨어 블록
+**CUDA Analogy:** `cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice)`
 
-# 2. BRAM (Block RAM)
+If the CPU (ARM Core) moves data one by one itself, it is too slow.
+Therefore, the DMA is a hardware block that rapidly pushes array data from main memory (DDR) into the NPU automatically once the CPU issues a command.
 
-CUDA 비유: Shared Memory (__shared__) 또는 L1 Cache
+---
 
-FPGA 칩 내부에 콕 박혀있는 작고 엄청나게 빠른 SRAM 덩어리. DMA가 DDR에서 가져온 데이터를 여기에 임시로 저장해두면,  systolic_2x2가 클럭마다 여기서 데이터를 사용함. BRAM 2개가 ping-pong-buffer
+## 2. BRAM (Block RAM)
 
-# 3. Parameter (파라미터)
+**CUDA Analogy:** Shared Memory (`__shared__`) or L1 Cache
 
-C++ 비유: template <int N> 또는 #define SIZE 8
+BRAM is a small, incredibly fast block of SRAM embedded inside the FPGA chip. When the DMA temporarily stores data fetched from DDR here, the `systolic_2x2` uses this data every clock cycle. Two BRAMs form a ping-pong buffer.
 
-```verilog
+---
+
+## 3. Parameter
+
+**C++ Analogy:** `template <int N>` or `#define SIZE 8`
+
+```systemverilog
     parameter DATA_WIDTH = 8,
     parameter ADDR_WIDTH = 8 // 256 depth
 ```
-코드가 칩으로 구워지기 전(합성 단계)에 하드웨어의 크기나 규격을 결정하는 상수야. 예를 들어 parameter DATA_WIDTH = 8이라고 쓰면, "아, 이 모듈은 8비트짜리 전선(자료형)을 쓰는구나" 하고 컴파일러가 회로를 8가닥으로 맞춰서 그려줌
 
-# 4. Address (주소 연산)
+Parameters are constants that define the hardware's size or specifications before the code is synthesized into a chip. For example, `parameter DATA_WIDTH = 8` tells the compiler to synthesize an 8-bit wire path for this module.
 
-C++ 비유: 배열의 인덱스 array[index]
+---
 
-메모리에서 몇 번째 칸의 데이터를 읽고 쓸지 지정하는 숫자.소프트웨어에선 포인터나 인덱스로 접근하지만, 하드웨어에선 8비트짜리 addr 전선에 00000001 이라는 전기 신호를 주면 메모리의 1번 인덱스 방 문이 열리는 방식.
+## 4. Address (Address Calculation)
 
-# 5. MUX (Multiplexer, 멀티플렉서)
+**C++ Analogy:** Array index `array[index]`
 
-C++ 비유: if-else문, 삼항 연산자 ? :, 혹은 포인터 스위칭
-```verilog
-    // BRAM 0번 제어
-    assign we_0   = (ping_pong_sel == 1'b0) ? dma_we   : 1'b0;       // NPU가 쓸 땐 Write 금지
+Address is a number specifying which memory slot to read/write. In software, this is accessed via pointers or indices. In hardware, applying an electrical signal like `00000001` to an 8-bit `addr` wire opens the door to memory index 1.
+
+---
+
+## 5. MUX (Multiplexer)
+
+**C++ Analogy:** `if-else` statements, ternary operator `? :`, or pointer switching
+
+```systemverilog
+    // BRAM 0 Control
+    assign we_0   = (ping_pong_sel == 1'b0) ? dma_we   : 1'b0;       // Disable write when NPU is using it
     assign addr_0 = (ping_pong_sel == 1'b0) ? dma_addr : sys_addr;
 
-    // BRAM 1번 제어
-    assign we_1   = (ping_pong_sel == 1'b1) ? dma_we   : 1'b0;       // NPU가 쓸 땐 Write 금지
+    // BRAM 1 Control
+    assign we_1   = (ping_pong_sel == 1'b1) ? dma_we   : 1'b0;       // Disable write when NPU is using it
     assign addr_1 = (ping_pong_sel == 1'b1) ? dma_addr : sys_addr;
 
-    // Systolic 쪽으로 나가는 데이터 (Demux)
+    // Data going out to Systolic Array (Demux)
     assign sys_rdata = (ping_pong_sel == 1'b0) ? rdata_1 : rdata_0;
 ```
-소프트웨어는 if문이 거짓이면 그 안의 코드를 아예 실행 안 하는데. 하지만 하드웨어는 모든 모듈(전선)이 항상 살아서 전기가 흐르고 있음.그래서 MUX라는 스위치를 달아서 "선택 신호가 0이면 A 전선의 데이터를, 1이면 B 전선의 데이터를 통과시켜!"라는 물리적인 길을 터주는 역할. 아까 assign sys_rdata = (sel == 0) ? rdata_1 : rdata_0; 코드가 바로 이 MUX 회로.
 
-# 1. 내부에 BRAM_0과 BRAM_1 모듈 두 개를 생성한다.
+In software, if a condition is false, the code block inside is not executed. However, in hardware, electricity is always flowing through all modules (wires). Therefore, a MUX acts as a physical switch: "If the selection signal is 0, pass the data from wire A; if 1, pass wire B!" The line `assign sys_rdata = (sel == 0) ? rdata_1 : rdata_0;` is exactly this MUX circuit.
+
+---
+
+## 6. How it Works
+
+### Step 1. Create two modules: `BRAM_0` and `BRAM_1`
+
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
-    
-    subgraph "FPGA 메모리 (BRAM)"
+
+    subgraph "FPGA Memory (BRAM)"
         B0[("BRAM_0")]:::memory
         B1[("BRAM_1")]:::memory
     end
-    
-    SYS[systolic_2x2 연산 유닛]:::logic
 
-    %% 스타일 정의
+    SYS[systolic_2x2 Computation Unit]:::logic
+
+    %% Style definitions
     classDef input fill:#f9f,stroke:#333,stroke-width:2px;
     classDef memory fill:#ff9,stroke:#333,stroke-width:2px;
     classDef logic fill:#9cf,stroke:#333,stroke-width:2px;
 
-    %% 연결선 (개념적)
+    %% Conceptual connections
     DMA -.-> B0
     DMA -.-> B1
     B0 -.-> SYS
     B1 -.-> SYS
 ```
 
-# 2.ping_pong_sel이라는 1비트짜리 스위치(포인터)를 둔다.
-# 3.ping_pong_sel == 0일 때: AXI DMA (외부 메모리)는 BRAM_0에 다음 연산할 데이터를 열심히 쓰고(Write), 그와 동시에 우리의 systolic_2x2는 BRAM_1에서 이미 준비된 데이터를 읽어와서(Read) 연산을 돌린다.
-* 상황 1: ping_pong_sel == 0 일 때
-스위치 상태: 위쪽(0번)으로 입력, 아래쪽(1번)에서 출력
-DMA: BRAM_0에 열심히 데이터를 채워 넣습니다 (Write).
-Systolic: 이미 데이터가 차 있는 BRAM_1에서 데이터를 가져와 연산합니다 (Read).
+### Step 2. Introduce a 1-bit switch (pointer) named `ping_pong_sel`.
+
+### Step 3. When `ping_pong_sel == 0`:
+The AXI DMA (external memory) actively writes the next data to `BRAM_0` (Write), while simultaneously, our `systolic_2x2` reads already prepared data from `BRAM_1` (Read) and performs computations.
+
+**Scenario 1: `ping_pong_sel == 0`**
+- Switch state: Input to the top (0), Output from the bottom (1)
+- **DMA**: Diligently fills `BRAM_0` with data (Write).
+- **Systolic**: Fetches data from the already filled `BRAM_1` for computation (Read).
+
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
     SYS[systolic_2x2]:::logic
-    
+
     subgraph "Ping-Pong Control (sel == 0)"
         direction TB
-        B0[("BRAM_0 writing ")]:::activeWrite
+        B0[("BRAM_0 writing")]:::activeWrite
         B1[("BRAM_1 reading")]:::activeRead
     end
 
-    %% 흐름선
-    DMA == "데이터 쓰기 (Write)" ==> B0
-    B1 == "데이터 읽기 (Read)" ==> SYS
+    %% Flow lines
+    DMA == "Write Data" ==> B0
+    B1 == "Read Data" ==> SYS
 
-    %% 스타일 정의
+    %% Style definitions
     classDef input fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef logic fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef activeWrite fill:#ffcdd2,stroke:#b71c1c,color:black,stroke-width:4px;
     classDef activeRead fill:#c8e6c9,stroke:#1b5e20,color:black,stroke-width:4px;
 ```
-* 전환 (Switching): 양쪽 작업 완료 후
-DMA도 쓰기를 다 했고, Systolic도 연산을 다 마쳤다면?
-ping_pong_sel = ~ping_pong_sel (0 → 1)로 바뀝니다.  
 
-* 상황 2: ping_pong_sel == 1 일 때
-스위치 상태: 경로가 크로스(교차) 됩니다.
-DMA: 이제 비어있는 BRAM_1에 새 데이터를 채웁니다.
-Systolic: 아까(상황 1에서) DMA가 꽉 채워둔 BRAM_0의 데이터를 가져와 연산합니다.
+**Switching: After both tasks are complete**
+If the DMA finishes writing and the Systolic array finishes computing, the `ping_pong_sel` is toggled: `ping_pong_sel = ~ping_pong_sel` (from 0 to 1).
+
+**Scenario 2: `ping_pong_sel == 1`**
+- Switch state: Paths cross over.
+- **DMA**: Now fills the empty `BRAM_1` with new data.
+- **Systolic**: Fetches data from `BRAM_0` (which the DMA just filled in Scenario 1) for computation.
+
 ```mermaid
 graph LR
     DMA[AXI DMA]:::input
     SYS[systolic_2x2]:::logic
-    
+
     subgraph "Ping-Pong Control (sel == 1)"
         direction TB
         B0[("BRAM_0 reading")]:::activeRead
         B1[("BRAM_1 writing")]:::activeWrite
     end
 
-    %% 흐름선
-    DMA == "데이터 쓰기 (Write)" ==> B1
-    B0 == "데이터 읽기 (Read)" ==> SYS
+    %% Flow lines
+    DMA == "Write Data" ==> B1
+    B0 == "Read Data" ==> SYS
 
-    %% 스타일 정의
+    %% Style definitions
     classDef input fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef logic fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
     classDef activeWrite fill:#ffcdd2,stroke:#b71c1c,color:black,stroke-width:4px;
     classDef activeRead fill:#c8e6c9,stroke:#1b5e20,color:black,stroke-width:4px;
 ```
 
-```mermaid
+### Step 4. When both tasks are done, switch `ping_pong_sel = ~ping_pong_sel;` (0 to 1, or 1 to 0).
 
-```
-
-# 4.양쪽 작업이 다 끝나면 ping_pong_sel = ~ping_pong_sel; 로 스위칭! (0은 1로, 1은 0으로)
-
-```c++
+```cpp
 int buffer_0[256]; // BRAM 0
 int buffer_1[256]; // BRAM 1
 
@@ -154,41 +172,42 @@ buffer_0[0] = 10; // 0a
 buffer_0[1] = 20; // 14
 
 // Phase 2 (ping_pong_sel = 1)
-// NPU는 buffer_0에서 데이터를 안전하게 읽고
-int read_val = buffer_0[0]; 
+// NPU safely reads from buffer_0
+int read_val = buffer_0[0];
 
-// 동시에 DMA는 다음 데이터를 buffer_1에 쓴다!
-buffer_1[0] = 30; // 1e  <-- 30은 여기에 들어감!
+// Simultaneously, DMA writes next data into buffer_1!
+buffer_1[0] = 30; // 1e  <-- 30 goes in here!
 ```
 
->Q:  "시뮬레이션 웨이브 상으로는 dma_addr과 wdata에 00, 0a(10)이 ram의 값으로 들어가는 순간 동시(클럭상으로 동일)에 dma_addr과 wdata에 01, 14(20)가 할당되는 것처럼 보여 이게 문제 없을까?"  
+---
 
-A: 하드웨어의 핵심: "과거를 읽고, 미래를 쓴다" (<= Non-blocking)
-하드웨어의 모든 플립플롭(메모리, 레지스터)은 클럭이 0에서 1로 딱 올라가는 **Rising Edge (파형에서 솟아오르는 순간)** 에만 동작해. 이때 아주 중요한 2가지 절대 규칙이 있어.
+## 7. Q&A on Simulation Waveforms
 
-* 읽을 때는 '클럭이 뛰기 직전(과거)'의 값을 읽어간다. (Setup Time)
+> **Q:** "On the simulation waveform, at the exact moment `dma_addr` and `wdata` assign `00` and `0a` (10) into the ram, it looks like `01` and `14` (20) are being assigned simultaneously on the same clock cycle. Is this a problem?"
 
-* 값이 변하는 건 '클럭이 뛴 직후(미래)'부터 반영된다. (Clock-to-Q)
+**A: The core principle of hardware: "Read the past, Write the future" (Non-blocking)**
 
-[클럭이 뛰기 0.001초 전]
+All flip-flops (memory, registers) in hardware operate only on the **Rising Edge** (the exact moment the waveform shoots up from 0 to 1). There are two absolute rules here:
 
-* dma_addr는 00을 유지하고 있고, dma_wdata는 0a (10)을 유지하고 있다.  
+1. **Setup Time:** When reading, it fetches the value from 'just before the clock tick' (the past).
+2. **Clock-to-Q:** The changed value is reflected 'just after the clock tick' (the future).
 
-[클럭 엣지 발생]
+**[0.001 seconds before the clock tick]**
+- `dma_addr` maintains `00`, and `dma_wdata` maintains `0a` (10).
 
-* BRAM : 방금 전까지 가지고 있던 주소(00)랑 데이터(0a) 를 ram[0] 안에 넣음 (여기서 ram[0]에 10이 저장됨)
+**[Clock Edge Occurs]**
+- **BRAM:** Stores the address (`00`) and data (`0a`) it held a moment ago into `ram[0]`. (10 is stored here).
+- **Testbench (DMA):** Prepares the next address `01` and data `14` (20). (The waveform values change to `01` and `14` here).
 
-* 테스트벤치(DMA) : 주소 01이랑 데이터 14 (20)를 저장 (여기서 파형의 값이 01, 14(10진수 20)로 바뀜)  
-
-```c++
-// 매 클럭(Loop)마다 일어나는 일
+```cpp
+// What happens every clock cycle (Loop)
 int old_addr = current_addr;
 int old_data = current_data;
 
-// 1. BRAM은 옛날(방금 전) 값을 읽어서 저장하고
-ram[old_addr] = old_data; 
+// 1. BRAM reads the old value (from a moment ago) and stores it
+ram[old_addr] = old_data;
 
-// 2. 테스트벤치는 새로운 값으로 업데이트함 (동시에 발생!)
+// 2. Testbench updates with new values (Happens simultaneously!)
 current_addr = 1;
 current_data = 20;
 ```

--- a/Architecture/Systolic_Array_NxN.md
+++ b/Architecture/Systolic_Array_NxN.md
@@ -1,7 +1,7 @@
 # Systolic Array NxN — Scalable Core Array
 
 ## 1. Overview: Evolution from 2x2 to NxN
-The hardcoded wire connections of the initial 2x2 prototype become impossible to maintain when scaling up to 4x4 or 8x8 arrays. 
+The hardcoded wire connections of the initial 2x2 prototype become impossible to maintain when scaling up to 4x4 or 8x8 arrays.
 To solve this, we introduced SystemVerilog's `generate for` statements, implementing a **Scalable Architecture** where the entire grid is automatically generated at compile-time simply by changing the `ARRAY_SIZE` parameter.
 
 ## 2. 2D Array Routing using Generate Statements
@@ -14,14 +14,15 @@ graph TD
         PE_ij["PE(i, j)"]
         PE_right["PE(i, j+1)"]
         PE_bottom["PE(i+1, j)"]
-        
+
         PE_ij -- "o_a -> i_a" --> PE_right
         PE_ij -- "o_b -> i_b" --> PE_bottom
     end
 ```
-Key Implementation Details
-We declare a 2D wire array wire [7:0] a_wires [0:N][0:N] to pre-allocate all connection pathways between the PEs.
 
-External inputs (In_a, In_b) are plugged into the boundaries (a_wires[i][0] and b_wires[0][j]), and the final outputs are extracted from o_acc[i][j].
+### Key Implementation Details
+We declare a 2D wire array `wire [7:0] a_wires [0:N][0:N]` to pre-allocate all connection pathways between the PEs.
 
-Advantage: Even when synthesizing a 16x16 array (256 MAC cores), not a single line of the routing code needs to be modified.
+External inputs (`In_a`, `In_b`) are plugged into the boundaries (`a_wires[i][0]` and `b_wires[0][j]`), and the final outputs are extracted from `o_acc[i][j]`.
+
+**Advantage**: Even when synthesizing a 16x16 array (256 MAC cores), not a single line of the routing code needs to be modified.

--- a/Architecture/Testbench.md
+++ b/Architecture/Testbench.md
@@ -1,108 +1,108 @@
-# 테스트벤치 시뮬레이션 흐름
+# Testbench Simulation Flow
 
-세 개의 testbench가 각 모듈을 검증한다.
+Three testbenches verify each respective module.
 
 ---
 
-## 전체 검증 구조
+## Overall Verification Structure
 
 ```mermaid
 flowchart LR
-    %% 전체는 가로(1행 3열) 배치
-    
-    subgraph tb_mac_unit["<h3>tb_mac_unit<br/>(pe_unit 검증)</h3>"]
+    %% Overall horizontal (1 row 3 columns) arrangement
+
+    subgraph tb_mac_unit["<h3>tb_mac_unit<br/>(pe_unit Verification)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing from title
         sep1[ ] --- T1
         style sep1 fill:none,stroke:none
-        
-        T1["① 리셋 (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=3 → acc=6"]
+
+        T1["① Reset (rst_n=0 → 1)"] --> T2["② i_a=2, i_b=3 → acc=6"]
         T2 --> T3["③ i_a=4, i_b=5 → acc=26"]
         T3 --> T4["④ i_a=10, i_b=10 → acc=126"]
-        T4 --> T5["⑤ $display로 결과 출력"]
-        T5 --> W1["⚠️ i_valid 연결 안 됨\n→ 항상 누산됨"]
+        T4 --> T5["⑤ Output result via $display"]
+        T5 --> W1["⚠️ i_valid is unconnected\n→ Accumulates continuously"]
     end
 
-    subgraph tb_ping_pong["<h3>tb_ping_pong<br/>(PP-bram 검증)</h3>"]
+    subgraph tb_ping_pong["<h3>tb_ping_pong<br/>(PP-bram Verification)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing from title
         sep2[ ] --- P1
         style sep2 fill:none,stroke:none
 
         P1["① sel=0, DMA→BRAM_0[0]=10"] --> P2["② DMA→BRAM_0[1]=20"]
-        P2 --> P3["③ sel=1 (스위치!)"]
-        P3 --> P4["④ NPU가 sys_addr=0 → rdata=10"]
-        P4 --> P5["⑤ 동시에 DMA→BRAM_1[0]=30"]
-        P5 --> W2["⚠️ 동기 읽기라\n1 사이클 후 데이터"]
+        P2 --> P3["③ sel=1 (Switch!)"]
+        P3 --> P4["④ NPU sys_addr=0 → rdata=10"]
+        P4 --> P5["⑤ Simultaneously DMA→BRAM_1[0]=30"]
+        P5 --> W2["⚠️ Synchronous read\nso data appears 1 cycle later"]
     end
 
-    subgraph tb_systolic["<h3>tb_systolic<br/>(systolic_2x2 검증)</h3>"]
+    subgraph tb_systolic["<h3>tb_systolic<br/>(systolic_2x2 Verification)</h3>"]
         direction TB
-        %% 제목과의 간격을 위한 투명 노드
+        %% Transparent node for spacing from title
         sep3[ ] --- S1
         style sep3 fill:none,stroke:none
 
-        S1["① in_valid=1, 파도 1 투입"] --> S2["② 파도 2 투입"]
-        S2 --> S3["③ 파도 3 투입"]
-        S3 --> S4["④ in_valid=0 (flush)"]
-        S4 --> S5["⑤ PE들이 순차적으로 결과 수렴"]
-        S5 --> W3["⚠️ PE(1,1)은\n2 사이클 늦게 시작"]
+        S1["① in_valid=1, Input Wave 1"] --> S2["② Input Wave 2"]
+        S2 --> S3["③ Input Wave 3"]
+        S3 --> S4["④ in_valid=0 (Flush)"]
+        S4 --> S5["⑤ PEs sequentially converge results"]
+        S5 --> W3["⚠️ PE(1,1) starts\n2 cycles later"]
     end
 
-    %% 3열 배치를 유지하기 위한 투명 연결선
+    %% Transparent connecting lines to maintain the 3-column layout
     tb_mac_unit ~~~ tb_ping_pong
     tb_ping_pong ~~~ tb_systolic
 ```
 
 ---
 
-## 1. tb_mac_unit — pe_unit 단독 검증
+## 1. `tb_mac_unit` — `pe_unit` Standalone Verification
 
-PE 하나를 단독으로 검증한다. 매 클럭 입력을 넣고 누적 결과가 올바른지 확인.
+Verifies a single PE in isolation. Inputs are provided every clock, and it checks whether the accumulated result is correct.
 
 ```
-시나리오:
-  rst_n = 0 → 1  (리셋 해제)
+Scenario:
+  rst_n = 0 → 1  (Release Reset)
   Cycle 1: i_a=2, i_b=3  → acc = 0 + 6  = 6
   Cycle 2: i_a=4, i_b=5  → acc = 6 + 20 = 26
   Cycle 3: i_a=10, i_b=10 → acc = 26 + 100 = 126 ✓
 ```
 
-**알려진 이슈:** `tb_mac_unit.sv`에서 `i_valid` 포트가 연결되지 않아 항상 valid 상태로 동작한다. 실제 systolic 배열과 달리 valid 제어를 테스트하지 못한다.
+**Known Issue:** The `i_valid` port is unconnected in `tb_mac_unit.sv`, meaning it operates in an always-valid state. It does not test the valid control differently from the actual systolic array.
 
 ---
 
-## 2. tb_ping_pong — ping_pong_bram 더블버퍼 검증
+## 2. `tb_ping_pong` — `ping_pong_bram` Double Buffer Verification
 
-핑퐁 버퍼의 핵심: DMA 쓰기와 NPU 읽기가 **동시에** 일어나는지 확인.
+The core of the ping-pong buffer: verify that DMA writes and NPU reads occur **simultaneously**.
 
 ```
 Phase 1 (sel=0):
   DMA → BRAM_0[0] = 10
   DMA → BRAM_0[1] = 20
 
-Phase 2 (sel=1, 스위치!):
-  NPU  → sys_addr=0 → (1 사이클 후) rdata = 10  ← BRAM_0에서 읽기
-  DMA  → BRAM_1[0] = 30                          ← BRAM_1에 쓰기 (동시!)
-  NPU  → sys_addr=1 → (1 사이클 후) rdata = 20
+Phase 2 (sel=1, Switch!):
+  NPU  → sys_addr=0 → (1 cycle later) rdata = 10  ← Read from BRAM_0
+  DMA  → BRAM_1[0] = 30                           ← Write to BRAM_1 (Simultaneous!)
+  NPU  → sys_addr=1 → (1 cycle later) rdata = 20
 ```
 
-**동기식 읽기 주의:** `simple_bram`은 동기식이므로 주소 입력 후 **다음 클럭**에 데이터가 나온다.
+**Synchronous Read Caution:** Because `simple_bram` is synchronous, data is output on the **next clock** after the address is inputted.
 
 ---
 
-## 3. tb_systolic — systolic_2x2 행렬 연산 검증
+## 3. `tb_systolic` — `systolic_2x2` Matrix Multiplication Verification
 
-4사이클 파도를 흘려보내며 2×2 행렬 곱 결과를 검증한다.
+Verifies the 2x2 matrix multiplication result by flowing waves over 4 cycles.
 
-| 사이클 | in_a_0 | in_a_1 | in_b_0 | in_b_1 | 이벤트 |
+| Cycle | in_a_0 | in_a_1 | in_b_0 | in_b_1 | Event |
 |--------|--------|--------|--------|--------|--------|
-| 1 | 1 | 0 | 1 | 0 | PE(0,0) 첫 연산 시작 |
-| 2 | 2 | 3 | 3 | 2 | 파도 확산: PE(0,0), (0,1), (1,0) 가동 |
-| 3 | 0 | 4 | 0 | 4 | 전체 가동: PE(1,1) 첫 연산 |
-| 4 | 0 | 0 | 0 | 0 | valid=0 (flush): PE(1,1) 마지막 연산 |
+| 1 | 1 | 0 | 1 | 0 | PE(0,0) starts first computation |
+| 2 | 2 | 3 | 3 | 2 | Wave spreads: PE(0,0), (0,1), (1,0) activate |
+| 3 | 0 | 4 | 0 | 4 | Full activation: PE(1,1) first computation |
+| 4 | 0 | 0 | 0 | 0 | valid=0 (flush): PE(1,1) final computation |
 
-**valid 전파 지연:** PE(0,0) → PE(0,1), PE(1,0)까지는 **1 사이클** 늦고, PE(1,1)은 **2 사이클** 늦게 계산을 시작한다.
+**Valid Propagation Delay:** Computations at PE(0,1) and PE(1,0) are delayed by **1 cycle** compared to PE(0,0). Computations at PE(1,1) start **2 cycles** later.
 
 ```mermaid
 sequenceDiagram
@@ -124,14 +124,14 @@ sequenceDiagram
 
 ---
 
-## 4. 검증 환경
+## 4. Verification Environment
 
-**EDA Tool:** Xilinx Vivado 2025.2  
-**Target:** xc7z020clg400-1 (PYNQ-Z2)  
-**Simulator:** XSim (Vivado 내장) + Verilator (고속 C++ 기반)
+- **EDA Tool:** Xilinx Vivado 2025.2
+- **Target:** xc7z020clg400-1 (PYNQ-Z2)
+- **Simulator:** XSim (Built-in Vivado) + Verilator (High-speed C++ based)
 
 ```bash
-# Verilator로 빠른 시뮬레이션
+# Fast simulation with Verilator
 verilator --cc --exe --build tb_systolic.sv systolic_2x2.sv pe_unit.sv
 ./obj_dir/Vsystolic_2x2
 ```

--- a/Architecture/The Math Accelerators.md
+++ b/Architecture/The Math Accelerators.md
@@ -6,11 +6,11 @@ To achieve a full hardware bypass of the CPU and process the Gemma 3-4B-IT LLM e
 
 ## 1. 1-Clock RMSNorm Accelerator (`rmsnorm_inv_sqrt.sv`)
 
-**Target Operation:** Inverse Square Root ($1/\sqrt{x}$)
+**Target Operation:** Inverse Square Root ( $ 1/\sqrt{x} $ )
 **Latency:** 1 Clock Cycle
 **Method:** Piecewise Linear Approximation (PWL)
 
-In software, dividing by a square root takes dozens of cycles. We accelerated this by approximating the non-linear curve with 1024 tiny linear segments ($y = ax + b$).
+In software, dividing by a square root takes dozens of cycles. We accelerated this by approximating the non-linear curve with 1024 tiny linear segments ( $ y = ax + b $ ).
 
 ### Hardware Architecture
 1. **BRAM LUT (1024 Depth):** The upper 10 bits of the input `x` act as a memory address. The BRAM outputs the pre-calculated `Slope (a)` and `Intercept (b)` for that specific segment.
@@ -36,18 +36,22 @@ graph TD
 
 ## 2. 3-Clock Softmax Accelerator (`softmax_exp_unit.sv`)
 
-**Target Operation:** Natural Exponential ($e^x$)
+**Target Operation:** Natural Exponential ( $ e^x $ )
 **Latency:** 3 Clock Cycles
-**Method:** Base-2 Conversion ($e^x = 2^{x \cdot \log_2 e}$)
+**Method:** Base-2 Conversion
 
-Calculating $e^x$ using Taylor series requires floating-point division and many loops. We completely bypassed this by switching bases.
+$$
+e^x = 2^{x \cdot \log_2 e}
+$$
+
+Calculating $ e^x $ using Taylor series requires floating-point division and many loops. We completely bypassed this by switching bases.
 
 ### Hardware Architecture
-1. **Multiplication (Cycle 1):** Multiply the input by the constant $\log_2 e \approx 1.442695$.
+1. **Multiplication (Cycle 1):** Multiply the input by the constant $ \log_2 e \approx 1.442695 $.
 2. **Split (Cycle 2):** Hardware splits the result into an `Integer` part and a `Fractional` part automatically by tapping different wires.
 3. **Shift & LUT (Cycle 3):**
-   - **Integer Part:** $2^{\text{int}}$ is calculated simply by shifting the bits to the left (`1 << int_part`). This costs **zero hardware logic**.
-   - **Fractional Part:** $2^{\text{frac}}$ is fetched from a tiny 1024-segment LUT.
+   - **Integer Part:** $ 2^{\text{int}} $ is calculated simply by shifting the bits to the left (`1 << int_part`). This costs **zero hardware logic**.
+   - **Fractional Part:** $ 2^{\text{frac}} $ is fetched from a tiny 1024-segment LUT.
 4. **Final Result:** Multiply the shifted integer result by the fractional LUT output.
 
 ```mermaid
@@ -70,11 +74,11 @@ graph LR
 
 ## 3. 1-Clock GeLU Accelerator (`gelu_lut.sv`)
 
-**Target Operation:** Gaussian Error Linear Unit ($0.5x(1 + \text{tanh}(\dots))$)
+**Target Operation:** Gaussian Error Linear Unit ( $ 0.5x(1 + \text{tanh}(\dots)) $ )
 **Latency:** 1 Clock Cycle
 **Method:** Full-ROM Lookup Table
 
-GeLU requires calculating complex trigonometric functions. Since we operate on 16-bit intermediate values, the total number of possible inputs is only $2^{16} = 65,536$.
+GeLU requires calculating complex trigonometric functions. Since we operate on 16-bit intermediate values, the total number of possible inputs is only $ 2^{16} = 65,536 $.
 
 ### Hardware Architecture
 We mapped all 65,536 possible answers into a 64KB Block RAM (ROM). When a 16-bit MAC result comes in, it immediately serves as the address, outputting the GeLU result on the very next clock cycle.


### PR DESCRIPTION
Fix markdown rendering issues, translate documentation to English, and improve visual explanations with Mermaid diagrams across the Architecture documentation.