### PR TITLE
docs: add v0.1.0-alpha release draft

### DIFF
--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -1,0 +1,82 @@
+# pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — release draft
+
+> **Draft only — do not publish.** No tag is created, no GitHub release
+> is published. This file is a planning document for human review and
+> will be turned into the actual release notes when the v0.1.0-alpha
+> tag is eventually pushed in a separately approved cycle.
+
+- **Target repo**: `pccxai/pccx-FPGA-NPU-LLM-kv260`
+- **Target base SHA**: `5195ace` (current `main` HEAD as of 2026-05-01,
+  immediately after the citation-metadata cleanup merge)
+- **Title (proposed)**: `pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — KV260 RTL preview snapshot`
+- **Tag (proposed, NOT created)**: `v0.1.0-alpha`
+- **Pre-release**: yes
+
+## Highlights
+
+- First public RTL preview of the pccx v002 NPU implementation
+  targeting Xilinx Kria KV260 (Zynq UltraScale+ ZU5EV) under the
+  `pccxai` organization.
+- SystemVerilog testbenches for `tb_ctrl_npu_decoder` and
+  `tb_barrel_shifter_BF16` (BF16 to 27-bit fixed-point) wired into the
+  verification flow.
+- Multi-driver issue on `OUT_fetch_PC_ready` repaired in the decoder
+  testbench path.
+- Sail ISA model — types, regs, decode, and execute increments 1 to 3
+  (per-opcode MAC, DMA, and SFU effects, and per-opcode operand
+  latching). CI installs `z3` and runs the `Sail typecheck` workflow on
+  every PR.
+- `repo-validate` required status check on `main`; covers URL hygiene,
+  brand-name guard, and license / citation sanity.
+- Verification workflow section in the README explains how to run the
+  testbench suite locally and what each `tb` covers.
+- Phantom `llm-lite` submodule reference removed; the clone footprint
+  is now clean.
+- Project renamed from `uXC` to `pccx`; legacy strings purged from
+  tracked sources.
+
+## Known limitations
+
+- This is a reference implementation, not a timing-closed production
+  bitstream. No place-and-route closure or KV260 board bring-up
+  artifacts are included.
+- The Sail ISA model covers decode and the first three execute
+  increments only; later opcodes are still being modelled.
+- Some testbenches (notably `tb_GEMM_fmap_staggered_delay`, the
+  shift-chain timing model) are parked WIP and are not part of CI.
+- No bit-accurate co-simulation harness with `pccx-lab` yet — that
+  bridge lands in v0.2.0.
+- Wiki is enabled on this repository but currently empty; the intended
+  documentation surface is the `pccxai/pccx` site, not the wiki.
+
+## Validation status
+
+- `repo-validate` and `Sail typecheck` required checks green on
+  `main`.
+- Stage 1, 2, and 3 ruleset active; direct push to `main` blocked.
+- README and `CITATION.cff` reference `pccxai/pccx` as the canonical
+  architecture repo.
+- No standalone-vendor brand-token leaks in tracked sources.
+
+## Citation
+
+Cite using the in-repo `CITATION.cff`, which also references the
+canonical `pccxai/pccx` architecture repository under `references:`.
+Author: Hyunwoo Kim (Independent researcher); ORCID intentionally
+omitted until registered.
+
+## Not included in this release
+
+- Tag push or GitHub Release publication.
+- KV260 board bring-up bitstream.
+- Timing-closed synthesis reports.
+- Full Sail ISA execute coverage (4th increment onward).
+- The full GEMM staggered-delay timing model.
+
+## Next milestones
+
+- `v0.2.0` (subtitle: "Bring-up and closure"): complete remaining
+  Sail execute increments, expand testbench coverage, and post the
+  first bring-up logs.
+- Integrate the driver path with `pccx-lab` and ship a timing-closed
+  bitstream candidate.


### PR DESCRIPTION
Adds `docs/releases/v0.1.0-alpha.md` as an in-tree draft for the
upcoming v0.1.0-alpha release notes. The file is explicitly marked
**Draft only — do not publish** at the top, so it will not be turned
into a GitHub Release until a separately approved cycle.

## Why land it now

- Locks the release scope (highlights, known limitations, next
  milestones) against the current `main` SHA so reviewers comment on a
  stable text rather than a moving target.
- Lets the eventual release-publish step copy this file verbatim into
  the GitHub Release body — no last-minute prose authoring.
- Becomes the artefact contributors can link to from issues / PRs /
  discussions during the run-up to the tag.

## What this PR is *not*

- It does **not** create a tag.
- It does **not** publish a GitHub Release.
- It does **not** mint a Zenodo DOI.
- It does **not** modify rulesets, required checks, or workflows.

## Validation

- Markdown only; no code, no CI workflow, no settings.
- No vendor / brand tokens added (`NVIDIA`, standalone-vendor names).
- Base SHA pinned to current `main` HEAD at the top of the file.