### PR TITLE
Fix KV260 wrapper elaboration gaps

### DIFF
--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -73,8 +73,13 @@ module mem_dispatcher #() (
   assign OUT_cvo_busy  = cvo_bridge_busy;
 
   // ===| Shape Constant RAM — FMap |=============================================
+  // Split write- and read-side pointers so the MEMSET handler (write side)
+  // and the LOAD-uop handler (read side) drive independent flops; sharing a
+  // single signal across two always_ff blocks tripped xelab's
+  // multi-driver check.
   logic        fmap_write_enable;
-  logic [ 5:0] fmap_shape_read_address;
+  logic [ 5:0] fmap_shape_wr_addr;
+  logic [ 5:0] fmap_shape_rd_addr;
   logic [16:0] fmap_arr_shape_X;
   logic [16:0] fmap_arr_shape_Y;
   logic [16:0] fmap_arr_shape_Z;
@@ -103,11 +108,11 @@ module mem_dispatcher #() (
 
       case (IN_mem_set_uop.dest_cache)
         data_to_fmap_shape: begin
-          fmap_shape_read_address <= IN_mem_set_uop.dest_addr;
-          fmap_arr_shape_X        <= IN_mem_set_uop.a_value;
-          fmap_arr_shape_Y        <= IN_mem_set_uop.b_value;
-          fmap_arr_shape_Z        <= IN_mem_set_uop.c_value;
-          fmap_write_enable       <= 1'b1;
+          fmap_shape_wr_addr <= IN_mem_set_uop.dest_addr;
+          fmap_arr_shape_X   <= IN_mem_set_uop.a_value;
+          fmap_arr_shape_Y   <= IN_mem_set_uop.b_value;
+          fmap_arr_shape_Z   <= IN_mem_set_uop.c_value;
+          fmap_write_enable  <= 1'b1;
         end
 
         data_to_weight_shape: begin
@@ -127,11 +132,11 @@ module mem_dispatcher #() (
       .clk   (clk_core),
       .rst_n (rst_n_core),
       .wr_en (fmap_write_enable),
-      .wr_addr(fmap_shape_read_address),
+      .wr_addr(fmap_shape_wr_addr),
       .wr_val0(fmap_arr_shape_X),
       .wr_val1(fmap_arr_shape_Y),
       .wr_val2(fmap_arr_shape_Z),
-      .rd_addr(fmap_shape_read_address),
+      .rd_addr(fmap_shape_rd_addr),
       .rd_val0(fmap_read_arr_shape_X),
       .rd_val1(fmap_read_arr_shape_Y),
       .rd_val2(fmap_read_arr_shape_Z)
@@ -190,7 +195,7 @@ module mem_dispatcher #() (
           };
           acp_rx_start <= 1'b1;
           IN_acp_rdy   <= 1'b1;
-          fmap_shape_read_address <= IN_LOAD_uop.shape_ptr_addr;
+          fmap_shape_rd_addr <= IN_LOAD_uop.shape_ptr_addr;
         end
 
         // L2 → host DDR4 (result DMA out)
@@ -202,7 +207,7 @@ module mem_dispatcher #() (
           };
           acp_rx_start <= 1'b1;
           IN_acp_rdy   <= 1'b1;
-          fmap_shape_read_address <= IN_LOAD_uop.shape_ptr_addr;
+          fmap_shape_rd_addr <= IN_LOAD_uop.shape_ptr_addr;
         end
 
         // L2 → GEMM fmap broadcast
@@ -214,7 +219,7 @@ module mem_dispatcher #() (
           };
           npu_rx_start <= 1'b1;
           IN_npu_rdy   <= 1'b1;
-          fmap_shape_read_address <= IN_LOAD_uop.shape_ptr_addr;
+          fmap_shape_rd_addr <= IN_LOAD_uop.shape_ptr_addr;
         end
 
         // L2 → GEMV fmap broadcast
@@ -226,7 +231,7 @@ module mem_dispatcher #() (
           };
           npu_rx_start <= 1'b1;
           IN_npu_rdy   <= 1'b1;
