### PR TITLE
docs: clarify FPGA alpha software scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ issues are welcome.
 | Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://pccxai.github.io/pccx/en/docs/v002/Models/index.html)        |
 | RTL (SystemVerilog)                  | this repo — `hw/rtl/`                      | —                                                                                         |
 | Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://pccxai.github.io/pccx/en/docs/v002/Drivers/api.html)  |
-| Application                          | this repo — `sw/gemma3NE4B/`               | —                                                                                         |
+| Application (planned, v0.2.0)        | this repo — `sw/gemma3NE4B/` (not yet in tree) | —                                                                                     |
 
 If you want to **read about how the accelerator works**, head to the
 **[pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)** —
@@ -281,7 +281,7 @@ Full phase-by-phase plan, decision points, compute budget, and Year 2
 | Python golden model                              | Verified       |
 | pccx v002 re-parameterization (1 DSP = 2 MAC)    | **In progress** |
 | uXC driver (AXI-Lite HAL)                        | Skeleton       |
-| Gemma 3N E4B application (submodule)             | Skeleton       |
+| Gemma 3N E4B application (`sw/gemma3NE4B/`)      | Planned (v0.2.0) — not yet in tree |
 | Simulation / trace-driven verification           | Not started    |
 | Vivado synthesis + timing closure                | Not started    |
 
@@ -309,7 +309,7 @@ hw/
     Library/                  ← BF16 math pkg, algorithms pkg, QUEUE
 sw/
   driver/                     ← AXI-Lite MMIO HAL + inference API (skeleton)
-  gemma3NE4B/                 ← Gemma 3N E4B application (submodule)
+  gemma3NE4B/                 ← Gemma 3N E4B application — planned for v0.2.0, not yet in tree
 docs/                         ← Redirect stub only — full docs live on pccx
 ```
 

--- a/sw/driver/uCA_v1_api.h
+++ b/sw/driver/uCA_v1_api.h
@@ -1,9 +1,9 @@
 // ===| uCA API (High-Level Driver Interface) |====================================
 // uCA: micro Compute Architecture — AI model acceleration API for FPGA NPU.
 //
-// This is the "CUDA equivalent" for the uCA NPU. Application code
-// (sw/gemma3NE4B/ and future projects) should call only functions from
-// this layer — never touch the HAL directly.
+// This is the "CUDA equivalent" for the uCA NPU. Future application
+// code in sw/ should call only functions from this layer — never
+// touch the HAL directly.
 //
 // This layer builds 64-bit VLIW instructions per the pccx v002 ISA and
 // issues them via the HAL. The NPU frontend is fully decoupled: each


### PR DESCRIPTION
## Summary

Docs-only hotfix surfaced by the `pccxai/pccx#27` runnable smoke audit
(closes #55). The public `v0.1.0-alpha` README presents
`sw/gemma3NE4B/` as if it already lived in the working tree; only
`sw/driver/` is actually present.

This PR keeps the audit's principle — public alpha should honestly
reflect what exists in-tree — by relabeling the entry as planned for
v0.2.0 and softening the `uCA_v1_api.h` comment that referenced the
same directory.

## Changes

- `README.md`
  - "What's here vs. what's in pccx" table — application row marked
    `(planned, v0.2.0)` with `(not yet in tree)` next to the path.
  - "Implementation Status" table — Gemma 3N E4B application row
    changed from `Skeleton` → `Planned (v0.2.0) — not yet in tree`,
    and the parenthetical "(submodule)" replaced with the actual path.
  - "Repository Layout" tree — `gemma3NE4B/` annotated as planned
    rather than presented as if it existed.
- `sw/driver/uCA_v1_api.h`
  - Comment no longer names `sw/gemma3NE4B/`. It now points to "future
    application code in sw/", which matches the actual tree.

## Out of scope

- No RTL change.
- No driver code change.
- No release / tag / changelog update — this is a docs hotfix only;
  no `v0.1.1-alpha` is being cut.
- Actually landing `sw/gemma3NE4B/` is tracked under EPIC #43 and the
  v0.2.0 ecosystem milestone.

## Validation

- `repo-validate` (forbidden basename, stale-URL, `.gitmodules`,
  YAML) — required check, expected PASS.
- Sail typecheck — required check, expected PASS (no `formal/sail/`
  change).

## Refs

- Audit: pccxai/pccx#27
- Issue: #55