### PR TITLE
Add KV260 roadmap status card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # pccx — Bare-Metal Transformer Accelerator on Kria KV260
 
+Open SystemVerilog NPU for Gemma-class LLM inference on AMD/Xilinx
+Kria KV260.
+
+<p align="center">
+  <img src="docs/assets/pccx-kv260-roadmap.svg" alt="PCCX KV260 Roadmap status card" width="920">
+</p>
+
+<p align="center">
+  <strong>Current status:</strong> RTL alpha. Verification and bring-up are active; timing-closed bitstream and full runtime integration are in progress.
+</p>
+
 ![Architecture](https://img.shields.io/badge/Architecture-pccx_v002-purple)
 ![RTL](https://img.shields.io/badge/RTL-SystemVerilog-green)
 ![Target](https://img.shields.io/badge/Target-Kria_KV260-orange)
@@ -7,11 +18,11 @@
 ![Clock](https://img.shields.io/badge/Core-400_MHz-blue)
 ![Goal](https://img.shields.io/badge/Gemma_3N_E4B-20_tok%2Fs-yellow)
 
-This repo is the **bare-metal Kria KV260 implementation** (RTL + driver +
-application) of the **pccx v002** NPU architecture. It hosts an early
-SystemVerilog RTL and bare-metal driver source snapshot intended to
-close the loop between the pccx architecture specification, source-level
-RTL inspection, early verification setup, and planned KV260 bring-up.
+This repo is the **bare-metal Kria KV260 implementation** of the
+**pccx v002** NPU architecture. It hosts an early SystemVerilog RTL and
+bare-metal driver source snapshot intended to close the loop between the
+pccx architecture specification, source-level RTL inspection, early
+verification setup, and planned KV260 bring-up.
 
 This is not a timing-closed production bitstream release — Vivado
 synthesis, trace-driven verification, and full Gemma 3N E4B application
@@ -376,4 +387,3 @@ for the end-to-end flow diagram and the Tauri IPC surface.
 
 Apache 2.0 — same as pccx. This protects the architecture from patent
 risk while keeping the ecosystem open for hardware research.
-

--- a/docs/assets/pccx-kv260-roadmap.svg
+++ b/docs/assets/pccx-kv260-roadmap.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" role="img" aria-labelledby="title desc">
+  <title id="title">PCCX KV260 Roadmap</title>
+  <desc id="desc">Roadmap status card for the PCCX KV260 open SystemVerilog NPU project, showing staged progress toward the v0.2.0 evidence pack.</desc>
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="960" y2="560" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.58" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <linearGradient id="edge" x1="20" y1="20" x2="940" y2="540" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#67e8f9" stop-opacity="0.5"/>
+      <stop offset="0.45" stop-color="#64748b" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#a78bfa" stop-opacity="0.42"/>
+    </linearGradient>
+    <linearGradient id="chip" x1="718" y1="50" x2="892" y2="142" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1e293b"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+    <linearGradient id="green" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#10b981"/>
+      <stop offset="1" stop-color="#6ee7b7"/>
+    </linearGradient>
+    <linearGradient id="blue" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0284c7"/>
+      <stop offset="1" stop-color="#67e8f9"/>
+    </linearGradient>
+    <linearGradient id="amber" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d97706"/>
+      <stop offset="1" stop-color="#fbbf24"/>
+    </linearGradient>
+    <linearGradient id="orange" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ea580c"/>
+      <stop offset="1" stop-color="#fb923c"/>
+    </linearGradient>
+    <linearGradient id="violet" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#64748b"/>
+      <stop offset="1" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="28" y="32" width="904" height="512" rx="30" fill="#020617" opacity="0.24"/>
+  <rect x="20" y="20" width="920" height="520" rx="30" fill="url(#panel)" stroke="url(#edge)" stroke-width="2"/>
+  <path d="M52 478H908" stroke="#334155" stroke-width="1" opacity="0.45"/>
+  <path d="M52 156H908" stroke="#334155" stroke-width="1" opacity="0.35"/>
+
+  <g opacity="0.45">
+    <path d="M64 188H896M64 240H896M64 292H896M64 344H896M64 396H896" stroke="#1e293b" stroke-width="1"/>
+    <path d="M240 176V432M520 176V432M800 176V432" stroke="#1e293b" stroke-width="1"/>
+  </g>
+
+  <text x="64" y="72" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" letter-spacing="1.6">PCCX / KRIA KV260</text>
+  <text x="64" y="116" fill="#f8fafc" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700">PCCX KV260 Roadmap</text>
+  <text x="64" y="147" fill="#cbd5e1" font-family="Arial, Helvetica, sans-serif" font-size="17">Open SystemVerilog NPU for Gemma-class LLM inference on Kria KV260</text>
+
+  <g transform="translate(718 50)">
+    <rect x="0" y="0" width="174" height="92" rx="18" fill="url(#chip)" stroke="#334155"/>
+    <rect x="22" y="22" width="58" height="48" rx="10" fill="#0f172a" stroke="#475569"/>
+    <path d="M34 37H68M34 52H58" stroke="#67e8f9" stroke-width="3" stroke-linecap="round"/>
+    <path d="M18 30H4M18 46H4M18 62H4M80 30H94M80 46H94M80 62H94" stroke="#475569" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="122" cy="32" r="5" fill="#34d399"/>
+    <circle cx="142" cy="32" r="5" fill="#38bdf8"/>
+    <text x="104" y="60" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">RTL alpha</text>
+    <text x="104" y="77" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11">bring-up active</text>
+  </g>
+
+  <g font-family="Arial, Helvetica, sans-serif" font-size="16">
+    <text x="64" y="212" fill="#e2e8f0" font-weight="700">RTL Alpha</text>
+    <rect x="240" y="199" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="240" y="199" width="476" height="14" rx="7" fill="url(#green)"/>
+    <text x="836" y="212" fill="#d1fae5" font-weight="700" text-anchor="end">85%</text>
+
+    <text x="64" y="264" fill="#e2e8f0" font-weight="700">Verification</text>
+    <rect x="240" y="251" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="240" y="251" width="392" height="14" rx="7" fill="url(#blue)"/>
+    <text x="836" y="264" fill="#cffafe" font-weight="700" text-anchor="end">70%</text>
+
+    <text x="64" y="316" fill="#e2e8f0" font-weight="700">Driver Bring-up</text>
+    <rect x="240" y="303" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="240" y="303" width="252" height="14" rx="7" fill="url(#amber)"/>
+    <text x="836" y="316" fill="#fef3c7" font-weight="700" text-anchor="end">45%</text>
+
+    <text x="64" y="368" fill="#e2e8f0" font-weight="700">Bitstream</text>
+    <rect x="240" y="355" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="240" y="355" width="140" height="14" rx="7" fill="url(#orange)"/>
+    <text x="836" y="368" fill="#ffedd5" font-weight="700" text-anchor="end">25%</text>
+
+    <text x="64" y="420" fill="#e2e8f0" font-weight="700">Public Release</text>
+    <rect x="240" y="407" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <rect x="240" y="407" width="84" height="14" rx="7" fill="url(#violet)"/>
+    <text x="836" y="420" fill="#ede9fe" font-weight="700" text-anchor="end">15%</text>
+  </g>
+
+  <g font-family="Arial, Helvetica, sans-serif">
+    <rect x="64" y="452" width="832" height="50" rx="16" fill="#0b1220" stroke="#334155"/>
+    <text x="88" y="484" fill="#94a3b8" font-size="15" font-weight="700">Next milestone:</text>
+    <text x="216" y="484" fill="#f8fafc" font-size="18" font-weight="700">v0.2.0 evidence pack</text>
+    <rect x="700" y="466" width="166" height="22" rx="11" fill="#1e293b" stroke="#475569"/>
+    <text x="783" y="482" fill="#cbd5e1" font-size="12" font-weight="700" text-anchor="middle">release evidence</text>
+    <text x="64" y="526" fill="#94a3b8" font-size="14">Status: RTL alpha &#183; timing closure and full runtime bring-up in progress</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
Adds a custom SVG roadmap/status card near the top of the README.

The card shows the current KV260 v0.2.0 bring-up track as a staged roadmap, with the next milestone listed as the v0.2.0 evidence pack.

## What changed
- Added `docs/assets/pccx-kv260-roadmap.svg`
- Added the SVG card near the top of `README.md`

## Validation
- `git diff --check`
- `grep -R "mermaid" README.md docs || true`
- SVG XML parse with Python

## Notes
This is a visual README polish change only.
It does not claim timing closure, bitstream completion, KV260 inference success, or 20 tok/s.
No RTL or FPGA implementation files were changed.