-          fmap_shape_read_address <= IN_LOAD_uop.shape_ptr_addr;
+          fmap_shape_rd_addr <= IN_LOAD_uop.shape_ptr_addr;
         end
 
         // L2 → CVO input (handled by mem_CVO_stream_bridge below)

--- a/hw/rtl/NPU_Controller/NPU_frontend/ctrl_npu_frontend.sv
+++ b/hw/rtl/NPU_Controller/NPU_frontend/ctrl_npu_frontend.sv
@@ -37,8 +37,8 @@ module ctrl_npu_frontend (
     output logic                  OUT_kick,
 
     // Status <- Encoder / FSM
-    input logic [`ISA_WIDTH:0] IN_enc_stat,
-    input logic                IN_enc_valid, // FIXED: Added missing comma
+    input logic [`ISA_WIDTH-1:0] IN_enc_stat,
+    input logic                  IN_enc_valid,
 
     input logic IN_fetch_ready  // FIXED: Removed illegal semicolon
 );
@@ -68,9 +68,11 @@ module ctrl_npu_frontend (
 
       // AXI4-Lite Write channels directly routed from the interface
       .s_awaddr (S_AXIL_CTRL.awaddr),
+      .s_awprot (S_AXIL_CTRL.awprot),
       .s_awvalid(S_AXIL_CTRL.awvalid),
       .s_awready(S_AXIL_CTRL.awready),
       .s_wdata  (S_AXIL_CTRL.wdata),
+      .s_wstrb  (S_AXIL_CTRL.wstrb),
       .s_wvalid (S_AXIL_CTRL.wvalid),
       .s_wready (S_AXIL_CTRL.wready),
       .s_bresp  (S_AXIL_CTRL.bresp),

--- a/hw/rtl/PREPROCESS/preprocess_fmap.sv
+++ b/hw/rtl/PREPROCESS/preprocess_fmap.sv
@@ -70,6 +70,9 @@ module preprocess_fmap #(
   logic         fmap_fifo_ready;
 
 
+  // Pad the 128-bit ACP beat into the 256-bit FIFO word. The downstream
+  // shifter pipeline still expects 256 bits — the upper half stays zero
+  // until the two-beat merge harness above is wired up in a future phase.
   xpm_fifo_axis #(
       .FIFO_DEPTH(`DEVICE_XPM_FIFO_DEPTH),
       .TDATA_WIDTH(256),
@@ -79,7 +82,7 @@ module preprocess_fmap #(
       .s_aclk(clk),
       .m_aclk(clk),
       .s_aresetn(rst_n),
-      .s_axis_tdata(S_AXIS_ACP_FMAP.tdata),
+      .s_axis_tdata({128'd0, S_AXIS_ACP_FMAP.tdata}),
       .s_axis_tvalid(S_AXIS_ACP_FMAP.tvalid),
       .s_axis_tready(S_AXIS_ACP_FMAP.tready),
       .m_axis_tdata(fmap_fifo_data),

--- a/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
+++ b/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
@@ -33,7 +33,16 @@ module GEMV_generate_lut
     // e_max (from Cache for Normalization alignment) — only the 8-bit BF16
     // exponent field is carried here; matches GEMV_top's port width.
     input logic [dtype_pkg::Bf16ExpWidth-1:0] IN_cached_emax_out[0:param.fmap_cache_out_cnt-1],
-    output logic signed [param.fixed_mant_width+2:0] OUT_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:param.weight_width-1],
+    // LUT depth = 2^weight_width (one entry per signed INT4 value, -8..+7).
+    output logic signed [param.fixed_mant_width+2:0] OUT_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1],
+    // OUT_fmap_ready feeds GEMV_accumulate.init, which the reduction_branch
+    // header documents as a one-cycle pulse opening a new GEMV batch. This
+    // module is pure-combinational with no clk/rst_n, so it cannot produce
+    // such a pulse on its own; fmap_cache.rd_valid is also a level held
+    // high across the 2048-cycle broadcast burst. Driving this port from
+    // the level-valid signal would gate the accumulator off for the whole
+    // burst. Left undriven until a clocked edge-detector lands at the
+    // consumer side.
     output logic OUT_fmap_ready
 );
   genvar idx, w;
@@ -42,7 +51,7 @@ module GEMV_generate_lut
       wire signed [29:0] F;
       assign F = {{3{IN_fmap_broadcast[idx][26]}}, IN_fmap_broadcast[idx]};
 
-      for (w = 0; w < 16; w++) begin : lut_entry
+      for (w = 0; w < (1<<param.weight_width); w++) begin : lut_entry
         // w - 8 = INT4 range (-8 ~ 7)
         assign OUT_fmap_LUT[idx][w] = F * $signed(5'(w) - 5'd8);
       end

--- a/hw/rtl/VEC_CORE/GEMV_reduction.sv
+++ b/hw/rtl/VEC_CORE/GEMV_reduction.sv
@@ -32,7 +32,7 @@ module GEMV_reduction
     input logic rst_n,
     input logic IN_is_lane_active,
     input logic IN_valid,
-    input logic signed [param.fixed_mant_width+2:0] IN_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:param.weight_width-1],
+    input logic signed [param.fixed_mant_width+2:0] IN_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1],
     input logic [param.weight_width - 1:0] IN_weight[0:param.weight_cnt -1],
 
     output logic [param.fixed_mant_width+2:0] OUT_reduction_result,

--- a/hw/rtl/VEC_CORE/GEMV_reduction_branch.sv
+++ b/hw/rtl/VEC_CORE/GEMV_reduction_branch.sv
@@ -38,7 +38,7 @@ module GEMV_reduction_branch
     input logic [16:0] IN_num_recur,
 
     input logic IN_activated_lane,
-    input logic signed [param.fixed_mant_width+2:0] IN_fmap_LUT [0:param.fmap_cache_out_cnt-1][0:param.weight_width-1],
+    input logic signed [param.fixed_mant_width+2:0] IN_fmap_LUT [0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1],
 
     output logic [param.fixed_mant_width+2:0] OUT_GEMV_result_vector[0:param.gemv_batch-1],
     output logic OUT_valid

--- a/hw/rtl/VEC_CORE/GEMV_top.sv
+++ b/hw/rtl/VEC_CORE/GEMV_top.sv
@@ -80,7 +80,7 @@ module GEMV_top
     output logic OUT_result_valid_D
 );
 
-  logic signed [param.fixed_mant_width+2:0] fmap_LUT_wire[0:param.fmap_cache_out_cnt-1][0:param.weight_width-1];
+  logic signed [param.fixed_mant_width+2:0] fmap_LUT_wire[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1];
 
   logic fmap_ready_wire;
 


### PR DESCRIPTION
## Summary
Fixes wrapper-level elaboration gaps surfaced by the KV260 NPU wrapper path.

## What changed
- Split the `mem_dispatcher` fmap shape read/write address drivers to remove a multi-driver issue
- Aligned GEMV LUT dimensions with the indexed address range
- Fixed frontend AXI-Lite/control width and protection wiring
- Padded the preprocess fmap AXIS-to-XPM FIFO data path to the expected width
- Documented the GEMV `fmap_ready` level-vs-pulse hazard without changing the runtime contract

## Validation
- `git diff --check`: clean
- `xvlog -sv -f hw/vivado/filelist.f`: clean
- `xelab xil_defaultlib.npu_core_wrapper xil_defaultlib.glbl ...`: snapshot built
- `bash hw/sim/run_verification.sh`: 7/7 PASS

## Notes
This PR does not add BD/DTBO/bitstream packaging.
This PR does not claim timing closure.
This PR does not claim KV260 inference success.
This PR does not claim 20 tok/s.

## Deferred
- GEMV-level testbench for `fmap_ready`/`init` pulse behavior
- BD/DTBO/bitstream packaging
- KV260 smoke run with real firmware/model inputs