### PR TITLE
chore: drop phantom llm-lite submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sw/gemma3NE4B"]
-	path = sw/gemma3NE4B
-	url = https://github.com/hwkim-dev/llm-lite.git


### PR DESCRIPTION
## Summary

Remove the phantom `sw/gemma3NE4B` submodule declaration from `.gitmodules`.

The entry pointed to `https://github.com/hwkim-dev/llm-lite.git`, which returns 404 under both the deprecated `hwkim-dev` account and the current `hkimw` account.

The submodule was never integrated:
- No gitlink (`mode 160000`) anywhere in the tracked tree.
- No `sw/gemma3NE4B/` directory in the working tree.
- No entry in `.git/config` (never `git submodule init`-ed).
- No CI step in this repo, in `pccx`, or in `pccx-lab` runs `git submodule update --init`.

The private staging mirror's `main` already lacks this file, so the public clone has been the deviant since the broken target appeared.

## Verification

- Private staging CI: [run 25148542183](https://github.com/hkimw/pccx-FPGA-NPU-LLM-kv260-staging/actions/runs/25148542183) -- `success`. The `rtl-lint` job checked out `candidate/main` at `97011d2` and passed.
- No literalinclude in `pccx`'s docs targets `sw/gemma3NE4B/`, so the docs build is unaffected.

## Out of scope

- `README.md` lines 42 and 286 still describe `sw/gemma3NE4B/` as a planned application slot. Those are design-intent prose, not a working-tree path, and remain unchanged.
- `pccx`'s `docs/v002/Models/index.rst` and the Korean mirror still reference the same planned slot. Separate PR on the docs repo.
- Other `hwkim-dev` references in this repo (`docs/index.html`, `formal/sail/pccx.sail_project`, `sw/driver/uCA_v1_api.{c,h}`) are deferred to the post-transfer URL sweep.