### PR TITLE
test(hw): add shape_const_ram xsim smoke

### DIFF
--- a/hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv
+++ b/hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv
@@ -7,13 +7,9 @@
 //                `weight_array_shape` (Stage E analysis §6.3.1, Stage C
 //                decisions memo item 5).
 //
-//                **AUTHORED-BUT-UNWIRED** in this batch:
-//                this file is intentionally NOT in `hw/vivado/filelist.f`
-//                and `mem_dispatcher.sv` still instantiates the two
-//                concrete modules. It is staged here so a future commit
-//                can migrate `mem_dispatcher` to instantiate this
-//                parameterised form and delete the two duplicates with a
-//                single, focused review.
+//                Wired into `mem_dispatcher.sv` as the replacement for the
+//                legacy concrete shape RAM pair. The old modules can be
+//                removed after migration validation and review.
 //
 // Spec ref     : pccx v002 §3.3 (MEMSET), §5.4 (shape pointer routing).
 // Clock        : clk @ 400 MHz.
@@ -29,18 +25,10 @@
 //                identical to the existing modules' 3 × 17-bit fan-out so
 //                a parent migration is a one-line swap and a port name
 //                change.
-// Migration path:
-//   1. Land this file in filelist.f (after isa_pkg) without removing
-//      fmap_array_shape / weight_array_shape — confirms it lints clean.
-//   2. In `mem_dispatcher.sv`, swap each instance of
-//        fmap_array_shape   u_fmap_shape   (...);
-//        weight_array_shape u_weight_shape (...);
-//      for the parameterised form and rerun
-//      `bash hw/sim/run_verification.sh`.
-//   3. Once the two callers migrate, delete
-//      fmap_array_shape.sv / weight_array_shape.sv and remove the two
-//      filelist lines. `dead_module_inventory.md` updates reflect the
-//      removal.
+// Follow-up:
+//   Delete fmap_array_shape.sv / weight_array_shape.sv and remove their
+//   filelist entries once the dispatcher migration is reviewed with xsim
+//   evidence.
 // ===============================================================================
 
 module shape_const_ram

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -78,6 +78,8 @@ module mem_dispatcher #() (
   logic [16:0] fmap_arr_shape_X;
   logic [16:0] fmap_arr_shape_Y;
   logic [16:0] fmap_arr_shape_Z;
+  shape_xyz_t  fmap_shape_wr_xyz;
+  shape_xyz_t  fmap_shape_rd_xyz;
   logic [16:0] fmap_read_arr_shape_X;
   logic [16:0] fmap_read_arr_shape_Y;
   logic [16:0] fmap_read_arr_shape_Z;
@@ -88,6 +90,8 @@ module mem_dispatcher #() (
   logic [16:0] weight_arr_shape_X;
   logic [16:0] weight_arr_shape_Y;
   logic [16:0] weight_arr_shape_Z;
+  shape_xyz_t  weight_shape_wr_xyz;
+  shape_xyz_t  weight_shape_rd_xyz;
   logic [16:0] weight_read_arr_shape_X;
   logic [16:0] weight_read_arr_shape_Y;
   logic [16:0] weight_read_arr_shape_Z;
@@ -123,32 +127,38 @@ module mem_dispatcher #() (
     end
   end
 
