### PR TITLE
chore(fpga): add v002 runnable candidate evidence flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Full phase-by-phase plan, decision points, compute budget, and Year 2
 | uXC driver (AXI-Lite HAL)                        | Skeleton       |
 | Gemma 3N E4B application (`sw/gemma3NE4B/`)      | Planned (v0.2.0) — not yet in tree |
 | Simulation / trace-driven verification           | xsim smoke suite active |
-| Vivado synthesis + timing closure                | Not started    |
+| Vivado synthesis + timing closure                | Synth attempted; no completed report yet. Timing closure pending. |
 
 > The current `hw/rtl/` tree reflects the v001 parameterization
 > (W4A16 / 32×32 array / 1 DSP = 1 MAC). Re-parameterization to the
@@ -347,6 +347,7 @@ PASS verdict rules, and the evidence checklist.
 | Testbench | Module(s) under test | Verdict count |
 |-----------|-----------------------|--------------:|
 | `tb_shape_const_ram`                | `shape_const_ram` (reset / write / read contract)        |   15 |
+| `tb_mem_dispatcher_shape_lookup`    | `mem_dispatcher` + `shape_const_ram` LOAD pointer routing |   11 |
 | `tb_GEMM_dsp_packer_sign_recovery` | `GEMM_dsp_packer` + `GEMM_sign_recovery` (W4A8 dual-MAC) | 1024 |
 | `tb_GEMM_fmap_staggered_delay`     | `GEMM_fmap_staggered_dispatch` (column stagger)          |   65 |
 | `tb_GEMM_weight_dispatcher`        | `GEMM_weight_dispatcher` (upper / lower AND-valid)      |  128 |

--- a/docs/TIMING_EVIDENCE.md
+++ b/docs/TIMING_EVIDENCE.md
@@ -28,6 +28,12 @@ From `hw/`:
 long board-flow job and should only be launched when synthesis is clean
 and the wrapper/block-design boundary is ready.
 
+On memory-constrained hosts, reduce Vivado run parallelism:
+
+```bash
+PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth
+```
+
 ## Expected Report Locations
 
 Generated files land under `hw/build/` and are ignored by git unless a

--- a/docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/blocker.txt
+++ b/docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/blocker.txt
@@ -1,0 +1,6 @@
+status=BLOCKED_BOARD
+reason=Missing required board SSH environment: PCCX_KV260_HOST,PCCX_KV260_USER,PCCX_MODEL_DIR,PCCX_BITSTREAM_PATH,PCCX_RUN_PROMPT,PCCX_RUN_TOKENS,PCCX_BOARD_RUNTIME_DIR
+instructions:
+- Export PCCX_KV260_HOST with the KV260 hostname or IP.
+- Export PCCX_KV260_USER with the SSH user configured for key-based login.
+- Re-run this script after the board is powered, booted, and reachable over SSH.

--- a/docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/summary.txt
+++ b/docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/summary.txt
@@ -1,0 +1,16 @@
+run_id=20260502T142200Z-b1b0dee-blocked-board
+branch=closure/v002-runnable-candidate
+git_commit=b1b0dee023c4aeb161415fa3fda652dcf3d1c99a
+result_status=BLOCKED_BOARD
+runtime_path=blocked
+board_reachable=no
+model_found=no
+model_location=unknown
+bitstream_found=no
+bitstream_loaded=no
+bitstream_basename=unknown
+bitstream_sha256=unknown
+token_count=unknown
+tok_per_sec=unknown
+elapsed_sec=0.005
+blocker_reason=Missing required board SSH environment: PCCX_KV260_HOST,PCCX_KV260_USER,PCCX_MODEL_DIR,PCCX_BITSTREAM_PATH,PCCX_RUN_PROMPT,PCCX_RUN_TOKENS,PCCX_BOARD_RUNTIME_DIR

