### PR TITLE
chore(rtl): add shape_const_ram parameterised RAM

### DIFF
--- a/hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv
+++ b/hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv
@@ -1,0 +1,80 @@
+`timescale 1ns / 1ps
+
+// ===| Module: shape_const_ram — parameterised shape constant RAM |=============
+// Purpose      : Single source for the (X, Y, Z) tensor-shape constant RAM
+//                used by fmap and weight MEMSET descriptors. Replaces the
+//                byte-for-byte duplicate pair `fmap_array_shape` +
+//                `weight_array_shape` (Stage E analysis §6.3.1, Stage C
+//                decisions memo item 5).
+//
+//                **AUTHORED-BUT-UNWIRED** in this batch:
+//                this file is intentionally NOT in `hw/vivado/filelist.f`
+//                and `mem_dispatcher.sv` still instantiates the two
+//                concrete modules. It is staged here so a future commit
+//                can migrate `mem_dispatcher` to instantiate this
+//                parameterised form and delete the two duplicates with a
+//                single, focused review.
+//
+// Spec ref     : pccx v002 §3.3 (MEMSET), §5.4 (shape pointer routing).
+// Clock        : clk @ 400 MHz.
+// Reset        : rst_n active-low (synchronous clear of all entries).
+// Geometry     : Depth × shape_xyz_t. With Depth = 64 the 51-bit storage
+//                exactly matches the existing fmap_array_shape /
+//                weight_array_shape footprint.
+// Latency      : Write — 1 cycle. Read — 0 cycles (combinational).
+// Throughput   : 1 write + 1 read per cycle.
+// Reset state  : All entries cleared to 0.
+// Notes        : Uses isa_pkg::shape_dim_t / shape_xyz_t typedefs (added
+//                to isa_pkg in the prior commit). Port widths are
+//                identical to the existing modules' 3 × 17-bit fan-out so
+//                a parent migration is a one-line swap and a port name
+//                change.
+// Migration path:
+//   1. Land this file in filelist.f (after isa_pkg) without removing
+//      fmap_array_shape / weight_array_shape — confirms it lints clean.
+//   2. In `mem_dispatcher.sv`, swap each instance of
+//        fmap_array_shape   u_fmap_shape   (...);
+//        weight_array_shape u_weight_shape (...);
+//      for the parameterised form and rerun
+//      `bash hw/sim/run_verification.sh`.
+//   3. Once the two callers migrate, delete
+//      fmap_array_shape.sv / weight_array_shape.sv and remove the two
+//      filelist lines. `dead_module_inventory.md` updates reflect the
+//      removal.
+// ===============================================================================
+
+module shape_const_ram
+  import isa_pkg::*;
+#(
+    parameter int Depth = 64
+) (
+    input logic clk,
+    input logic rst_n,
+
+    // ===| write |===
+    input logic                       wr_en,
+    input logic [$clog2(Depth)-1:0]   wr_addr,
+    input shape_xyz_t                 wr_xyz,    // packed { Z, Y, X }
+
+    // ===| read |===
+    input  ptr_addr_t                  rd_addr,  // 6-bit pointer (matches Depth=64)
+    output shape_xyz_t                 rd_xyz    // packed { Z, Y, X }
+);
+
+  // 64 × 51-bit (3 × shape_dim_t) flop array. Vivado infers FFs because
+  // the read path is combinational; consumers therefore see 0-cycle reads.
+  shape_xyz_t mem [0:Depth-1];
+
+  // ===| write (sync to clk) |===================================================
+  always_ff @(posedge clk) begin
+    if (!rst_n) begin
+      for (int i = 0; i < Depth; i++) mem[i] <= '0;
+    end else if (wr_en) begin
+      mem[wr_addr] <= wr_xyz;
+    end
+  end
+
+  // ===| read (comb logic - latency 0) |=========================================
+  assign rd_xyz = mem[rd_addr];
+
+endmodule

--- a/hw/vivado/filelist.f
+++ b/hw/vivado/filelist.f
@@ -34,6 +34,7 @@ rtl/Library/Algorithms/QUEUE/IF_queue.sv
 
 # ===| ISA package (depends on types) |========================================
 rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv
+rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv
 
 # ===| MAT_CORE |==============================================================
 rtl/MAT_CORE/GEMM_dsp_packer.sv


### PR DESCRIPTION
## Summary
Adds `shape_const_ram.sv` as a standalone parameterised shape RAM module and wires it into `hw/vivado/filelist.f` immediately after `isa_pkg.sv`.

This is GLOBAL_CONST Phase 3 Step 1 only. No callers are migrated in this PR.

## What changed
- Added `hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv`
- Added one filelist entry after `isa_pkg.sv`

## What did not change
- `mem_dispatcher` still instantiates `fmap_array_shape` and `weight_array_shape`
- `fmap_array_shape.sv` and `weight_array_shape.sv` are not deleted
- No behavior change
- No timing/KV260/stable release claim
- No W4A8/BF16-INT8 files included
- No protected preprocess file included

## Validation
- `xvlog`: 0 error / 0 warning
- `bash hw/sim/run_verification.sh`: 7/7 PASS

## Deferred
- Step 2: migrate `mem_dispatcher` to instantiate `shape_const_ram`
- Step 3: delete duplicate shape RAM modules after migration is validated

## Reviewer notes
This PR intentionally lands the reusable RAM module before migration. It validates the package/type dependency path introduced in PR #59 without changing behavior.