### PR TITLE
docs(kv260): add bring-up evidence checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pccx — Bare-Metal Transformer Accelerator on Kria KV260
 
-Open SystemVerilog NPU for Gemma-class LLM inference on AMD/Xilinx
-Kria KV260.
+Open SystemVerilog NPU for experimental Gemma-class LLM acceleration on
+AMD/Xilinx Kria KV260.
 
 ```text
 PCCX KV260 Roadmap
@@ -171,7 +171,7 @@ Details: [DSP48E2 W4A8 bit-packing →](https://pccxai.github.io/pccx/en/docs/v0
 
 ---
 
-## How Gemma 3N E4B Runs on This Thing
+## Target Gemma 3N E4B Execution Path
 
 The target model (Google Gemma 3N E4B) has several deviations from a
 textbook decoder that the scheduler has to honor. The short list:
@@ -256,10 +256,10 @@ Details: [KV cache strategy →](https://pccxai.github.io/pccx/en/docs/v002/Arch
 This repository hosts the RTL for **both** active tracks. As of
 2026-04-20:
 
-| Track | Target model | Goal | Horizon | Shared RTL assets |
+| Track | Target model | Planned target | Horizon | Shared RTL assets |
 |-------|-------------|------|---------|-------------------|
-| **v002 Extended** (this repo, `main`) | Gemma 3N E4B | **20 tok/s** measured | Week 1–49 | sparse weight fetcher (Phase G), EAGLE draft/verify dispatch (Phase H+), SSD scheduler (Phase I), tree mask generator (Phase J) |
-| **v003** (future branch) | Gemma 4 E4B | **12–15 tok/s** | Week 16–52 (parallel) | reuses v002 Phase G/H/I/J modules with hidden/layer/KV-head re-parameterization |
+| **v002 Extended** (this repo, `main`) | Gemma 3N E4B | **20 tok/s** target, evidence-gated | Week 1–49 | sparse weight fetcher (Phase G), EAGLE draft/verify dispatch (Phase H+), SSD scheduler (Phase I), tree mask generator (Phase J) |
+| **v003** (future branch) | Gemma 4 E4B | **12–15 tok/s** target | Week 16–52 (parallel) | reuses v002 Phase G/H/I/J modules with hidden/layer/KV-head re-parameterization |
 
 - v002 freeze → snapshotted into `pccx/codes/v002/` via the pccx
   version-cutover workflow (`tools/freeze_active.sh`).

--- a/docs/KV260_BRINGUP.md
+++ b/docs/KV260_BRINGUP.md
@@ -1,0 +1,91 @@
+# KV260 Bring-Up Evidence Checklist
+
+This checklist describes the evidence path for KV260 board smoke runs.
+It is a bring-up scaffold, not proof that the NPU bitstream or Gemma 3N
+E4B runtime works on hardware.
+
+## Current Runner
+
+The repo includes:
+
+```bash
+scripts/kv260/run_gemma3n_e4b_smoke.sh
+```
+
+The script is explicit by default: without the required environment it
+exits with a `BLOCKED_*` status and writes a blocker summary under
+`docs/evidence/kv260-gemma3n-e4b/<run_id>/`.
+
+Do not run it against a board unless the board, bitstream, model path,
+runtime directory, and prompt fixture are intentionally configured.
+
+## Required Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `PCCX_KV260_HOST` | KV260 hostname or IP for SSH |
+| `PCCX_KV260_USER` | SSH user with key-based login |
+| `PCCX_MODEL_DIR` | Board-side model directory, or host directory when staging is enabled |
+| `PCCX_BITSTREAM_PATH` | Local or board-side bitstream path |
+| `PCCX_RUN_PROMPT` | Smoke input text |
+| `PCCX_RUN_TOKENS` | Small positive max-new-token count |
+| `PCCX_BOARD_RUNTIME_DIR` | Writable directory on the KV260 for runner and evidence files |
+
+Optional controls:
+
+| Variable | Purpose |
+| --- | --- |
+| `PCCX_STAGE_MODEL_TO_BOARD=1` | Copy a host model directory to the board runtime area |
+| `PCCX_SKIP_BITSTREAM_LOAD=1` | Skip programming when the intended image is already loaded |
+| `PCCX_REMOTE_RUN_CMD` | Override the board-side NPU runtime command |
+| `PCCX_RUN_ID` | Force a stable evidence directory name |
+
+## Evidence Flow
+
+1. Confirm board reachability over non-interactive SSH.
+2. Create a board-side runtime/evidence directory.
+3. Confirm the model directory exists on the board, or stage it only when
+   `PCCX_STAGE_MODEL_TO_BOARD=1` is set.
+4. Confirm the bitstream exists locally or on the board.
+5. Record the bitstream basename and SHA256.
+6. Program the PL with `fpgautil` or `xbutil`, unless
+   `PCCX_SKIP_BITSTREAM_LOAD=1` is set.
+7. Stage the remote smoke runner.
+8. Run the NPU runtime candidate or record a precise blocker.
+9. Fetch sanitized stdout, stderr, generated output, and `result.env`.
+10. Write `summary.txt` and, when blocked, `blocker.txt`.
+
+## Result Status
+
+| Status | Meaning |
+| --- | --- |
+| `PASS_KV260_NPU` | Board-side NPU runtime reported a pass |
+| `PASS_KV260_FALLBACK` | Board-side software fallback reported a pass; this is not NPU inference evidence |
+| `BLOCKED_BOARD` | SSH or board setup is missing or unreachable |
+| `BLOCKED_MODEL` | Model path or staging is missing |
+| `BLOCKED_BITSTREAM` | Bitstream path, copy, or programming failed |
+| `BLOCKED_RUNTIME` | Runtime wrapper, output, or metrics are missing |
+| `BLOCKED_RTL` | The runtime identified an RTL/Vivado readiness blocker |
+
+Only `PASS_KV260_NPU` with the captured logs, bitstream hash, commit SHA,
+and runtime output should be treated as KV260 NPU smoke evidence.
+
+## What To Record
+
+- Git commit SHA and branch.
+- Vivado/Vitis version used to create the bitstream.
+- Bitstream basename and SHA256.
+- Board identifier, if available.
+- Exact environment variable set, with private hostnames and paths
+  redacted in public notes.
+- Prompt fixture and requested token count.
+- `summary.txt`, `blocker.txt` when present, and sanitized runtime logs.
+- Whether the runtime path was `FPGA_NPU`, `PS_FALLBACK`, or `blocked`.
+
+## Public Wording
+
+Use "KV260 bring-up logs", "runtime readiness checks", or "target
+path" until a real `PASS_KV260_NPU` evidence directory exists for the
+current bitstream and commit. Do not claim board inference, Gemma 3N E4B
+runtime success, timing closure, or measured throughput from a blocked
+or fallback run.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Pages, bilingual EN / KO).
 
 - **Latest architecture — v002** (current target of this repo):
   <https://pccxai.github.io/pccx/en/docs/v002/index.html>
+- Repo-local KV260 bring-up checklist:
+  [KV260_BRINGUP.md](KV260_BRINGUP.md)
 - Documentation root (language picker):
   <https://pccxai.github.io/pccx/en/index.html>
 - pccx source repository:


### PR DESCRIPTION
## Summary
Adds a public-safe KV260 bring-up evidence checklist and tightens README wording around target throughput.

## What changed
- Adds `docs/KV260_BRINGUP.md` covering required environment, evidence flow, result statuses, and public wording.
- Links the checklist from `docs/README.md`.
- Rewords README from hardware/performance-sounding claims toward experimental target-path language.
- Changes the roadmap table from “measured” throughput wording to evidence-gated target wording.

## What did not change
- No board commands were run.
- No generated board logs were added.
- No bitstreams, weights, model blobs, or private paths are committed.
- No KV260 inference, Gemma 3N E4B runtime success, timing closure, or measured throughput claim is made.
- No release or tag is included.

## Validation
- `bash -n scripts/kv260/run_gemma3n_e4b_smoke.sh`: PASS
- `bash -n hw/sim/run_verification.sh`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS before commit
- `bash hw/sim/run_verification.sh`: PASS on `origin/main` baseline
- Large-file scan: no files over 50 MB
- Private-path scan: no hits in README/docs/.github/hw/sw/scripts
- Unsupported-claim scan: remaining hits are negated timing-closed wording in existing docs

## Relationship to other PRs
This PR is based directly on `main` and is independent from the shape RAM stacked PR chain (#68-#71).