--- a/evidence/v002/FINAL_CANDIDATE_SUMMARY.md
+++ b/evidence/v002/FINAL_CANDIDATE_SUMMARY.md
@@ -1,0 +1,131 @@
+# pccx v002 Runnable Candidate Evidence Summary
+
+Date: 2026-05-02
+Branch: `closure/v002-runnable-candidate`
+
+## Scope
+
+This is a runnable-candidate evidence record, not a release claim.
+It records what was verified locally and what remains blocked by missing
+hardware, runtime, or completed Vivado reports.
+
+## PR Stack Status
+
+- The mem-dispatcher shape lookup test and shape RAM consolidation are
+  already included in `origin/main`.
+- This candidate branch adds:
+  - `scripts/v002/run-local-candidate.sh`
+  - `PCCX_VIVADO_JOBS` support for memory-constrained Vivado synth runs
+  - current KV260 blocker evidence for the candidate SHA
+
+## Local Runnable Candidate
+
+Candidate SHA under test: `b1b0dee023c4aeb161415fa3fda652dcf3d1c99a`
+
+Command:
+
+```bash
+bash scripts/v002/run-local-candidate.sh
+```
+
+Evidence:
+
+```text
+hw/build/v002-local-candidate/20260502T141937Z-b1b0dee/summary.txt
+```
+
+Results:
+
+- `bash_syntax`: PASS
+- `xsim_list`: PASS
+- `tb_shape_const_ram`: PASS
+- `tb_mem_dispatcher_shape_lookup`: PASS
+- `tb_GEMM_fmap_staggered_delay`: PASS
+- full xsim regression: PASS
+- Vivado `xvlog` filelist compile: PASS
+- `npu_core_wrapper` elaboration with `xpm` + `unisims_ver`: PASS
+
+## Vivado Synth / Timing
+
+Vivado version observed: 2025.2.
+
+Attempts:
+
+- `./vivado/build.sh synth`
+  - Started: 2026-05-02 21:43 KST.
+  - Result: failed after 31m46s; Vivado parent process was killed during
+    synthesis under local memory pressure.
+- `PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth`
+  - Started: 2026-05-02 22:16 KST.
+  - Result: stopped after the 60-minute local cutoff with no generated
+    `hw/build/reports/*_post_synth.rpt` reports.
+  - Last run log stage: `Start Cross Boundary and Area Optimization`.
+
+Observed blocker signals:
+
+- `Synth 8-11357` warned that `emax_cache_mem_reg` and `emax_pipe_reg`
+  3D RAM / struct RAM patterns may create large register implementations.
+- `pccx_timing.xdc` produced critical warnings for unmatched false-path
+  and multicycle objects at lines 34, 41, 43, 53, and 56.
+
+Timing status:
+
+- No fresh completed post-synth timing report was produced in this run.
+- No post-implementation timing report exists for this candidate.
+- Timing closure is not claimed.
+
+## KV260 / Gemma 3N E4B
+
+Command:
+
+```bash
+PCCX_RUN_ID=20260502T142200Z-b1b0dee-blocked-board \
+  bash scripts/kv260/run_gemma3n_e4b_smoke.sh
+```
+
+Evidence:
+
+```text
+docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/
+```
+
+Result:
+
+- `result_status=BLOCKED_BOARD`
+- `board_reachable=no`
+- `model_found=no`
+- `bitstream_found=no`
+- `bitstream_loaded=no`
+- `token_count=unknown`
+- `tok_per_sec=unknown`
+
+Blocker:
+
+- Required board/runtime environment variables were not present:
+  `PCCX_KV260_HOST`, `PCCX_KV260_USER`, `PCCX_MODEL_DIR`,
+  `PCCX_BITSTREAM_PATH`, `PCCX_RUN_PROMPT`, `PCCX_RUN_TOKENS`,
+  `PCCX_BOARD_RUNTIME_DIR`.
+
+Gemma host artifacts were inspected read-only under:
+
+```text
+/home/hwkim/Desktop/github/hkimw/llm-bottleneck-lab/x64/gemma3N_E4B
+```
+
+The host has INT4 safetensor shards and large mmap/cache artifacts, but
+no KV260 staging or model execution was performed.
+
+## Performance Boundary
+
+- A 20 tok/s target remains a target only.
+- No token throughput was measured on KV260.
+- No Gemma 3N E4B board runtime evidence was produced.
+
+## Non-Claims
+
+- No production readiness claim.
+- No stable-release claim.
+- No timing-closure claim.
+- No KV260 inference claim.
+- No Gemma 3N E4B on-KV260 runtime claim.
+- No achieved-throughput claim.

