### PR TITLE
ci: opt JavaScript actions into Node.js 24

### DIFF
--- a/.github/workflows/sail-check.yml
+++ b/.github/workflows/sail-check.yml
@@ -15,6 +15,12 @@ on:
       - 'formal/sail/**'
       - '.github/workflows/sail-check.yml'
 
+# Opt JavaScript actions into the Node.js 24 runtime ahead of the
+# 2026-06-02 forced cutover. See:
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt JavaScript actions into the Node.js 24 runtime ahead of the
+# 2026-06-02 forced cutover. See:
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   repo-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env to both workflow files so `actions/checkout` (sail-check.yml + validate.yml) and `actions/cache` (sail-check.yml) use the Node.js 24 runtime ahead of the 2026-06-02 forced cutover.

No version bumps; no behavioural change beyond the runtime.

## Diff

- `.github/workflows/sail-check.yml`: +6 / -0 (top-level `env:` block).
- `.github/workflows/validate.yml`: +6 / -0 (top-level `env:` block).

## Verification

- YAML syntax: OK.
- Private staging CI: [run 25178824897](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260-staging/actions/runs/25178824897) -- success.
- The `repo-validate` Stage 3 required check runs on this PR; passing it is the natural validation.