-  fmap_array_shape u_fmap_shape (
+  assign fmap_shape_wr_xyz.x = fmap_arr_shape_X;
+  assign fmap_shape_wr_xyz.y = fmap_arr_shape_Y;
+  assign fmap_shape_wr_xyz.z = fmap_arr_shape_Z;
+  assign fmap_read_arr_shape_X = fmap_shape_rd_xyz.x;
+  assign fmap_read_arr_shape_Y = fmap_shape_rd_xyz.y;
+  assign fmap_read_arr_shape_Z = fmap_shape_rd_xyz.z;
+
+  shape_const_ram u_fmap_shape (
       .clk   (clk_core),
       .rst_n (rst_n_core),
       .wr_en (fmap_write_enable),
       .wr_addr(fmap_shape_read_address),
-      .wr_val0(fmap_arr_shape_X),
-      .wr_val1(fmap_arr_shape_Y),
-      .wr_val2(fmap_arr_shape_Z),
+      .wr_xyz(fmap_shape_wr_xyz),
       .rd_addr(fmap_shape_read_address),
-      .rd_val0(fmap_read_arr_shape_X),
-      .rd_val1(fmap_read_arr_shape_Y),
-      .rd_val2(fmap_read_arr_shape_Z)
+      .rd_xyz(fmap_shape_rd_xyz)
   );
 
-  weight_array_shape u_weight_shape (
+  assign weight_shape_wr_xyz.x = weight_arr_shape_X;
+  assign weight_shape_wr_xyz.y = weight_arr_shape_Y;
+  assign weight_shape_wr_xyz.z = weight_arr_shape_Z;
+  assign weight_read_arr_shape_X = weight_shape_rd_xyz.x;
+  assign weight_read_arr_shape_Y = weight_shape_rd_xyz.y;
+  assign weight_read_arr_shape_Z = weight_shape_rd_xyz.z;
+
+  shape_const_ram u_weight_shape (
       .clk   (clk_core),
       .rst_n (rst_n_core),
       .wr_en (weight_write_enable),
       .wr_addr(weight_shape_read_address),
-      .wr_val0(weight_arr_shape_X),
-      .wr_val1(weight_arr_shape_Y),
-      .wr_val2(weight_arr_shape_Z),
+      .wr_xyz(weight_shape_wr_xyz),
       .rd_addr(weight_shape_read_address),
-      .rd_val0(weight_read_arr_shape_X),
-      .rd_val1(weight_read_arr_shape_Y),
-      .rd_val2(weight_read_arr_shape_Z)
+      .rd_xyz(weight_shape_rd_xyz)
   );
 
   // ===| Shape totals (word counts for DMA) |====================================

--- a/hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv
+++ b/hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv
@@ -11,7 +11,7 @@
 // Provides
 //   Address types : dest_addr_t / src_addr_t / addr_t / ptr_addr_t / parallel_lane_t
 //   Value types   : a_value_t / b_value_t / c_value_t / length_t
-//   Shape types   : shape_dim_t / shape_xyz_t (preparatory; no consumers yet)
+//   Shape types   : shape_dim_t / shape_xyz_t (shape constant RAM contract)
 //   Direction enums: from_device_e, to_device_e, async_e, dest_cache_e
 //   Flag structs   : flags_t (GEMV/GEMM), cvo_flags_t
 //   Opcode enum    : opcode_e (5 ops: GEMV / GEMM / MEMCPY / MEMSET / CVO)
@@ -46,7 +46,7 @@ package isa_pkg;
   // CVO length (16-bit element count)
   typedef logic [15:0] length_t;
 
-  // ===| Shape Types (preparatory vocabulary, no consumers yet) |================
+  // ===| Shape Types (shape constant RAM contract) |=============================
   // Both fmap_array_shape and weight_array_shape today expose three flat
   // 17-bit ports per access (wr_val0/1/2 and rd_val0/1/2) for the X / Y / Z
   // axes of the constant shape RAM. Naming the dimension and the triplet
@@ -57,11 +57,8 @@ package isa_pkg;
   //   shape_xyz_t : a 3-axis bundle (Z is most-significant in packed order
   //                 so { Z, Y, X } maps to a familiar memory layout).
   //
-  // These are added now so the deferred shape-RAM consolidation
-  // (`shape_const_ram` per docs/internal/dead_module_inventory.md §3 and
-  // KELLER §6.3.1) and any new shape-aware module can adopt them
-  // immediately. No existing module imports these typedefs in this batch,
-  // so xvlog and the existing TBs are unaffected.
+  // These types back the parameterised shape_const_ram used by mem_dispatcher
+  // for fmap and weight shape lookup.
   typedef logic [16:0] shape_dim_t;
 
   typedef struct packed {

--- a/hw/sim/run_verification.sh
+++ b/hw/sim/run_verification.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Unified verification runner for pccx-FPGA.
 #
-# Runs every known testbench (currently tb_GEMM_dsp_packer_sign_recovery)
-# and reports a one-line summary plus the path to the generated .pccx
-# traces so pccx-lab can visualise them.
+# Runs every known testbench in deterministic order and reports a one-line
+# summary plus the path to the generated .pccx traces so pccx-lab can
+# visualise them.
 #
 # Intentionally idempotent: each tb writes to its own work dir under
 # hw/sim/work/<tb_name>/ so concurrent / repeated runs don't stomp.
@@ -27,6 +27,7 @@ fi
 # ─── Per-testbench RTL dependency map ───────────────────────────────────────
 # Each entry lists the .sv modules xvlog must pick up, relative to hw/rtl/.
 declare -A TB_DEPS=(
+    [tb_shape_const_ram]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv MEM_control/memory/Constant_Memory/shape_const_ram.sv"
     [tb_GEMM_dsp_packer_sign_recovery]="MAT_CORE/GEMM_dsp_packer.sv MAT_CORE/GEMM_sign_recovery.sv"
     [tb_mat_result_normalizer]="Constants/compilePriority_Order/C_type_pkg/dtype_pkg.sv MAT_CORE/mat_result_normalizer.sv"
     [tb_GEMM_weight_dispatcher]="MAT_CORE/GEMM_weight_dispatcher.sv"
@@ -41,13 +42,25 @@ declare -A TB_DEPS=(
 # Core-id assigned to a tb's emitted pccx trace. Kept contiguous so the UI
 # Timeline shows one lane per testbench when the traces are composed.
 declare -A TB_CORE=(
-    [tb_GEMM_dsp_packer_sign_recovery]=0
-    [tb_mat_result_normalizer]=1
-    [tb_GEMM_weight_dispatcher]=2
-    [tb_FROM_mat_result_packer]=3
-    [tb_barrel_shifter_BF16]=4
-    [tb_ctrl_npu_decoder]=5
-    [tb_mem_u_operation_queue]=6
+    [tb_shape_const_ram]=0
+    [tb_GEMM_dsp_packer_sign_recovery]=1
+    [tb_mat_result_normalizer]=2
+    [tb_GEMM_weight_dispatcher]=3
+    [tb_FROM_mat_result_packer]=4
+    [tb_barrel_shifter_BF16]=5
+    [tb_ctrl_npu_decoder]=6
+    [tb_mem_u_operation_queue]=7
+)
+
+TB_LIST=(
+    tb_shape_const_ram
+    tb_GEMM_dsp_packer_sign_recovery
+    tb_mat_result_normalizer
+    tb_GEMM_weight_dispatcher
+    tb_FROM_mat_result_packer
+    tb_barrel_shifter_BF16
+    tb_ctrl_npu_decoder
+    tb_mem_u_operation_queue
 )
 
 run_tb() {
@@ -60,7 +73,9 @@ run_tb() {
         rtl_args+=("$HW_DIR/rtl/$rel")
     done
 
+    local tool_status=0
     (
+        set -euo pipefail
         cd "$work"
         echo "  [xvlog]"
         xvlog -sv \
@@ -84,11 +99,21 @@ run_tb() {
             --testbench "$tb" \
             --core-id "${TB_CORE[$tb]:-0}" \
             >"$work/from_xsim_log.log" 2>&1
-    )
+    ) || tool_status=$?
+
+    if (( tool_status != 0 )); then
+        printf '%-50s  TOOL FAIL: see %s\n' "$tb" "$work"
+        return 1
+    fi
 
     local verdict
-    verdict="$(grep -E '^(PASS|FAIL):' "$work/xsim.log" | head -1)"
+    verdict="$(awk '/^(PASS|FAIL):/ { print; exit }' "$work/xsim.log")"
+    if [[ -z "$verdict" ]]; then
+        verdict="FAIL: no PASS/FAIL verdict in $work/xsim.log"
+    fi
     printf '%-50s  %s\n' "$tb" "$verdict"
+
+    [[ "$verdict" == PASS:* ]]
 }
 
 # ─── Main ───────────────────────────────────────────────────────────────────
@@ -96,8 +121,11 @@ echo "==> Running pccx-FPGA testbench suite"
 echo ""
 printf '%-50s  %s\n' "TESTBENCH" "RESULT"
 printf '%-50s  %s\n' "---------" "------"
-for tb in "${!TB_DEPS[@]}"; do
-    run_tb "$tb"
+overall_status=0
+for tb in "${TB_LIST[@]}"; do
+    if ! run_tb "$tb"; then
+        overall_status=1
+    fi
 done
 
 echo ""
@@ -114,3 +142,5 @@ if [[ -f "$HW_DIR/build/reports/timing_summary_post_synth.rpt" ]]; then
 else
     echo "  No synth report — run hw/vivado/synth.tcl first."
 fi
+
+exit "$overall_status"

--- a/hw/tb/tb_shape_const_ram.sv
+++ b/hw/tb/tb_shape_const_ram.sv
@@ -1,0 +1,185 @@
+`timescale 1ns / 1ps
+
+// ===============================================================================
+// Testbench: tb_shape_const_ram
+// Phase : pccx v002 — MEM_control shape descriptor RAM
+//
+// Purpose
+// -------
+//   Smoke-validates the parameterised shape_const_ram used by mem_dispatcher
+//   for MEMSET shape descriptors. The TB checks the hardware contract that
+//   matters for the dispatcher migration:
+//
+//     1. Reset clears every sampled entry to zero.
+//     2. Writes commit on the rising clock edge, not before it.
+//     3. Reads are combinational after the write clock edge.
+//     4. wr_en=0 preserves existing contents.
+//     5. A later reset clears previously written entries.
+//
+//   This does not claim board execution; it is an xsim validation candidate
+//   for the shape-RAM bring-up path.
+// ===============================================================================
+
+module tb_shape_const_ram;
+
+  import isa_pkg::*;
+
+  // ===| Clock + reset |=========================================================
+  logic clk;
+  logic rst_n;
+  initial clk = 1'b0;
+  always #2 clk = ~clk;
+
+  // ===| DUT IO |================================================================
+  logic       wr_en;
+  logic [5:0] wr_addr;
+  shape_xyz_t wr_xyz;
+
+  ptr_addr_t  rd_addr;
+  shape_xyz_t rd_xyz;
+
+  shape_const_ram u_dut (
+      .clk    (clk),
+      .rst_n  (rst_n),
+      .wr_en  (wr_en),
+      .wr_addr(wr_addr),
+      .wr_xyz (wr_xyz),
+      .rd_addr(rd_addr),
+      .rd_xyz (rd_xyz)
+  );
+
+  // ===| Scoreboard |============================================================
+  int errors = 0;
+  int checks = 0;
+
+  task automatic set_read_addr(input ptr_addr_t addr);
+    begin
+      rd_addr = addr;
+      #1;
+    end
+  endtask
+
+  task automatic expect_shape(
+      input string tag,
+      input shape_dim_t exp_x,
+      input shape_dim_t exp_y,
+      input shape_dim_t exp_z
+  );
+    begin
+      checks++;
+      if (rd_xyz.x !== exp_x || rd_xyz.y !== exp_y || rd_xyz.z !== exp_z) begin
+        errors++;
+        $display("[%0t] mismatch %s: got x=%0d y=%0d z=%0d exp x=%0d y=%0d z=%0d",
+                 $time, tag,
+                 rd_xyz.x, rd_xyz.y, rd_xyz.z,
+                 exp_x, exp_y, exp_z);
+      end
+    end
+  endtask
+
+  task automatic write_shape(
+      input ptr_addr_t addr,
+      input shape_dim_t x_val,
+      input shape_dim_t y_val,
+      input shape_dim_t z_val
+  );
+    begin
+      wr_en   = 1'b1;
+      wr_addr = addr;
+      wr_xyz  = '{z: z_val, y: y_val, x: x_val};
+      @(posedge clk);
+      #1;
+      wr_en = 1'b0;
+    end
+  endtask
+
+  // ===| Stimulus |==============================================================
+  initial begin
+    rst_n   = 1'b0;
+    wr_en   = 1'b0;
+    wr_addr = '0;
+    wr_xyz  = '0;
+    rd_addr = '0;
+
+    repeat (4) @(posedge clk);
+    #1;
+
+    set_read_addr(6'd0);
+    expect_shape("reset_addr0", 17'd0, 17'd0, 17'd0);
+    set_read_addr(6'd63);
+    expect_shape("reset_addr63", 17'd0, 17'd0, 17'd0);
+
+    rst_n = 1'b1;
+    @(posedge clk);
+    #1;
+
+    set_read_addr(6'd8);
+    wr_en   = 1'b1;
+    wr_addr = 6'd8;
+    wr_xyz  = '{z: 17'd33, y: 17'd22, x: 17'd11};
+    #1;
+    expect_shape("pre_clock_write_addr8", 17'd0, 17'd0, 17'd0);
+    @(posedge clk);
+    #1;
+    wr_en = 1'b0;
+    expect_shape("post_clock_write_addr8", 17'd11, 17'd22, 17'd33);
+
+    wr_addr = 6'd8;
+    wr_xyz  = '{z: 17'd333, y: 17'd222, x: 17'd111};
+    @(posedge clk);
+    #1;
+    set_read_addr(6'd8);
+    expect_shape("write_disabled_hold_addr8", 17'd11, 17'd22, 17'd33);
+
+    write_shape(6'd0, 17'd1, 17'd2, 17'd3);
+    set_read_addr(6'd0);
+    expect_shape("write_addr0", 17'd1, 17'd2, 17'd3);
+
+    write_shape(6'd63, 17'd131071, 17'd65535, 17'd4096);
+    set_read_addr(6'd63);
+    expect_shape("write_addr63", 17'd131071, 17'd65535, 17'd4096);
+
+    write_shape(6'd0, 17'd17, 17'd34, 17'd51);
+    set_read_addr(6'd0);
+    expect_shape("overwrite_addr0", 17'd17, 17'd34, 17'd51);
+    set_read_addr(6'd63);
+    expect_shape("addr63_preserved", 17'd131071, 17'd65535, 17'd4096);
+
+    set_read_addr(6'd17);
+    expect_shape("unwritten_addr17", 17'd0, 17'd0, 17'd0);
+
+    // Simultaneous read of an existing entry while writing a different entry.
+    set_read_addr(6'd63);
+    wr_en   = 1'b1;
+    wr_addr = 6'd17;
+    wr_xyz  = '{z: 17'd777, y: 17'd666, x: 17'd555};
+    @(posedge clk);
+    #1;
+    wr_en = 1'b0;
+    expect_shape("read_during_other_write", 17'd131071, 17'd65535, 17'd4096);
+    set_read_addr(6'd17);
+    expect_shape("write_addr17", 17'd555, 17'd666, 17'd777);
+
+    rst_n = 1'b0;
+    repeat (2) @(posedge clk);
+    #1;
+    set_read_addr(6'd0);
+    expect_shape("second_reset_addr0", 17'd0, 17'd0, 17'd0);
+    set_read_addr(6'd17);
+    expect_shape("second_reset_addr17", 17'd0, 17'd0, 17'd0);
+    set_read_addr(6'd63);
+    expect_shape("second_reset_addr63", 17'd0, 17'd0, 17'd0);
+
+    if (errors == 0) begin
+      $display("PASS: %0d cycles, shape_const_ram matches golden.", checks);
+    end else begin
+      $display("FAIL: %0d mismatches over %0d checks.", errors, checks);
+    end
+    $finish;
+  end
+
+  initial begin
+    #100000 $display("FAIL: shape_const_ram timeout"); $finish;
+  end
+
+endmodule


### PR DESCRIPTION
## Summary
Adds direct xsim smoke coverage for the shared `shape_const_ram` contract used by the dispatcher migration.

## What changed
- Adds `tb_shape_const_ram` coverage for reset clear, clocked write visibility, combinational read, write-disabled hold, overwrite, and reset-clear behavior.
- Adds `tb_shape_const_ram` to the deterministic verification runner.
- Tightens runner verdict handling so missing PASS/FAIL verdicts fail nonzero.
- Updates shape descriptor comments to match the dispatcher-wired contract.

## What did not change
- No board execution was performed.
- No timing closure work or timing claim is included.
- No release or tag is included.
- No model weights, generated model blobs, bitstreams, or generated reports are committed.

## Validation
- `bash -n hw/sim/run_verification.sh`: PASS
- `git diff --check`: PASS
- `bash hw/sim/run_verification.sh`: PASS
- Vivado `xvlog` filelist compile with repo include paths: PASS

## Known skips
- `tb_GEMM_fmap_staggered_delay` remains excluded from the active xsim suite and needs separate triage.
- No KV260 bring-up logs are added.
- No post-implementation timing evidence is added.

## Relationship to PR #61
This is a stacked PR on top of #61 (`codex/shape-const-ram-dispatcher-migration`). The local smoke commit `bb3de50` has #61 head `47d6a42` as an ancestor. PR #61 is currently open with passing `repo-validate` but reports merge conflicts against `main`, so this PR is reviewable as the follow-on smoke layer only after #61 is resolved.