--- a/evidence/v002/FINAL_CANDIDATE_SUMMARY.md
+++ b/evidence/v002/FINAL_CANDIDATE_SUMMARY.md
@@ -106,14 +106,10 @@ Blocker:
   `PCCX_BITSTREAM_PATH`, `PCCX_RUN_PROMPT`, `PCCX_RUN_TOKENS`,
   `PCCX_BOARD_RUNTIME_DIR`.
 
-Gemma host artifacts were inspected read-only under:
-
-```text
-/home/hwkim/Desktop/github/hkimw/llm-bottleneck-lab/x64/gemma3N_E4B
-```
-
-The host has INT4 safetensor shards and large mmap/cache artifacts, but
-no KV260 staging or model execution was performed.
+A maintainer-local Gemma host artifact directory was inspected read-only;
+the local absolute path is intentionally omitted from tracked evidence.
+The host has INT4 safetensor shards and large mmap/cache artifacts, but no
+KV260 staging or model execution was performed.
 
 ## Performance Boundary
 

--- a/hw/vivado/README.md
+++ b/hw/vivado/README.md
@@ -40,8 +40,8 @@ cd hw
 | `xelab` on `GEMV_top`, `CVO_top`, `GEMM_systolic_top` | ✅ clean |
 | `xelab` on `NPU_top` standalone | ⚪ expected fail — interface ports need a wrapper; see `npu_core_wrapper.sv` |
 | `create_project.tcl` | ✅ runs green |
-| `synth.tcl` (out-of-context) | 🟡 first real smoke test — see `build/reports/` for the outcome of the current run |
-| `impl.tcl` (write_bitstream) | 🔴 not attempted yet — gated on synth being warning-free |
+| `synth.tcl` (out-of-context) | 🟡 attempted locally; no completed report yet. Use `PCCX_VIVADO_JOBS=1` on memory-constrained hosts |
+| `impl.tcl` (write_bitstream) | 🔴 not attempted yet — gated on completed synth evidence |
 | Block design / Zynq PS integration | 🔴 not written yet (see §Next steps) |
 | Device-tree overlay | 🔴 not written yet |
 | Driver smoke test on board | 🔴 not attempted yet |

--- a/hw/vivado/build.sh
+++ b/hw/vivado/build.sh
@@ -7,6 +7,7 @@
 #   ./build.sh clean     # wipe build/ + generated .jou/.log
 #
 # Target: Vivado 2023.2+ on Linux. Will attempt Vivado 2025.2 if available.
+# Set PCCX_VIVADO_JOBS=1 or 2 on memory-constrained hosts.
 
 set -euo pipefail
 

--- a/hw/vivado/synth.tcl
+++ b/hw/vivado/synth.tcl
@@ -23,6 +23,19 @@ set PROJ_DIR [file normalize $HW_ROOT/build/pccx_v002_kv260]
 set REPORTS  $HW_ROOT/build/reports
 file mkdir $REPORTS
 
+set SYNTH_JOBS 4
+if {[info exists ::env(PCCX_VIVADO_JOBS)] && $::env(PCCX_VIVADO_JOBS) ne ""} {
+    set SYNTH_JOBS $::env(PCCX_VIVADO_JOBS)
+}
+if {![string is integer -strict $SYNTH_JOBS] || $SYNTH_JOBS < 1} {
+    puts "\[pccx\] invalid PCCX_VIVADO_JOBS=$SYNTH_JOBS; expected positive integer."
+    exit 2
+}
+if {[catch {set_param general.maxThreads $SYNTH_JOBS} msg]} {
+    puts "\[pccx\] warning: could not set general.maxThreads=$SYNTH_JOBS: $msg"
+}
+puts "\[pccx\] synth jobs/threads = $SYNTH_JOBS"
+
 # Open the project only if create_project.tcl wasn't sourced first.
 if {[llength [current_project -quiet]] == 0} {
     open_project $PROJ_DIR/pccx_v002_kv260.xpr
@@ -40,7 +53,7 @@ set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} \
              -objects [get_runs synth_1]
 
 # Synthesize.
