### PR TITLE
docs: polish release and citation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,57 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
+## v0.1.0-alpha
 
-- (placeholder) The first tag will be `v0.1.0-alpha` — an early
-  source snapshot of the SystemVerilog RTL under `hw/rtl/` and the
-  bare-metal driver under `sw/driver/`.  Bitstreams are out of scope
-  for this release.
+First public RTL preview of the pccx v002 NPU implementation targeting
+Xilinx Kria KV260 (Zynq UltraScale+ ZU5EV) under the `pccxai`
+organization. Mirrors the release draft at
+[`docs/releases/v0.1.0-alpha.md`](docs/releases/v0.1.0-alpha.md).
+
+### Highlights
+
+- First public RTL preview of the pccx v002 NPU implementation
+  targeting Xilinx Kria KV260 (Zynq UltraScale+ ZU5EV) under the
+  `pccxai` organization.
+- SystemVerilog testbenches for `tb_ctrl_npu_decoder` and
+  `tb_barrel_shifter_BF16` (BF16 to 27-bit fixed-point) wired into the
+  verification flow.
+- Multi-driver issue on `OUT_fetch_PC_ready` repaired in the decoder
+  testbench path.
+- Sail ISA model — types, regs, decode, and execute increments 1 to 3
+  (per-opcode MAC, DMA, and SFU effects, and per-opcode operand
+  latching). CI installs `z3` and runs the `Sail typecheck` workflow on
+  every PR.
+- `repo-validate` required status check on `main`; covers URL hygiene,
+  brand-name guard, and license / citation sanity.
+- Verification workflow section in the README explains how to run the
+  testbench suite locally and what each `tb` covers.
+- Phantom `llm-lite` submodule reference removed; the clone footprint
+  is now clean.
+- Project renamed from `uXC` to `pccx`; legacy strings purged from
+  tracked sources.
+
+### Known limitations
+
+- This is a reference implementation, not a timing-closed production
+  bitstream. No place-and-route closure or KV260 board bring-up
+  artifacts are included.
+- The Sail ISA model covers decode and the first three execute
+  increments only; later opcodes are still being modelled.
+- Some testbenches (notably `tb_GEMM_fmap_staggered_delay`, the
+  shift-chain timing model) are parked WIP and are not part of CI.
+- No bit-accurate co-simulation harness with `pccx-lab` yet — that
+  bridge lands in v0.2.0.
+- Wiki is enabled on this repository but currently empty; the intended
+  documentation surface is the `pccxai/pccx` site, not the wiki.
+
+### Validation
+
+- `repo-validate` and `Sail typecheck` required checks green on
+  `main`.
+- Stage 1, 2, and 3 ruleset active; direct push to `main` blocked.
+- README and `CITATION.cff` reference `pccxai/pccx` as the canonical
+  architecture repo.
+- No standalone-vendor brand-token leaks in tracked sources.
 
 [Unreleased]: https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/compare/HEAD...HEAD

--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ issues are welcome.
 | Entry point | Link |
 | --- | --- |
 | Architecture & ISA spec | <https://pccxai.github.io/pccx/en/docs/v002/index.html> |
+| RTL reference (this repo) | [`hw/rtl/`](hw/rtl/) — top wrapper [`NPU_top.sv`](hw/rtl/NPU_top.sv) |
 | Releases | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/releases> |
+| `v0.1.0-alpha` notes | [docs/releases/v0.1.0-alpha.md](docs/releases/v0.1.0-alpha.md) |
 | Roadmap (project board) | <https://github.com/orgs/pccxai/projects/1> |
 | Contributing | <https://github.com/pccxai/.github/blob/main/CONTRIBUTING.md> |
-| Discussions | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/discussions> |
+| How to cite | [CITATION.cff](CITATION.cff) |
+| Verification check | `Sail typecheck` + `repo-validate` required on `main` |
+| Discussions (board bring-up, RTL Q&A) | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/discussions> |
 | Good first issues | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/labels/good%20first%20issue> |
+
+> The repository **Wiki** is intentionally empty — RTL- and bring-up
+> questions belong in **Discussions**, and the canonical architecture
+> documentation lives on the [pccx Sphinx site](https://pccxai.github.io/pccx/en/docs/v002/index.html).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `v0.1.0-alpha` release-notes, RTL reference (top wrapper), `How to cite`, verification gating, and Discussions rows to the README **Project status** entry-point table.
- Add a one-line note clarifying that the intentionally-empty Wiki is not the documentation surface — RTL / board bring-up questions belong in Discussions, architectural docs live on the pccx Sphinx site.
- Replace the placeholder `[Unreleased]` block in `CHANGELOG.md` with a full `v0.1.0-alpha` section (Highlights / Known limitations / Validation) mirroring `docs/releases/v0.1.0-alpha.md` and the GitHub draft release body.

No tag is created and the GitHub draft release is unchanged.

## Test plan

- [x] `git diff` review — README adds five rows + a Wiki/Discussions note; CHANGELOG replaces the placeholder.
- [ ] CI required checks green on this PR (`repo-validate`, `Sail typecheck`).
- [ ] README entry-point table renders cleanly on the PR view.