### PR TITLE
chore: update links after organization transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@ and this project follows [Semantic Versioning](https://semver.org/).
   bare-metal driver under `sw/driver/`.  Bitstreams are out of scope
   for this release.
 
-[Unreleased]: https://github.com/hkimw/pccx-FPGA-NPU-LLM-kv260/compare/HEAD...HEAD
+[Unreleased]: https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/compare/HEAD...HEAD

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ abstract: >-
   production bitstream release.
 type: software
 license: Apache-2.0
-repository-code: "https://github.com/hkimw/pccx-FPGA-NPU-LLM-kv260"
-url: "https://hkimw.github.io/pccx/"
+repository-code: "https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260"
+url: "https://pccxai.github.io/pccx/"
 authors:
   - family-names: Kim
     given-names: Hyunwoo
@@ -24,7 +24,7 @@ authors:
 references:
   - type: software
     title: "pccx — open FPGA-oriented LLM inference accelerator"
-    repository-code: "https://github.com/hkimw/pccx"
+    repository-code: "https://github.com/pccxai/pccx"
     notes: "Canonical architecture, ISA, and docs that this repo implements."
 keywords:
   - FPGA

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ wiring are still in progress or planned.
 > the **pccx documentation site**. This repo implements what that site
 > specifies — read the spec first, then come back here for the RTL.
 >
-> **→ [pccx v002 — Architecture & ISA spec](https://hkimw.github.io/pccx/en/docs/v002/index.html)**
-> &nbsp;·&nbsp; [Gemma 3N E4B on pccx v002](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
-> &nbsp;·&nbsp; [한국어 문서](https://hkimw.github.io/pccx/ko/docs/v002/index.html)
+> **→ [pccx v002 — Architecture & ISA spec](https://pccxai.github.io/pccx/en/docs/v002/index.html)**
+> &nbsp;·&nbsp; [Gemma 3N E4B on pccx v002](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
+> &nbsp;·&nbsp; [한국어 문서](https://pccxai.github.io/pccx/ko/docs/v002/index.html)
 
-Related repos: [pccx (spec)](https://github.com/hkimw/pccx) · [pccx-lab (profiler / simulator)](https://github.com/hkimw/pccx-lab) · [llm-bottleneck-lab (related research)](https://github.com/hkimw/llm-bottleneck-lab)
+Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profiler / simulator)](https://github.com/pccxai/pccx-lab) · [llm-bottleneck-lab (related research)](https://github.com/hkimw/llm-bottleneck-lab)
 
 ---
 
@@ -35,14 +35,14 @@ Related repos: [pccx (spec)](https://github.com/hkimw/pccx) · [pccx-lab (profil
 
 | Layer                                | Lives in                                   | Authoritative source                                                                     |
 | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Architecture / ISA / driver spec     | `pccx/docs/v002/`                          | [pccx v002 docs](https://hkimw.github.io/pccx/en/docs/v002/index.html)               |
-| Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://hkimw.github.io/pccx/en/docs/v002/Models/index.html)        |
+| Architecture / ISA / driver spec     | `pccx/docs/v002/`                          | [pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)               |
+| Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://pccxai.github.io/pccx/en/docs/v002/Models/index.html)        |
 | RTL (SystemVerilog)                  | this repo — `hw/rtl/`                      | —                                                                                         |
-| Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://hkimw.github.io/pccx/en/docs/v002/Drivers/api.html)  |
+| Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://pccxai.github.io/pccx/en/docs/v002/Drivers/api.html)  |
 | Application                          | this repo — `sw/gemma3NE4B/`               | —                                                                                         |
 
 If you want to **read about how the accelerator works**, head to the
-**[pccx v002 docs](https://hkimw.github.io/pccx/en/docs/v002/index.html)** —
+**[pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)** —
 that's the canonical source for every architectural decision in this repo.
 If you want to **read the RTL or synthesize the bitstream**, stay here.
 
@@ -50,7 +50,7 @@ If you want to **read the RTL or synthesize the bitstream**, stay here.
 
 ## Architecture Snapshot (pccx v002)
 
-[![pccx v002 architecture](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/architecture_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/top_level.html)
+[![pccx v002 architecture](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/architecture_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/top_level.html)
 
 *Click the diagram for the annotated top-level page on the pccx site.*
 
@@ -67,8 +67,8 @@ Three heterogeneous cores around a centralized L2 URAM cache:
 - **Activation path**: host DDR4 → ACP DMA → L2 URAM (1.75 MB, true dual port).
 - **Direct-connect FIFO**: GEMV → SFU, so softmax runs without an L2 round-trip.
 
-Full rationale and numbers: [Top-Level →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/top_level.html)
-· [Design rationale →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/rationale.html)
+Full rationale and numbers: [Top-Level →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/top_level.html)
+· [Design rationale →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/rationale.html)
 
 ---
 
@@ -78,16 +78,16 @@ Weight-stationary 2D systolic layout. Activations broadcast along
 columns, partial sums propagate vertically into the result accumulator.
 Used only during prefill; idle during decode.
 
-[![GEMM array layout](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_1_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
+[![GEMM array layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_1_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
 
 Inside each PE — a DSP48E2 wrapped with input flip-flops on both
 Activation and Weight ports, and an accumulator with a P-register
 output:
 
-[![GEMM single PE](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_2_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
+[![GEMM single PE](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_2_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
 
-Details: [GEMM core →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
-· [GEMM dataflow →](https://hkimw.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Details: [GEMM core →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
+· [GEMM dataflow →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
 
 ---
 
@@ -98,15 +98,15 @@ Activation broadcast and a Weight row. Outputs feed a reduction tree
 that collapses partial products into the final vector entry register.
 The primary compute path during autoregressive decode.
 
-[![GEMV core layout](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_1_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
+[![GEMV core layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_1_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
 
 Per-cycle operand shapes — a 1×N activation row multiplied against an
 N×N weight tile:
 
-[![GEMV operand shapes](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_2_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
+[![GEMV operand shapes](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_2_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
 
-Details: [GEMV core →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
-· [GEMV dataflow →](https://hkimw.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Details: [GEMV core →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
+· [GEMV dataflow →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
 
 ---
 
@@ -117,12 +117,12 @@ The DSP48E2 has a single 27×18 multiplier, not two. pccx v002 bit-packs
 port B, so each DSP emits **two MACs per cycle** into the 48-bit
 accumulator with a 19-bit guard band between the two channels.
 
-[![DSP48E2 W4A8 port layout](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_4_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+[![DSP48E2 W4A8 port layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_4_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 After accumulation, a sign-recovery step restores the upper channel
 when the lower channel borrowed a carry:
 
-[![Sign recovery SV snippet](https://raw.githubusercontent.com/hkimw/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_5_v002.png)](https://hkimw.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+[![Sign recovery SV snippet](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_5_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 - Maximum accumulations before draining the ACCM: **2^10 ≈ 1024** per
   channel (guard-band limited).
@@ -131,7 +131,7 @@ when the lower channel borrowed a carry:
   tree and merges the partial sums.
 - Peak: **2048 MAC × 400 MHz ≈ 819 GMAC/s** across the two systolic arrays.
 
-Details: [DSP48E2 W4A8 bit-packing →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+Details: [DSP48E2 W4A8 bit-packing →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 ---
 
@@ -154,12 +154,12 @@ End-to-end decode flow, per-cycle overlap strategy, instruction-level
 mapping, memory layout, and the performance budget all live in the
 pccx Models section:
 
-- [Gemma 3N overview](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)
-- [Full operator pipeline (embedding → sampling)](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)
-- [Attention & RoPE constraints](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)
-- [PLE & LAuReL routing rules](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)
-- [FFN Gaussian Top-K sparsity](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)
-- [**Execution & scheduling on pccx v002**](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
+- [Gemma 3N overview](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)
+- [Full operator pipeline (embedding → sampling)](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)
+- [Attention & RoPE constraints](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)
+- [PLE & LAuReL routing rules](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)
+- [FFN Gaussian Top-K sparsity](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)
+- [**Execution & scheduling on pccx v002**](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
 
 ---
 
@@ -175,8 +175,8 @@ Five opcodes, 64 bits each: `[63:60]` opcode + `[59:0]` body.
 | `4'h3` | `OP_MEMSET`| Write shape / size / scale constants to the Constant Cache              |
 | `4'h4` | `OP_CVO`   | Element-wise non-linear (exp, sqrt, GELU, sin, cos, reduce_sum, scale, recip) |
 
-Spec: [Per-instruction encoding →](https://hkimw.github.io/pccx/en/docs/v002/ISA/instructions.html)
-· [Dataflow per opcode →](https://hkimw.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Spec: [Per-instruction encoding →](https://pccxai.github.io/pccx/en/docs/v002/ISA/instructions.html)
+· [Dataflow per opcode →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
 
 The pipeline is **fully decoupled**: the front-end decodes and enqueues
 into per-engine FIFOs, and each compute engine fires independently once
@@ -211,7 +211,7 @@ enforced at RTL / memory controller / driver level:
    (`max_tokens = 8192`). Wrap-around overwrites the oldest entries.
    This bounds both OOM risk and worst-case memory traffic.
 
-Details: [KV cache strategy →](https://hkimw.github.io/pccx/en/docs/v002/Architecture/kv_cache.html)
+Details: [KV cache strategy →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/kv_cache.html)
 
 ---
 
@@ -233,8 +233,8 @@ This repository hosts the RTL for **both** active tracks. As of
 Full phase-by-phase plan, decision points, compute budget, and Year 2
 **Auto-Porting Pipeline α** vision:
 
-**→ [Roadmap (EN)](https://hkimw.github.io/pccx/en/docs/roadmap.html)**
-&nbsp;·&nbsp; [**한국어**](https://hkimw.github.io/pccx/ko/docs/roadmap.html)
+**→ [Roadmap (EN)](https://pccxai.github.io/pccx/en/docs/roadmap.html)**
+&nbsp;·&nbsp; [**한국어**](https://pccxai.github.io/pccx/ko/docs/roadmap.html)
 
 ---
 
@@ -262,7 +262,7 @@ Full phase-by-phase plan, decision points, compute budget, and Year 2
 > The current `hw/rtl/` tree reflects the v001 parameterization
 > (W4A16 / 32×32 array / 1 DSP = 1 MAC). Re-parameterization to the
 > v002 target (W4A8 / 32×16 ×2 / 1 DSP = 2 MAC) is the current
-> in-flight task. See the [design rationale](https://hkimw.github.io/pccx/en/docs/v002/Architecture/rationale.html#id3)
+> in-flight task. See the [design rationale](https://pccxai.github.io/pccx/en/docs/v002/Architecture/rationale.html#id3)
 > for the 3.125× theoretical speedup.
 
 ---
@@ -329,7 +329,7 @@ TB_CORE[tb_new_module]=N   # pick an unused core-id for the emitted trace
 
 Then drop `hw/tb/tb_new_module.sv` with the canonical `$display` line on
 success / failure. See
-[pccx-lab's verification-workflow doc](https://hkimw.github.io/pccx/en/lab/verification-workflow.html)
+[pccx-lab's verification-workflow doc](https://pccxai.github.io/pccx/en/lab/verification-workflow.html)
 for the end-to-end flow diagram and the Tauri IPC surface.
 
 ### What plugs into pccx-lab
@@ -342,7 +342,7 @@ for the end-to-end flow diagram and the Tauri IPC surface.
 | Roofline classification | `RooflineCard`     (runs on the loaded trace)      |
 | Markdown summary        | `generate_markdown_report` IPC                     |
 
-[pccx-lab]: https://github.com/hkimw/pccx-lab
+[pccx-lab]: https://github.com/pccxai/pccx-lab
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,24 +7,24 @@ Pages, bilingual EN / KO).
 ## Jump straight in
 
 - **Latest architecture — v002** (current target of this repo):
-  <https://hkimw.github.io/pccx/en/docs/v002/index.html>
+  <https://pccxai.github.io/pccx/en/docs/v002/index.html>
 - Documentation root (language picker):
-  <https://hkimw.github.io/pccx/en/index.html>
+  <https://pccxai.github.io/pccx/en/index.html>
 - pccx source repository:
-  <https://github.com/hkimw/pccx>
+  <https://github.com/pccxai/pccx>
 
 ## Where the old documents went
 
 | Old file (deleted)               | New location                                                                                                                |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `FPGA_NPU_Architecture_v2.md`    | [v002 Architecture](https://hkimw.github.io/pccx/en/docs/v002/Architecture/index.html)                                  |
-| `ISA.md`                         | [v002 ISA](https://hkimw.github.io/pccx/en/docs/v002/ISA/index.html)                                                    |
-| `HW_Optimization_DSP48E2.md`     | [DSP48E2 W4A8 bit-packing](https://hkimw.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)                    |
-| `GEMMA_3N_E4B.md`                | [Gemma 3N overview](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)                             |
-| `Gemma3N_Pipeline_EN.md`         | [Gemma 3N pipeline](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)                             |
-| `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)               |
-| `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
-| `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
-| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://hkimw.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)              |
+| `FPGA_NPU_Architecture_v2.md`    | [v002 Architecture](https://pccxai.github.io/pccx/en/docs/v002/Architecture/index.html)                                  |
+| `ISA.md`                         | [v002 ISA](https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html)                                                    |
+| `HW_Optimization_DSP48E2.md`     | [DSP48E2 W4A8 bit-packing](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)                    |
+| `GEMMA_3N_E4B.md`                | [Gemma 3N overview](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)                             |
+| `Gemma3N_Pipeline_EN.md`         | [Gemma 3N pipeline](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)                             |
+| `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)               |
+| `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
+| `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
+| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)              |
 
 For the Korean mirror, swap `/en/` for `/ko/` in any of the links above.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>uXC documentation has moved</title>
-<meta http-equiv="refresh" content="0; url=https://hwkim-dev.github.io/pccx/en/docs/v002/index.html">
-<link rel="canonical" href="https://hwkim-dev.github.io/pccx/en/docs/v002/index.html">
+<meta http-equiv="refresh" content="0; url=https://pccxai.github.io/pccx/en/docs/v002/index.html">
+<link rel="canonical" href="https://pccxai.github.io/pccx/en/docs/v002/index.html">
 <style>
   html, body { margin: 0; padding: 0; background: #0b1021; color: #e6e6e6; font-family: system-ui, -apple-system, sans-serif; }
   main { max-width: 640px; margin: 10vh auto; padding: 0 24px; }
@@ -16,14 +16,14 @@
 <main>
 <h1>Documentation moved</h1>
 <p>uXC / pccx documentation now lives at:</p>
-<p><a href="https://hwkim-dev.github.io/pccx/en/docs/v002/index.html">
-https://hwkim-dev.github.io/pccx/en/docs/v002/index.html
+<p><a href="https://pccxai.github.io/pccx/en/docs/v002/index.html">
+https://pccxai.github.io/pccx/en/docs/v002/index.html
 </a></p>
 <p>If you are not redirected automatically, click the link above.</p>
-<p>Source: <a href="https://github.com/hwkim-dev/pccx">github.com/hwkim-dev/pccx</a></p>
+<p>Source: <a href="https://github.com/pccxai/pccx">github.com/pccxai/pccx</a></p>
 </main>
 <script>
-  window.location.replace("https://hwkim-dev.github.io/pccx/en/docs/v002/index.html");
+  window.location.replace("https://pccxai.github.io/pccx/en/docs/v002/index.html");
 </script>
 </body>
 </html>

--- a/formal/sail/README.md
+++ b/formal/sail/README.md
@@ -81,8 +81,8 @@ afford.  A formal Sail model lets us:
   the RTL refines against (Sail's C / OCaml back-ends).
 - **Prove correctness properties** via Sail's Isabelle / Coq / HOL4
   back-ends once the execute pass lands.
-- **Advertise rigour** — the site [hkimw.github.io/pccx][site]
+- **Advertise rigour** — the site [pccxai.github.io/pccx][site]
   lists Sail alongside Arm / RISC-V / CHERI as one of the ISAs
   authored with real ISA-semantics tooling.
 
-[site]: https://hkimw.github.io/pccx/en/
+[site]: https://pccxai.github.io/pccx/en/

--- a/formal/sail/pccx.sail_project
+++ b/formal/sail/pccx.sail_project
@@ -2,7 +2,7 @@
 //
 // Ground truth: ../../hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv
 // Sail website:   https://sail-lang.org/
-// pccx docs:      https://hwkim-dev.github.io/pccx/en/docs/v002/ISA/
+// pccx docs:      https://pccxai.github.io/pccx/en/docs/v002/ISA/
 //
 // Build:   sail --check  pccx.sail_project   (type-check only)
 //          sail --help   pccx.sail_project   (list commands)

--- a/sw/driver/uCA_v1_api.c
+++ b/sw/driver/uCA_v1_api.c
@@ -1,7 +1,7 @@
 // ===| uCA API Implementation |==================================================
 // Builds 64-bit VLIW instructions from structured arguments and issues them
 // to the NPU via the HAL. Encoding per pccx v002 ISA:
-// https://hwkim-dev.github.io/pccx/en/docs/v002/ISA/index.html
+// https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html
 // ================================================================================
 
 #include "uCA_v1_api.h"

--- a/sw/driver/uCA_v1_api.h
+++ b/sw/driver/uCA_v1_api.h
@@ -10,7 +10,7 @@
 // uca_* call returns immediately after issuing to the instruction FIFO.
 // Call uca_sync() to wait for all in-flight operations to complete.
 //
-// Encoding reference: https://hwkim-dev.github.io/pccx/en/docs/v002/ISA/index.html
+// Encoding reference: https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html
 // ================================================================================
 
 #ifndef UCA_V1_API_H


### PR DESCRIPTION
## Summary

Replace stale URLs across 9 files after the 2026-04-30 transfer of pccx, pccx-lab, and pccx-FPGA-NPU-LLM-kv260 to the pccxai organization.

Mechanical URL replacement only -- no prose rewrites:

- `hkimw/pccx-FPGA-NPU-LLM-kv260` -> `pccxai/pccx-FPGA-NPU-LLM-kv260`
- `hkimw/pccx-lab` -> `pccxai/pccx-lab`
- `hkimw/pccx` -> `pccxai/pccx`
- `hkimw.github.io/pccx` -> `pccxai.github.io/pccx`
- `hwkim-dev.github.io/pccx` -> `pccxai.github.io/pccx`
- `github.com/hwkim-dev/pccx` -> `github.com/pccxai/pccx`

## Preserved

- `hkimw/llm-bottleneck-lab` reference in `README.md` (Related repos block) -- this repository remains under hkimw as a personal research project and is intentionally not part of the org transfer.

## Files changed

`CHANGELOG.md`, `CITATION.cff`, `README.md`, `docs/README.md`, `docs/index.html`, `formal/sail/README.md`, `formal/sail/pccx.sail_project`, `sw/driver/uCA_v1_api.c`, `sw/driver/uCA_v1_api.h`.

Diff is balanced (+63 / -63), single commit, no functional code changes -- only URL strings in comments, docs, citation metadata, and HTML redirect targets.