### PR TITLE
docs: improve README first impression

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profi
 
 ---
 
+## Project status
+
+**Public alpha** — first tagged release `v0.1.0-alpha` is in draft. Core
+RTL and ISA are stable; verification and KV260 bring-up are in
+progress. This is not a timing-closed bitstream release. Feedback and
+issues are welcome.
+
+| Entry point | Link |
+| --- | --- |
+| Architecture & ISA spec | <https://pccxai.github.io/pccx/en/docs/v002/index.html> |
+| Releases | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/releases> |
+| Roadmap (project board) | <https://github.com/orgs/pccxai/projects/1> |
+| Contributing | <https://github.com/pccxai/.github/blob/main/CONTRIBUTING.md> |
+| Discussions | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/discussions> |
+| Good first issues | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/labels/good%20first%20issue> |
+
+---
+
 ## What's here vs. what's in pccx
 
 | Layer                                | Lives in                                   | Authoritative source                                                                     |


### PR DESCRIPTION
## Summary
- Add a **Project status** section near the top of the README so first-time visitors land on the alpha-status framing and the canonical entry points without scrolling.
- Single table with: architecture spec, releases, roadmap project, org-wide CONTRIBUTING, discussions, good first issues.
- Tone matches existing README — no new technical claims, no rewrite of body content.

## Test plan
- [ ] Render renders cleanly on github.com (table + admonition lines)
- [ ] All 6 links resolve (spec live, releases page, project board public, org CONTRIBUTING.md exists, discussions enabled, good-first-issue label exists)
- [ ] Required checks (repo-validation) start and pass