### PR TITLE
refactor(rtl): migrate mem_dispatcher to shape_const_ram

### DIFF
--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -78,6 +78,8 @@ module mem_dispatcher #() (
   logic [16:0] fmap_arr_shape_X;
   logic [16:0] fmap_arr_shape_Y;
   logic [16:0] fmap_arr_shape_Z;
+  shape_xyz_t  fmap_shape_wr_xyz;
+  shape_xyz_t  fmap_shape_rd_xyz;
   logic [16:0] fmap_read_arr_shape_X;
   logic [16:0] fmap_read_arr_shape_Y;
   logic [16:0] fmap_read_arr_shape_Z;
@@ -88,6 +90,8 @@ module mem_dispatcher #() (
   logic [16:0] weight_arr_shape_X;
   logic [16:0] weight_arr_shape_Y;
   logic [16:0] weight_arr_shape_Z;
+  shape_xyz_t  weight_shape_wr_xyz;
+  shape_xyz_t  weight_shape_rd_xyz;
   logic [16:0] weight_read_arr_shape_X;
   logic [16:0] weight_read_arr_shape_Y;
   logic [16:0] weight_read_arr_shape_Z;
@@ -123,32 +127,38 @@ module mem_dispatcher #() (
     end
   end
 
-  fmap_array_shape u_fmap_shape (
+  assign fmap_shape_wr_xyz.x = fmap_arr_shape_X;
+  assign fmap_shape_wr_xyz.y = fmap_arr_shape_Y;
+  assign fmap_shape_wr_xyz.z = fmap_arr_shape_Z;
+  assign fmap_read_arr_shape_X = fmap_shape_rd_xyz.x;
+  assign fmap_read_arr_shape_Y = fmap_shape_rd_xyz.y;
+  assign fmap_read_arr_shape_Z = fmap_shape_rd_xyz.z;
+
+  shape_const_ram u_fmap_shape (
       .clk   (clk_core),
       .rst_n (rst_n_core),
       .wr_en (fmap_write_enable),
       .wr_addr(fmap_shape_read_address),
-      .wr_val0(fmap_arr_shape_X),
-      .wr_val1(fmap_arr_shape_Y),
-      .wr_val2(fmap_arr_shape_Z),
+      .wr_xyz(fmap_shape_wr_xyz),
       .rd_addr(fmap_shape_read_address),
-      .rd_val0(fmap_read_arr_shape_X),
-      .rd_val1(fmap_read_arr_shape_Y),
-      .rd_val2(fmap_read_arr_shape_Z)
+      .rd_xyz(fmap_shape_rd_xyz)
   );
 
-  weight_array_shape u_weight_shape (
+  assign weight_shape_wr_xyz.x = weight_arr_shape_X;
+  assign weight_shape_wr_xyz.y = weight_arr_shape_Y;
+  assign weight_shape_wr_xyz.z = weight_arr_shape_Z;
+  assign weight_read_arr_shape_X = weight_shape_rd_xyz.x;
+  assign weight_read_arr_shape_Y = weight_shape_rd_xyz.y;
+  assign weight_read_arr_shape_Z = weight_shape_rd_xyz.z;
+
+  shape_const_ram u_weight_shape (
       .clk   (clk_core),
       .rst_n (rst_n_core),
       .wr_en (weight_write_enable),
       .wr_addr(weight_shape_read_address),
-      .wr_val0(weight_arr_shape_X),
-      .wr_val1(weight_arr_shape_Y),
-      .wr_val2(weight_arr_shape_Z),
+      .wr_xyz(weight_shape_wr_xyz),
       .rd_addr(weight_shape_read_address),
-      .rd_val0(weight_read_arr_shape_X),
-      .rd_val1(weight_read_arr_shape_Y),
-      .rd_val2(weight_read_arr_shape_Z)
+      .rd_xyz(weight_shape_rd_xyz)
   );
 
   // ===| Shape totals (word counts for DMA) |====================================


### PR DESCRIPTION
## Summary
Migrate `mem_dispatcher` to use the parameterised `shape_const_ram` introduced in PR #60.

## What changed
- Replaced duplicate shape RAM instantiation at the dispatcher boundary with `shape_const_ram`
- Kept external dispatcher interface unchanged
- Kept duplicate modules in the tree for a later deletion step

## What did not change
- No top-level interface change
- No W4A8/preprocess changes
- No deletion of `fmap_array_shape.sv` or `weight_array_shape.sv`
- No timing/KV260/stable release claim

## Validation
- `git diff --check`: clean
- `bash hw/sim/run_verification.sh`: PASS
- `xvlog`: 0 error / 0 warning

## Deferred
- Step 3: remove duplicate shape RAM modules after this migration PR is reviewed and merged
- W4A8/BF16-INT8 work remains separate and gated by golden-vector testing

## Reviewer notes
This PR is the behavior-preserving caller migration step after PR #60. The old duplicate modules are intentionally left in place to keep deletion separately reviewable.