### PR TITLE
docs: update v0.1.0-alpha release links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## v0.1.0-alpha
+## v0.1.0-alpha — 2026-05-01
 
 First public RTL preview of the pccx v002 NPU implementation targeting
 Xilinx Kria KV260 (Zynq UltraScale+ ZU5EV) under the `pccxai`
-organization. Mirrors the release draft at
+organization. Mirrors the release notes at
 [`docs/releases/v0.1.0-alpha.md`](docs/releases/v0.1.0-alpha.md).
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profi
 
 ## Project status
 
-**Public alpha** — first tagged release `v0.1.0-alpha` is in draft. Core
+**Public alpha** — `v0.1.0-alpha` is published as a prerelease. Core
 RTL and ISA are stable; verification and KV260 bring-up are in
 progress. This is not a timing-closed bitstream release. Feedback and
 issues are welcome.

--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -1,16 +1,14 @@
-# pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — release draft
+# pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — release notes
 
-> **Draft only — do not publish.** No tag is created, no GitHub release
-> is published. This file is a planning document for human review and
-> will be turned into the actual release notes when the v0.1.0-alpha
-> tag is eventually pushed in a separately approved cycle.
+> **Published prerelease.** Tag `v0.1.0-alpha` is pushed and the GitHub
+> Release is live as a prerelease (not marked latest). This page mirrors
+> the release body and is kept here as the in-tree reference.
 
-- **Target repo**: `pccxai/pccx-FPGA-NPU-LLM-kv260`
-- **Target base SHA**: `5195ace` (current `main` HEAD as of 2026-05-01,
-  immediately after the citation-metadata cleanup merge)
-- **Title (proposed)**: `pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — KV260 RTL preview snapshot`
-- **Tag (proposed, NOT created)**: `v0.1.0-alpha`
+- **Repo**: `pccxai/pccx-FPGA-NPU-LLM-kv260`
+- **Tag**: `v0.1.0-alpha`
+- **Title**: `pccx-FPGA-NPU-LLM-kv260 v0.1.0-alpha — KV260 RTL preview snapshot`
 - **Pre-release**: yes
+- **Release link**: <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/releases/tag/v0.1.0-alpha>
 
 ## Highlights
 
@@ -67,7 +65,6 @@ omitted until registered.
 
 ## Not included in this release
 
-- Tag push or GitHub Release publication.
 - KV260 board bring-up bitstream.
 - Timing-closed synthesis reports.
 - Full Sail ISA execute coverage (4th increment onward).


### PR DESCRIPTION
## Summary

- v0.1.0-alpha is now published as a prerelease, so the README,
  CHANGELOG, and in-tree release notes should describe it as such.
- Drops "draft" / "do not publish" / "tag not yet created" wording.
- Adds the actual published prerelease URL to the release notes.
- Removes the `tag push or GitHub Release publication` bullet from
  the "Not included in this release" list.

## Test plan

- [ ] `Sail typecheck` and `repo-validate` required checks pass.
- [ ] No new vendor / brand tokens introduced.