-launch_runs synth_1 -jobs 4
+launch_runs synth_1 -jobs $SYNTH_JOBS
 wait_on_run synth_1
 
 if {[get_property PROGRESS [get_runs synth_1]] ne "100%"} {

--- a/scripts/v002/run-local-candidate.sh
+++ b/scripts/v002/run-local-candidate.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Run the strongest local v002 candidate checks that do not require a board.
+#
+# Logs are written under hw/build/ so generated evidence stays out of git.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HW_DIR="$ROOT_DIR/hw"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+COMMIT="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+LOG_ROOT="${PCCX_V002_EVIDENCE_DIR:-$HW_DIR/build/v002-local-candidate/$STAMP-$COMMIT}"
+SUMMARY="$LOG_ROOT/summary.txt"
+
+mkdir -p "$LOG_ROOT"
+
+log_summary() {
+    printf '%s\n' "$*" | tee -a "$SUMMARY"
+}
+
+run_logged() {
+    local name="$1"
+    shift
+    local log="$LOG_ROOT/$name.log"
+
+    log_summary "==> $name"
+    log_summary "command: $*"
+    if "$@" >"$log" 2>&1; then
+        log_summary "result: PASS"
+    else
+        local status=$?
+        log_summary "result: FAIL ($status), see $log"
+        return "$status"
+    fi
+}
+
+run_shell() {
+    local name="$1"
+    shift
+    local log="$LOG_ROOT/$name.log"
+
+    log_summary "==> $name"
+    log_summary "command: $*"
+    if (cd "$ROOT_DIR" && bash -lc "$*") >"$log" 2>&1; then
+        log_summary "result: PASS"
+    else
+        local status=$?
+        log_summary "result: FAIL ($status), see $log"
+        return "$status"
+    fi
+}
+
+make_abs_filelist() {
+    local out="$1"
+    while IFS= read -r line; do
+        case "$line" in
+            rtl/*)    printf '%s/%s\n' "$HW_DIR" "$line" ;;
+            vivado/*) printf '%s/%s\n' "$HW_DIR" "$line" ;;
+            *)        printf '%s\n' "$line" ;;
+        esac
+    done <"$HW_DIR/vivado/filelist.f" >"$out"
+}
+
+run_optional_vivado_compile() {
+    if ! command -v xvlog >/dev/null 2>&1; then
+        log_summary "==> vivado_filelist_compile"
+        log_summary "result: SKIP, xvlog not found"
+        return 0
+    fi
+
+    local work="$LOG_ROOT/vivado_filelist_work"
+    local abs_filelist="$LOG_ROOT/filelist.abs.f"
+    mkdir -p "$work"
+    make_abs_filelist "$abs_filelist"
+
+    run_shell vivado_filelist_compile \
+        "cd '$work' && xvlog -sv \
+          -i '$HW_DIR/rtl' \
+          -i '$HW_DIR/rtl/Constants/compilePriority_Order/A_const_svh' \
+          -i '$HW_DIR/rtl/MAT_CORE' \
+          -i '$HW_DIR/rtl/MEM_control/IO' \
+          -i '$HW_DIR/rtl/NPU_Controller' \
+          -i '$HW_DIR/rtl/NPU_Controller/NPU_Control_Unit' \
+          -i '$HW_DIR/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE' \
+          -i '$HW_DIR/rtl/VEC_CORE' \
+          -f '$abs_filelist'"
+}
+
+run_optional_wrapper_elab() {
+    if ! command -v xvlog >/dev/null 2>&1 || ! command -v xelab >/dev/null 2>&1; then
+        log_summary "==> npu_core_wrapper_elab"
+        log_summary "result: SKIP, xvlog/xelab not found"
+        return 0
+    fi
+
+    local vivado_root="${XILINX_VIVADO:-}"
+    local glbl_v="${vivado_root:+$vivado_root/ids_lite/ISE/verilog/src/glbl.v}"
+    if [[ -z "$glbl_v" || ! -f "$glbl_v" ]]; then
+        log_summary "==> npu_core_wrapper_elab"
+        log_summary "result: SKIP, XILINX_VIVADO glbl.v not found"
+        return 0
+    fi
+
+    local work="$LOG_ROOT/top_elab_work"
+    local abs_filelist="$LOG_ROOT/filelist.top.abs.f"
+    mkdir -p "$work"
+    make_abs_filelist "$abs_filelist"
+
+    run_shell npu_core_wrapper_elab \
+        "cd '$work' && xvlog -sv \
+          -i '$HW_DIR/rtl' \
+          -i '$HW_DIR/rtl/Constants/compilePriority_Order/A_const_svh' \
+          -i '$HW_DIR/rtl/MAT_CORE' \
+          -i '$HW_DIR/rtl/MEM_control/IO' \
+          -i '$HW_DIR/rtl/NPU_Controller' \
+          -i '$HW_DIR/rtl/NPU_Controller/NPU_Control_Unit' \
+          -i '$HW_DIR/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE' \
+          -i '$HW_DIR/rtl/VEC_CORE' \
+          -f '$abs_filelist' '$glbl_v' && \
+          xelab -L xpm -L unisims_ver -debug typical npu_core_wrapper glbl -s npu_core_wrapper_snap"
+}
+
+: >"$SUMMARY"
+log_summary "pccx v002 local candidate"
+log_summary "utc: $STAMP"
+log_summary "branch: $(git -C "$ROOT_DIR" branch --show-current)"
+log_summary "commit: $(git -C "$ROOT_DIR" rev-parse HEAD)"
+log_summary "logs: $LOG_ROOT"
+log_summary ""
+
+run_logged bash_syntax bash -n \
+    "$ROOT_DIR/hw/sim/run_verification.sh" \
+    "$ROOT_DIR/scripts/kv260/run_gemma3n_e4b_smoke.sh" \
+    "$ROOT_DIR/scripts/v002/run-local-candidate.sh"
+
+run_logged xsim_list "$ROOT_DIR/hw/sim/run_verification.sh" --list
+run_logged xsim_shape_const_ram "$ROOT_DIR/hw/sim/run_verification.sh" --tb tb_shape_const_ram
+run_logged xsim_mem_dispatcher_shape_lookup "$ROOT_DIR/hw/sim/run_verification.sh" --tb tb_mem_dispatcher_shape_lookup
+run_logged xsim_fmap_staggered_delay "$ROOT_DIR/hw/sim/run_verification.sh" --tb tb_GEMM_fmap_staggered_delay
+run_logged xsim_full_regression "$ROOT_DIR/hw/sim/run_verification.sh"
+
+run_optional_vivado_compile
+run_optional_wrapper_elab
+
+log_summary ""
+log_summary "LOCAL-RUNNABLE-CANDIDATE checks completed."


### PR DESCRIPTION
## Summary
- Add a local v002 runnable-candidate validation runner for syntax, xsim, Vivado compile, and top elaboration checks.
- Add constrained Vivado synth job control via `PCCX_VIVADO_JOBS` and document the local synth status honestly.
- Add candidate evidence and KV260 smoke blocker summaries without committing generated logs or model artifacts.
- Update README/Vivado docs so public status reflects runnable local evidence and remaining hardware/timing blockers.

## Validation
- PASS: `bash scripts/v002/run-local-candidate.sh` on `e01debb01c1c75158c9ee797830243ec0400347a`.
- Evidence: `hw/build/v002-local-candidate/20260502T142606Z-e01debb/summary.txt`.
- BLOCKED_BOARD: `PCCX_RUN_ID=20260502T142200Z-b1b0dee-blocked-board bash scripts/kv260/run_gemma3n_e4b_smoke.sh` captured missing board/model/runtime inputs.
- Evidence: `docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/summary.txt` and `blocker.txt`.
- Vivado synth was attempted locally: default synth was killed under memory pressure; `PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth` was stopped after a 60-minute local cutoff with no post-synth report generated.

## Non-claims
- This PR does not claim KV260 inference success.
- This PR does not claim Gemma 3N E4B execution on hardware.
- This PR does not claim 20 tok/s evidence.
- This PR does not claim timing closure.
- This PR does not create or request a release/tag.