### PR TITLE
Replace KV260 roadmap card with terminal-style status view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,8 @@ Kria KV260.
 </p>
 
 <p align="center">
-  <strong>Current status:</strong> RTL alpha. Verification and bring-up are active; timing-closed bitstream and full runtime integration are in progress.
+  <strong>Current status:</strong> RTL alpha · timing closure and full runtime bring-up in progress.
 </p>
-
-![Architecture](https://img.shields.io/badge/Architecture-pccx_v002-purple)
-![RTL](https://img.shields.io/badge/RTL-SystemVerilog-green)
-![Target](https://img.shields.io/badge/Target-Kria_KV260-orange)
-![Precision](https://img.shields.io/badge/Precision-W4A8_(1_DSP_%3D_2_MAC)-green)
-![Clock](https://img.shields.io/badge/Core-400_MHz-blue)
-![Goal](https://img.shields.io/badge/Gemma_3N_E4B-20_tok%2Fs-yellow)
 
 This repo is the **bare-metal Kria KV260 implementation** of the
 **pccx v002** NPU architecture. It hosts an early SystemVerilog RTL and

--- a/docs/assets/pccx-kv260-roadmap.svg
+++ b/docs/assets/pccx-kv260-roadmap.svg
@@ -1,101 +1,50 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="424" viewBox="0 0 920 424" role="img" aria-labelledby="title desc">
   <title id="title">PCCX KV260 Roadmap</title>
-  <desc id="desc">Roadmap status card for the PCCX KV260 open SystemVerilog NPU project, showing staged progress toward the v0.2.0 evidence pack.</desc>
-  <defs>
-    <linearGradient id="panel" x1="0" y1="0" x2="960" y2="560" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#111827"/>
-      <stop offset="0.58" stop-color="#0f172a"/>
-      <stop offset="1" stop-color="#020617"/>
-    </linearGradient>
-    <linearGradient id="edge" x1="20" y1="20" x2="940" y2="540" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#67e8f9" stop-opacity="0.5"/>
-      <stop offset="0.45" stop-color="#64748b" stop-opacity="0.26"/>
-      <stop offset="1" stop-color="#a78bfa" stop-opacity="0.42"/>
-    </linearGradient>
-    <linearGradient id="chip" x1="718" y1="50" x2="892" y2="142" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#1e293b"/>
-      <stop offset="1" stop-color="#0f172a"/>
-    </linearGradient>
-    <linearGradient id="green" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#10b981"/>
-      <stop offset="1" stop-color="#6ee7b7"/>
-    </linearGradient>
-    <linearGradient id="blue" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0284c7"/>
-      <stop offset="1" stop-color="#67e8f9"/>
-    </linearGradient>
-    <linearGradient id="amber" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#d97706"/>
-      <stop offset="1" stop-color="#fbbf24"/>
-    </linearGradient>
-    <linearGradient id="orange" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#ea580c"/>
-      <stop offset="1" stop-color="#fb923c"/>
-    </linearGradient>
-    <linearGradient id="violet" x1="240" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#64748b"/>
-      <stop offset="1" stop-color="#a78bfa"/>
-    </linearGradient>
-  </defs>
+  <desc id="desc">Terminal-style roadmap status for PCCX KV260 bring-up toward the v0.2.0 evidence pack.</desc>
 
-  <rect x="28" y="32" width="904" height="512" rx="30" fill="#020617" opacity="0.24"/>
-  <rect x="20" y="20" width="920" height="520" rx="30" fill="url(#panel)" stroke="url(#edge)" stroke-width="2"/>
-  <path d="M52 478H908" stroke="#334155" stroke-width="1" opacity="0.45"/>
-  <path d="M52 156H908" stroke="#334155" stroke-width="1" opacity="0.35"/>
+  <rect x="16" y="16" width="888" height="392" rx="16" fill="#0b0f14" stroke="#334155" stroke-width="1.5"/>
+  <rect x="16" y="16" width="888" height="40" rx="16" fill="#111827"/>
+  <path d="M16 56H904" stroke="#334155" stroke-width="1"/>
+  <circle cx="42" cy="36" r="5" fill="#334155"/>
+  <circle cx="62" cy="36" r="5" fill="#334155"/>
+  <circle cx="82" cy="36" r="5" fill="#334155"/>
 
-  <g opacity="0.45">
-    <path d="M64 188H896M64 240H896M64 292H896M64 344H896M64 396H896" stroke="#1e293b" stroke-width="1"/>
-    <path d="M240 176V432M520 176V432M800 176V432" stroke="#1e293b" stroke-width="1"/>
-  </g>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, Liberation Mono, monospace" font-size="18">
+    <text x="112" y="42" fill="#94a3b8">pccx-kv260/status</text>
 
-  <text x="64" y="72" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" letter-spacing="1.6">PCCX / KRIA KV260</text>
-  <text x="64" y="116" fill="#f8fafc" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700">PCCX KV260 Roadmap</text>
-  <text x="64" y="147" fill="#cbd5e1" font-family="Arial, Helvetica, sans-serif" font-size="17">Open SystemVerilog NPU for Gemma-class LLM inference on Kria KV260</text>
+    <text x="56" y="98" fill="#e5e7eb" font-size="24" font-weight="700">PCCX KV260 Roadmap</text>
+    <text x="56" y="128" fill="#94a3b8" font-size="15">$ roadmap --target kv260 --release v0.2.0</text>
+    <line x1="56" y1="150" x2="864" y2="150" stroke="#334155" stroke-width="1"/>
 
-  <g transform="translate(718 50)">
-    <rect x="0" y="0" width="174" height="92" rx="18" fill="url(#chip)" stroke="#334155"/>
-    <rect x="22" y="22" width="58" height="48" rx="10" fill="#0f172a" stroke="#475569"/>
-    <path d="M34 37H68M34 52H58" stroke="#67e8f9" stroke-width="3" stroke-linecap="round"/>
-    <path d="M18 30H4M18 46H4M18 62H4M80 30H94M80 46H94M80 62H94" stroke="#475569" stroke-width="3" stroke-linecap="round"/>
-    <circle cx="122" cy="32" r="5" fill="#34d399"/>
-    <circle cx="142" cy="32" r="5" fill="#38bdf8"/>
-    <text x="104" y="60" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700">RTL alpha</text>
-    <text x="104" y="77" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11">bring-up active</text>
-  </g>
+    <text x="56" y="184" fill="#cbd5e1">RTL Alpha</text>
+    <line x1="288" y1="178" x2="644" y2="178" stroke="#334155" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <line x1="288" y1="178" x2="590" y2="178" stroke="#e5e7eb" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <text x="752" y="184" fill="#e5e7eb">85%</text>
 
-  <g font-family="Arial, Helvetica, sans-serif" font-size="16">
-    <text x="64" y="212" fill="#e2e8f0" font-weight="700">RTL Alpha</text>
-    <rect x="240" y="199" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <rect x="240" y="199" width="476" height="14" rx="7" fill="url(#green)"/>
-    <text x="836" y="212" fill="#d1fae5" font-weight="700" text-anchor="end">85%</text>
+    <text x="56" y="220" fill="#cbd5e1">Verification</text>
+    <line x1="288" y1="214" x2="644" y2="214" stroke="#334155" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <line x1="288" y1="214" x2="536" y2="214" stroke="#e5e7eb" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <text x="752" y="220" fill="#e5e7eb">70%</text>
 
-    <text x="64" y="264" fill="#e2e8f0" font-weight="700">Verification</text>
-    <rect x="240" y="251" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <rect x="240" y="251" width="392" height="14" rx="7" fill="url(#blue)"/>
-    <text x="836" y="264" fill="#cffafe" font-weight="700" text-anchor="end">70%</text>
+    <text x="56" y="256" fill="#cbd5e1">Driver Bring-up</text>
+    <line x1="288" y1="250" x2="644" y2="250" stroke="#334155" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <line x1="288" y1="250" x2="446" y2="250" stroke="#e5e7eb" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <text x="752" y="256" fill="#e5e7eb">45%</text>
 
-    <text x="64" y="316" fill="#e2e8f0" font-weight="700">Driver Bring-up</text>
-    <rect x="240" y="303" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <rect x="240" y="303" width="252" height="14" rx="7" fill="url(#amber)"/>
-    <text x="836" y="316" fill="#fef3c7" font-weight="700" text-anchor="end">45%</text>
+    <text x="56" y="292" fill="#cbd5e1">Bitstream</text>
+    <line x1="288" y1="286" x2="644" y2="286" stroke="#334155" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <line x1="288" y1="286" x2="374" y2="286" stroke="#e5e7eb" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <text x="752" y="292" fill="#e5e7eb">25%</text>
 
-    <text x="64" y="368" fill="#e2e8f0" font-weight="700">Bitstream</text>
-    <rect x="240" y="355" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <rect x="240" y="355" width="140" height="14" rx="7" fill="url(#orange)"/>
-    <text x="836" y="368" fill="#ffedd5" font-weight="700" text-anchor="end">25%</text>
+    <text x="56" y="328" fill="#cbd5e1">Public Release</text>
+    <line x1="288" y1="322" x2="644" y2="322" stroke="#334155" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <line x1="288" y1="322" x2="338" y2="322" stroke="#e5e7eb" stroke-width="16" stroke-dasharray="14 4" stroke-linecap="butt"/>
+    <text x="752" y="328" fill="#e5e7eb">15%</text>
 
-    <text x="64" y="420" fill="#e2e8f0" font-weight="700">Public Release</text>
-    <rect x="240" y="407" width="560" height="14" rx="7" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <rect x="240" y="407" width="84" height="14" rx="7" fill="url(#violet)"/>
-    <text x="836" y="420" fill="#ede9fe" font-weight="700" text-anchor="end">15%</text>
-  </g>
-
-  <g font-family="Arial, Helvetica, sans-serif">
-    <rect x="64" y="452" width="832" height="50" rx="16" fill="#0b1220" stroke="#334155"/>
-    <text x="88" y="484" fill="#94a3b8" font-size="15" font-weight="700">Next milestone:</text>
-    <text x="216" y="484" fill="#f8fafc" font-size="18" font-weight="700">v0.2.0 evidence pack</text>
-    <rect x="700" y="466" width="166" height="22" rx="11" fill="#1e293b" stroke="#475569"/>
-    <text x="783" y="482" fill="#cbd5e1" font-size="12" font-weight="700" text-anchor="middle">release evidence</text>
-    <text x="64" y="526" fill="#94a3b8" font-size="14">Status: RTL alpha &#183; timing closure and full runtime bring-up in progress</text>
+    <line x1="56" y1="348" x2="864" y2="348" stroke="#334155" stroke-width="1"/>
+    <text x="56" y="368" fill="#94a3b8" font-size="15">next milestone:</text>
+    <text x="196" y="368" fill="#e5e7eb" font-size="15">v0.2.0 evidence pack</text>
+    <text x="56" y="388" fill="#94a3b8" font-size="15">status:</text>
+    <text x="126" y="388" fill="#cbd5e1" font-size="15">RTL alpha · timing closure and full runtime bring-up in progress</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
Replaces the README roadmap SVG with a minimal terminal-style status card.

## Why
The previous visual was too dashboard-like. This version keeps the first-screen roadmap but uses a quieter CLI/status-output style that better matches the engineering tone of the repository.

## What changed
- Replaced `docs/assets/pccx-kv260-roadmap.svg`
- Kept the README card placement near the top
- Kept the status wording evidence-gated

## Validation
- `git diff --check`
- `grep -R "mermaid" README.md docs || true`
- SVG XML parse with Python

## Notes
This is a README visual polish change only.
It does not claim timing closure, bitstream completion, KV260 inference success, or 20 tok/s.