### PR TITLE
v002 synth timing evidence candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # pccx — Bare-Metal Transformer Accelerator on Kria KV260
 
+PCCX™ technology / operated by Altifigence™.
+
 Open SystemVerilog NPU for experimental Gemma-class LLM acceleration on
 AMD/Xilinx Kria KV260.
 
 ```text
-PCCX KV260 Roadmap
+PCCX KV260 Evidence State
 
-RTL Alpha        ███████████████░░  85%
-Verification     ███████████░░░░░  70%
-Driver Bring-up  ███████░░░░░░░░░  45%
-Bitstream        ████░░░░░░░░░░░░  25%
-Public Release   ██░░░░░░░░░░░░░░  15%
-
-Next milestone: v0.2.0 evidence pack
+xsim: PASS 12/0
+post-synth timing: RTL synthesis-closed (WNS 0.052)
+post-impl timing recovery in progress; evidence pending
+bitstream: not generated
+KV260 board execution: no evidence
+Gemma 3N E4B runtime: no evidence
+throughput: no measurement
 ```
 
-**Current status:** RTL alpha · timing closure and full runtime bring-up in progress.
+**Current status:** RTL synthesis-closed (WNS 0.052); post-impl timing recovery in progress; evidence pending.
 
 This repo is the **bare-metal Kria KV260 implementation** of the
 **pccx v002** NPU architecture. It hosts an early SystemVerilog RTL and
@@ -23,9 +25,10 @@ bare-metal driver source snapshot intended to close the loop between the
 pccx architecture specification, source-level RTL inspection, early
 verification setup, and planned KV260 bring-up.
 
-This is not a timing-closed production bitstream release — Vivado
-synthesis, trace-driven verification, and full Gemma 3N E4B application
-wiring are still in progress or planned.
+This is not a production bitstream release. xsim and RTL synthesis
+evidence are present; post-impl timing recovery, bitstream generation,
+board execution, and full Gemma 3N E4B application wiring remain in
+progress or pending.
 
 > ### Start with the architecture docs
 >
@@ -44,9 +47,9 @@ Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profi
 ## Project status
 
 **Public alpha** — `v0.1.0-alpha` is published as a prerelease. Core
-RTL and ISA are stable; verification and KV260 bring-up are in
-progress. This is not a timing-closed bitstream release. Feedback and
-issues are welcome.
+RTL and ISA are available; verification and KV260 bring-up are in
+progress. This is not a bitstream release. Feedback and issues are
+welcome.
 
 | Entry point | Link |
 | --- | --- |
@@ -258,8 +261,8 @@ This repository hosts the RTL for **both** active tracks. As of
 
 | Track | Target model | Planned target | Horizon | Shared RTL assets |
 |-------|-------------|------|---------|-------------------|
-| **v002 Extended** (this repo, `main`) | Gemma 3N E4B | **20 tok/s** target, evidence-gated | Week 1–49 | sparse weight fetcher (Phase G), EAGLE draft/verify dispatch (Phase H+), SSD scheduler (Phase I), tree mask generator (Phase J) |
-| **v003** (future branch) | Gemma 4 E4B | **12–15 tok/s** target | Week 16–52 (parallel) | reuses v002 Phase G/H/I/J modules with hidden/layer/KV-head re-parameterization |
+| **v002 Extended** (this repo, `main`) | Gemma 3N E4B | Throughput target, evidence pending | Week 1–49 | sparse weight fetcher (Phase G), EAGLE draft/verify dispatch (Phase H+), SSD scheduler (Phase I), tree mask generator (Phase J) |
+| **v003** (future branch) | Gemma 4 E4B | Throughput target TBD | Week 16–52 (parallel) | reuses v002 Phase G/H/I/J modules with hidden/layer/KV-head re-parameterization |
 
 - v002 freeze → snapshotted into `pccx/codes/v002/` via the pccx
   version-cutover workflow (`tools/freeze_active.sh`).

--- a/docs/GEMMA3N_HANDOFF.md
+++ b/docs/GEMMA3N_HANDOFF.md
@@ -116,7 +116,7 @@ Use:
 Avoid:
 
 - wording that presents Gemma 3N E4B board execution as complete
-- wording that presents KV260 inference as proven without logs
+- wording that presents board inference as proven without logs
 - throughput wording without tied evidence
 - production-readiness wording
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,6 @@ Pages, bilingual EN / KO).
 | `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)               |
 | `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
 | `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
-| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)              |
+| *(new)* target-model mapping here | [Gemma 3N on pccx v002 execution](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)              |
 
 For the Korean mirror, swap `/en/` for `/ko/` in any of the links above.

--- a/docs/RELEASE_EVIDENCE_CHECKLIST.md
+++ b/docs/RELEASE_EVIDENCE_CHECKLIST.md
@@ -73,7 +73,7 @@ date: 2026-04-20, design: NPU_top, device: xck26-sfvc784-2LV-c).
 - [ ] Utilization post-implementation recorded
 - [ ] Clock interaction post-implementation recorded
 - [ ] Critical path summary noted in release notes
-- [ ] Bitstream generated (`.bit` not committed to git — attach to GitHub
+- [ ] Bitstream evidence recorded (`.bit` not committed to git — attach to GitHub
       Release or record SHA + generation command)
 
 ---

--- a/docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md
+++ b/docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Connection to board smoke:
 
 Not yet verified by this template:
 
-- KV260 NPU inference.
+- KV260 NPU execution.
 - Gemma 3N E4B hardware execution.
-- 20 tok/s throughput.
+- Measured throughput.
 - Timing closure.

--- a/docs/evidence/v002/full_system_diagnosis.md
+++ b/docs/evidence/v002/full_system_diagnosis.md
@@ -1,0 +1,117 @@
+# v002 full-system diagnosis before next synth
+
+State: `IMPL_TIMING_NOT_CLEAN`.
+
+This note records the static/system pass before the next expensive Vivado run. It intentionally does not claim timing closure, bitstream readiness, KV260 execution, Gemma 3N E4B hardware execution, or measured throughput.
+
+## Top/module hierarchy
+
+The OOC synthesis top is `NPU_top`. `npu_core_wrapper` is a packaging shim for a future block-design flow and is not the current synthesis top.
+
+Main hierarchy:
+
+- `NPU_top`
+- `npu_controller_top` -> AXI-Lite frontend and `ctrl_npu_decoder`
+- `Global_Scheduler` -> ISA body to GEMM/GEMV/MEM/CVO uops
+- `mem_dispatcher` -> shape RAM, LOAD/MEMSET descriptor generation, L2/ACP/CVO boundary
+- `mem_GLOBAL_cache` -> ACP CDC, L2 URAM, ACP/NPU FSMs
+- `mem_L2_cache_fmap` -> XPM UltraRAM true dual-port memory
+- `mem_CVO_stream_bridge` -> 128-bit L2 words to 16-bit CVO stream and result writeback
+- `preprocess_fmap` -> L2 AXIS stream to BF16/fixed fmap broadcast
+- `GEMM_systolic_top`, `GEMV_top`, `CVO_top` -> compute engines
+
+## Data movement map
+
+Program intent enters through AXI-Lite, is decoded by `ctrl_npu_decoder`, and is translated by `Global_Scheduler` into one-cycle uop pulses. The memory path resolves shape pointers in `mem_dispatcher`, converts element dimensions to 128-bit L2 word ranges, and queues ACP or NPU descriptors through `mem_u_operation_queue`.
+
+Major paths:
+
+- Host to L2: AXIS ACP input -> `mem_BUFFER` CDC -> `mem_GLOBAL_cache` port A -> `mem_L2_cache_fmap`.
+- L2 to host: `mem_L2_cache_fmap` port A -> `mem_BUFFER` CDC -> AXIS ACP result.
+- L2 to GEMM/GEMV fmap: `mem_GLOBAL_cache` port B -> `M_AXIS_L1_FMAP` -> `preprocess_fmap`.
+- L2 to CVO and back: `mem_CVO_stream_bridge` owns direct port-B address/write/data while busy, streams BF16 elements into `CVO_top`, buffers results, and writes 128-bit words back to L2.
+
+## Clock/reset assumptions
+
+- Core clock target is 400 MHz (`core_clk`, 2.500 ns).
+- AXI clock target is 250 MHz (`axi_clk`, 4.000 ns).
+- `rst_n_core` and `rst_axi_n` are active-low.
+- `i_clear` is propagated through the controller, preprocessing, GEMM, and CVO paths.
+- The MEM subtree currently resets from `rst_n_core`/`rst_axi_n`; `mem_u_operation_queue` already documents that its optional counters do not soft-clear until `i_clear` is propagated through this subtree.
+
+## Filelist/script/constraint alignment
+
+Static filelist checks found:
+
+- No missing entries in `hw/vivado/filelist.f`.
+- No unlisted RTL `.sv` files under `hw/rtl`.
+- No duplicate module definitions among `hw/rtl` and `hw/vivado` SystemVerilog modules.
+- `NPU_top` remains the OOC synthesis top in `hw/vivado/synth.tcl`.
+- `top-status` / `top-bitstream` are explicit full-top flow gates and do not turn OOC route evidence into a KV260 bitstream claim.
+
+## Library reuse findings
+
+Reusable components present and in use:
+
+- `bf16_math_pkg` for BF16 helpers used by CVO and top-level imports.
+- `algorithms_pkg`, `IF_queue`, and `QUEUE` for AXI-Lite command queue plumbing.
+- `isa_pkg` / ISA subpackages for uop and instruction field types.
+- `mem_pkg`, `device_pkg`, and `vec_core_pkg` for architecture constants and typed boundaries.
+- Xilinx XPM FIFO/RAM primitives for CDC FIFOs, operation queues, result FIFO, and L2 URAM.
+
+No new arithmetic helper RTL was added in this pass. The immediate fix reused the existing deep memory boundary instead of introducing a wrapper.
+
+## Static bug risks found and fixed
+
+Finding: `mem_dispatcher` had a CVO direct L2 port-B mux (`cvo_l2_*` / `final_npu_*`) but only muxed write data reached `mem_GLOBAL_cache`; the muxed write-enable and address were not connected to `mem_L2_cache_fmap`. This meant the CVO bridge could compute L2 read/write addresses without the URAM port-B wrapper seeing them.
+
+Fix: `mem_GLOBAL_cache` now exposes an explicit `IN_npu_direct_*` port-B owner boundary. `mem_dispatcher` drives those signals from `mem_CVO_stream_bridge` while `cvo_bridge_busy` is asserted. The local NPU FSM is held while direct ownership is active.
+
+Coverage: `tb_mem_dispatcher_shape_lookup` now checks that a CVO uop drives the URAM port-B address/write-enable boundary.
+
+Finding from the single controlled synth re-entry: the direct boundary fix made the CVO bridge read-address adder visible to the URAM cascade address path. The current post-synth report for that intermediate tree shows WNS `-0.385 ns`, TNS `-34.307 ns`, with the top path from `mem_CVO_stream_bridge.rd_word_cnt` through `rd_base + rd_word_cnt` into `mem_L2_cache_fmap` port-B address.
+
+Fix after that report: `mem_CVO_stream_bridge` now registers the L2 read command address (`rd_word_addr` / `rd_word_valid`) before driving the URAM port-B address. This preserves the external CVO stream contract while moving the read-address add off the URAM input cycle. This later fix has xsim coverage but has not had a second synth run in this batch, to avoid a synth/fail loop.
+
+## Timing-risk classes
+
+Current report-backed risks:
+
+- `mem_CVO_stream_bridge` read-address to L2 URAM port-B: post-synth OOC WNS `-0.385 ns`, TNS `-34.307 ns` on the intermediate direct-boundary tree. A registered address cut was added after this report; next synth must verify it.
+- `mem_dispatcher` shape/word-count DSP-to-DSP path: previous post-impl OOC WNS `-0.009 ns`, TNS `-0.273 ns`. That implementation report predates this batch's RTL changes and must be treated as stale.
+- CVO BF16/SFU paths: previously reduced through explicit pipeline cuts; not the current top failing class.
+- L2 URAM cascade/readout path: previously top failing class; now displaced by descriptor arithmetic.
+- Clock fanout: current top path report shows high `clk_core` fanout, but this is not a user RTL bug by itself.
+- Full-top uncertainty: current implementation evidence is OOC route only, so full KV260 clocking/BD/partpin effects remain unknown.
+
+Deferred timing action: run one controlled synth on the final diagnosed tree. If the registered CVO read-address cut closes post-synth timing, then implementation can revisit the shape-word arithmetic path. If it does not, inspect the new top path before editing.
+
+## Evidence coverage
+
+Current regression covers:
+
+- Shape constant RAM.
+- `mem_dispatcher` shape lookup and CVO direct L2 port-B ownership smoke.
+- GEMM pack/sign recovery, weight dispatch, fmap stagger, result normalization, result pack.
+- BF16 barrel shifter.
+- Decoder and runtime smoke program path through decoder/scheduler.
+- CVO SFU smoke for reduce sum, GELU, EXP, RECIP, SCALE.
+- Memory operation queue.
+
+Coverage gaps that remain acceptable for this PR:
+
+- Full CVO vector read/compute/writeback with initialized L2 contents.
+- Full `NPU_top` AXI/AXIS end-to-end hardware traffic.
+- Full KV260 block design and bitstream flow.
+- Board execution, Gemma runtime, and throughput measurement.
+
+## Current blockers
+
+- The latest post-synth report was generated before the final registered CVO read-address cut and is not timing-clean for that intermediate tree.
+- OOC post-impl timing remains not closed in the existing report, and that post-impl report is stale relative to this batch's RTL changes.
+- Full top-level block design script is missing.
+- Full top-level implementation has not run.
+- Bitstream is not generated.
+- KV260 board execution evidence is unavailable.
+- Gemma 3N E4B hardware runtime evidence is unavailable.
+- Measured throughput evidence is unavailable.

--- a/docs/internal/kv260_gemma3n_e4b_hardware_handoff.md
+++ b/docs/internal/kv260_gemma3n_e4b_hardware_handoff.md
@@ -335,7 +335,7 @@ owner is not surprised when the next clean-host synth surfaces them.
   and `drc_post_synth.rpt` before promoting to impl.
 - The wrapper change is signal-level only — no behavioural delta on
   `NPU_top`. The TB suite is the regression evidence (7/7 PASS).
-- Do not claim KV260 inference success or timing closure unless the
+- Do not claim board inference success or timing closure unless the
   board run logs prove it. Until §5 items land, the public alpha
   scope statement (“FPGA bring-up in progress, no production claims”)
   is the only honest description.

--- a/docs/internal/stage_c_completion_notes.md
+++ b/docs/internal/stage_c_completion_notes.md
@@ -18,7 +18,7 @@ Per the Stage C decisions memo:
 - **Out of scope** (hard limits):
   - No FPGA RTL functional changes.
   - No top-level interface changes.
-  - No KV260 inference claims.
+  - No board inference claims.
   - No timing-closed claims.
   - No release / tag creation.
 
@@ -230,7 +230,7 @@ throughout.
 This batch did **not** touch:
 
 - Release tags (no v0.1.1-alpha or anything similar).
-- README claims about FPGA stable / timing-closed / KV260 inference.
+- README claims about FPGA stable / timing-closed / board inference.
 - The `docs/RELEASE_EVIDENCE_CHECKLIST.md` content.
 
 The internal docs added under `docs/internal/` describe engineering

--- a/hw/constraints/pccx_timing.xdc
+++ b/hw/constraints/pccx_timing.xdc
@@ -31,17 +31,20 @@ set_clock_groups -asynchronous \
 # ---------------------------------------------------------------------------
 # Any path into the first flop of a reset bridge is inherently async.
 # Mark those as false paths so they don't inflate the WNS report.
-set_false_path -to [get_cells -hier -filter {NAME =~ */u_reset_sync*/sync_reg_reg[0]}]
+set_false_path -quiet \
+    -to [get_cells -quiet -hier -filter {NAME =~ */u_reset_sync*/sync_reg_reg[0]}]
 
 # ---------------------------------------------------------------------------
 # Asynchronous FIFO flag paths
 # ---------------------------------------------------------------------------
 # Xilinx XPM_FIFO_ASYNC instances handle their own meta-stability; mark
 # the gray-coded pointer crossings as async.
-set_false_path -from [get_cells -hier -filter {NAME =~ */wr_pntr_gray_reg*}] \
-               -to   [get_cells -hier -filter {NAME =~ */wr_pntr_gray_sync_reg*}]
-set_false_path -from [get_cells -hier -filter {NAME =~ */rd_pntr_gray_reg*}] \
-               -to   [get_cells -hier -filter {NAME =~ */rd_pntr_gray_sync_reg*}]
+set_false_path -quiet \
+    -from [get_cells -quiet -hier -filter {NAME =~ */wr_pntr_gray_reg*}] \
+    -to   [get_cells -quiet -hier -filter {NAME =~ */wr_pntr_gray_sync_reg*}]
+set_false_path -quiet \
+    -from [get_cells -quiet -hier -filter {NAME =~ */rd_pntr_gray_reg*}] \
+    -to   [get_cells -quiet -hier -filter {NAME =~ */rd_pntr_gray_sync_reg*}]
 
 # ---------------------------------------------------------------------------
 # Multi-cycle paths on the accumulator drain
@@ -50,9 +53,9 @@ set_false_path -from [get_cells -hier -filter {NAME =~ */rd_pntr_gray_reg*}] \
 # controller issues a flush (§2.2 of the Phase A audit). The drain path
 # from P-register to the result packer can tolerate multiple cycles
 # because the controller stalls new MACs during flush.
-set_multicycle_path -setup 2 \
-    -from [get_cells -hier -filter {NAME =~ */GEMM_dsp_unit*/DSP_HARD_BLOCK*}] \
-    -to   [get_cells -hier -filter {NAME =~ */u_mat_result_normalizer*}]
-set_multicycle_path -hold  1 \
-    -from [get_cells -hier -filter {NAME =~ */GEMM_dsp_unit*/DSP_HARD_BLOCK*}] \
-    -to   [get_cells -hier -filter {NAME =~ */u_mat_result_normalizer*}]
+set_multicycle_path -quiet -setup 2 \
+    -from [get_cells -quiet -hier -filter {NAME =~ */GEMM_dsp_unit*/DSP_HARD_BLOCK*}] \
+    -to   [get_cells -quiet -hier -filter {NAME =~ */u_mat_result_normalizer*}]
+set_multicycle_path -quiet -hold  1 \
+    -from [get_cells -quiet -hier -filter {NAME =~ */GEMM_dsp_unit*/DSP_HARD_BLOCK*}] \
+    -to   [get_cells -quiet -hier -filter {NAME =~ */u_mat_result_normalizer*}]

--- a/hw/constraints/pccx_timing.xdc
+++ b/hw/constraints/pccx_timing.xdc
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # =============================================================================
 # pccx_timing.xdc — timing-only constraints for the pccx v002 NPU core.
 #

--- a/hw/rtl/CVO_CORE/CVO_cordic_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_cordic_unit.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GLOBAL_CONST.svh"
 
@@ -12,8 +14,8 @@ import bf16_math_pkg::*;
 // Internal fmt : Q4.12 signed fixed-point (16-bit). 1.0 = 0x1000 = 4096,
 //                π ≈ 0x3244 = 12868.
 // CORDIC gain K: 14 iterations ≈ 0.60725. Pre-baked into x0 = K * 4096 = 0x09B8.
-// Pipeline     : 16 clocks  (1 convert-in + 14 CORDIC + 1 convert-out).
-// Latency      : 16 cycles total.
+// Pipeline     : 17 clocks  (1 convert-in + 14 CORDIC + 2 convert-out).
+// Latency      : 17 cycles total.
 // Throughput   : 1 sin/cos pair per cycle in steady state.
 // Handshake    : Push-only; OUT_valid mirrors the input pipeline.
 // Reset state  : All pipeline registers cleared; OUT_valid = 0.
@@ -154,57 +156,76 @@ module CVO_cordic_unit (
     end
   endgenerate
 
-  // ===| Stage 15: Q4.12 → BF16 Conversion |=====================================
+  // ===| Stages 15-16: Q4.12 → BF16 Conversion |================================
   // cos result = cx[14], sin result = cy[14]
 
-  function automatic logic [15:0] q412_to_bf16(input logic signed [15:0] val);
-    automatic logic        sign_out;
-    automatic logic [14:0] mag;
-    automatic logic [ 3:0] leading;
-    automatic logic [ 7:0] exp_out;
-    automatic logic [ 6:0] mant_out;
+  typedef struct packed {
+    logic        sign;
+    logic [14:0] mag;
+    logic [ 3:0] leading;
+  } q412_pack_prep_t;
 
-    sign_out = val[15];
-    mag      = sign_out ? 15'(-$signed(val)) : 15'(val);
+  function automatic q412_pack_prep_t q412_prepare(input logic signed [15:0] val);
+    automatic q412_pack_prep_t prep;
+
+    prep.sign    = val[15];
+    prep.mag     = prep.sign ? 15'(-$signed(val)) : 15'(val);
+    prep.leading = 4'd0;
 
     // Find leading 1 position (bit 14 = highest in 15-bit magnitude)
-    leading = 4'd0;
     for (int b = 14; b >= 0; b--) begin
-      if (mag[b]) begin
-        leading = 4'(b);
+      if (prep.mag[b]) begin
+        prep.leading = 4'(b);
         break;
       end
     end
 
-    if (mag == 0) begin
+    return prep;
+  endfunction
+
+  function automatic logic [15:0] q412_pack_bf16(input q412_pack_prep_t prep);
+    automatic logic [ 7:0] exp_out;
+    automatic logic [ 6:0] mant_out;
+
+    if (prep.mag == 0) begin
       return 16'd0;
     end else begin
       // biased exponent: value_in_Q412 = mag * 2^(leading-12)
       // BF16 exponent bias = 127; real exp = leading - 12
-      exp_out = 8'd127 + leading - 8'd12;
+      exp_out = 8'd127 + prep.leading - 8'd12;
 
       // 7 mantissa bits below the leading 1
-      if (leading >= 7)
-        mant_out = mag[leading-1 -: 7];
+      if (prep.leading >= 7)
+        mant_out = prep.mag[prep.leading-1 -: 7];
       else
         // SV disallows variable part-selects, so shift the full magnitude
         // left to align its `leading` significant bits into the top 7
         // positions, then truncate to 7 bits.
-        mant_out = 7'(mag << (7 - leading));
+        mant_out = 7'(prep.mag << (7 - prep.leading));
 
-      return {sign_out, exp_out, mant_out};
+      return {prep.sign, exp_out, mant_out};
     end
   endfunction
 
+  q412_pack_prep_t sin_pack_prep;
+  q412_pack_prep_t cos_pack_prep;
+  logic            pack_valid;
+
   always_ff @(posedge clk) begin
     if (!rst_n) begin
+      sin_pack_prep <= '0;
+      cos_pack_prep <= '0;
+      pack_valid    <= 1'b0;
       OUT_cos_bf16 <= 16'd0;
       OUT_sin_bf16 <= 16'd0;
       OUT_valid    <= 1'b0;
     end else begin
-      OUT_valid    <= cv[14];
-      OUT_cos_bf16 <= q412_to_bf16(cx[14]);
-      OUT_sin_bf16 <= q412_to_bf16(cy[14]);
+      sin_pack_prep <= q412_prepare(cy[14]);
+      cos_pack_prep <= q412_prepare(cx[14]);
+      pack_valid    <= cv[14];
+      OUT_valid     <= pack_valid;
+      OUT_cos_bf16  <= q412_pack_bf16(cos_pack_prep);
+      OUT_sin_bf16  <= q412_pack_bf16(sin_pack_prep);
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  8 cycles  (Newton-Raphson, 1 step)
+//   RECIP      :  9 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  5 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -27,7 +27,7 @@ import bf16_math_pkg::*;
 // Reset state  : All per-op pipeline registers cleared; output mux silent.
 // Errors       : EXP overflow saturates to +inf (16'h7F80); EXP underflow → 0.
 // Counters     : none.
-// Protected    : Internals untouched (CLAUDE.md §6.2 — LUT math user-owned).
+// Ownership    : LUT math internals are timing-sensitive and kept local to this SFU.
 // ===============================================================================
 
 module CVO_sfu_unit (
@@ -367,12 +367,10 @@ module CVO_sfu_unit (
   logic        recip_s2a_zero;
   logic        recip_s2a_sign;
   logic [ 8:0] recip_s2a_esum;
-  logic [15:0] recip_s2a_mp;
+  logic [11:0] recip_s2a_mp_lo;
+  logic [11:0] recip_s2a_mp_hi;
   logic [15:0] recip_s2a_r0;
   logic        recip_s2a_out_sign;
-
-  logic [ 7:0] recip_s2a_er_wire;
-  logic [ 6:0] recip_s2a_mr_wire;
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
@@ -380,7 +378,8 @@ module CVO_sfu_unit (
       recip_s2a_zero     <= 1'b1;
       recip_s2a_sign     <= 1'b0;
       recip_s2a_esum     <= 9'd0;
-      recip_s2a_mp       <= 16'd0;
+      recip_s2a_mp_lo    <= 12'd0;
+      recip_s2a_mp_hi    <= 12'd0;
       recip_s2a_r0       <= 16'd0;
       recip_s2a_out_sign <= 1'b0;
     end else begin
@@ -388,19 +387,56 @@ module CVO_sfu_unit (
       recip_s2a_zero     <= (recip_s1_x[14:0] == 15'd0) || (recip_s1_r0[14:0] == 15'd0);
       recip_s2a_sign     <= recip_s1_x[15] ^ recip_s1_r0[15];
       recip_s2a_esum     <= {1'b0, recip_s1_x[14:7]} + {1'b0, recip_s1_r0[14:7]};
-      recip_s2a_mp       <= {1'b1, recip_s1_x[6:0]} * {1'b1, recip_s1_r0[6:0]};
+      recip_s2a_mp_lo    <= 12'({1'b1, recip_s1_x[6:0]} * recip_s1_r0[3:0]);
+      recip_s2a_mp_hi    <= 12'({1'b1, recip_s1_x[6:0]} * {1'b1, recip_s1_r0[6:4]});
       recip_s2a_r0       <= recip_s1_r0;
       recip_s2a_out_sign <= recip_s1_sign;
     end
   end
 
-  always_comb begin : comb_recip_xr0_pack
-    if (recip_s2a_mp[15]) begin
-      recip_s2a_er_wire = 8'(recip_s2a_esum - 9'd127 + 9'd1);
-      recip_s2a_mr_wire = recip_s2a_mp[14:8];
+  logic        recip_s2m_valid;
+  logic        recip_s2m_zero;
+  logic        recip_s2m_sign;
+  logic [ 8:0] recip_s2m_esum;
+  logic [15:0] recip_s2m_mp;
+  logic [15:0] recip_s2m_r0;
+  logic        recip_s2m_out_sign;
+
+  logic [15:0] recip_s2m_mp_wire;
+  logic [ 7:0] recip_s2m_er_wire;
+  logic [ 6:0] recip_s2m_mr_wire;
+
+  always_comb begin : comb_recip_xr0_partial_sum
+    recip_s2m_mp_wire = {4'd0, recip_s2a_mp_lo} + {recip_s2a_mp_hi, 4'd0};
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s2m_valid    <= 1'b0;
+      recip_s2m_zero     <= 1'b1;
+      recip_s2m_sign     <= 1'b0;
+      recip_s2m_esum     <= 9'd0;
+      recip_s2m_mp       <= 16'd0;
+      recip_s2m_r0       <= 16'd0;
+      recip_s2m_out_sign <= 1'b0;
     end else begin
-      recip_s2a_er_wire = 8'(recip_s2a_esum - 9'd127);
-      recip_s2a_mr_wire = recip_s2a_mp[13:7];
+      recip_s2m_valid    <= recip_s2a_valid;
+      recip_s2m_zero     <= recip_s2a_zero;
+      recip_s2m_sign     <= recip_s2a_sign;
+      recip_s2m_esum     <= recip_s2a_esum;
+      recip_s2m_mp       <= recip_s2m_mp_wire;
+      recip_s2m_r0       <= recip_s2a_r0;
+      recip_s2m_out_sign <= recip_s2a_out_sign;
+    end
+  end
+
+  always_comb begin : comb_recip_xr0_pack
+    if (recip_s2m_mp[15]) begin
+      recip_s2m_er_wire = 8'(recip_s2m_esum - 9'd127 + 9'd1);
+      recip_s2m_mr_wire = recip_s2m_mp[14:8];
+    end else begin
+      recip_s2m_er_wire = 8'(recip_s2m_esum - 9'd127);
+      recip_s2m_mr_wire = recip_s2m_mp[13:7];
     end
   end
 
@@ -416,10 +452,10 @@ module CVO_sfu_unit (
       recip_s2_r0    <= 16'd0;
       recip_s2_sign  <= 1'b0;
     end else begin
-      recip_s2_valid <= recip_s2a_valid;
-      recip_s2_xr0   <= recip_s2a_zero ? 16'd0 : {recip_s2a_sign, recip_s2a_er_wire, recip_s2a_mr_wire};
-      recip_s2_r0    <= recip_s2a_r0;
-      recip_s2_sign  <= recip_s2a_out_sign;
+      recip_s2_valid <= recip_s2m_valid;
+      recip_s2_xr0   <= recip_s2m_zero ? 16'd0 : {recip_s2m_sign, recip_s2m_er_wire, recip_s2m_mr_wire};
+      recip_s2_r0    <= recip_s2m_r0;
+      recip_s2_sign  <= recip_s2m_out_sign;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -17,7 +17,7 @@ import bf16_math_pkg::*;
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
 //   RECIP      :  6 cycles  (Newton-Raphson, 1 step)
-//   SCALE      :  3 cycles  (first input word = scalar, rest = data)
+//   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 19 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
@@ -527,19 +527,24 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| SCALE Pipeline (3 stages) |=============================================
+  // ===| SCALE Pipeline (4 stages) |=============================================
   // First element received = scalar (or 1/scalar if FLAG_RECIP_SCALE).
 
   logic        scale_scalar_loaded;
   logic [15:0] scale_scalar;
 
   logic        scale_s1_valid;
-  logic [15:0] scale_s1_product;
+  logic        scale_s1_zero;
+  logic        scale_s1_sign;
+  logic [ 8:0] scale_s1_esum;
+  logic [15:0] scale_s1_mp;
 
   logic        scale_s2_valid;
   logic [15:0] scale_s2_result;
 
   logic [15:0] scale_scalar_next_wire;
+  logic [ 7:0] scale_s1_er_wire;
+  logic [ 6:0] scale_s1_mr_wire;
 
   always_comb begin
     // Approximate 1/scalar for recip_scale mode: flip exponent + invert mantissa
@@ -553,7 +558,12 @@ module CVO_sfu_unit (
       scale_scalar_loaded <= 1'b0;
       scale_scalar        <= 16'd0;
       scale_s1_valid      <= 1'b0;
+      scale_s1_zero       <= 1'b1;
+      scale_s1_sign       <= 1'b0;
+      scale_s1_esum       <= 9'd0;
+      scale_s1_mp         <= 16'd0;
       scale_s2_valid      <= 1'b0;
+      scale_s2_result     <= 16'd0;
     end else begin
       if (IN_valid && IN_func == CVO_SCALE) begin
         if (!scale_scalar_loaded) begin
@@ -561,8 +571,11 @@ module CVO_sfu_unit (
           scale_scalar_loaded <= 1'b1;
           scale_s1_valid      <= 1'b0;
         end else begin
-          scale_s1_valid   <= 1'b1;
-          scale_s1_product <= bf16_mul(IN_data, scale_scalar);
+          scale_s1_valid <= 1'b1;
+          scale_s1_zero  <= (IN_data[14:0] == 15'd0) || (scale_scalar[14:0] == 15'd0);
+          scale_s1_sign  <= IN_data[15] ^ scale_scalar[15];
+          scale_s1_esum  <= {1'b0, IN_data[14:7]} + {1'b0, scale_scalar[14:7]};
+          scale_s1_mp    <= {1'b1, IN_data[6:0]} * {1'b1, scale_scalar[6:0]};
         end
       end else begin
         if (IN_func != CVO_SCALE) scale_scalar_loaded <= 1'b0;
@@ -570,7 +583,17 @@ module CVO_sfu_unit (
       end
 
       scale_s2_valid  <= scale_s1_valid;
-      scale_s2_result <= scale_s1_product;
+      scale_s2_result <= scale_s1_zero ? 16'd0 : {scale_s1_sign, scale_s1_er_wire, scale_s1_mr_wire};
+    end
+  end
+
+  always_comb begin : comb_scale_mul_pack
+    if (scale_s1_mp[15]) begin
+      scale_s1_er_wire = 8'(scale_s1_esum - 9'd127 + 9'd1);
+      scale_s1_mr_wire = scale_s1_mp[14:8];
+    end else begin
+      scale_s1_er_wire = 8'(scale_s1_esum - 9'd127);
+      scale_s1_mr_wire = scale_s1_mp[13:7];
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -675,6 +675,7 @@ module CVO_sfu_unit (
 
   logic [15:0] rsum_count;
   logic [15:0] rsum_accum;
+  logic        rsum_active;
   logic        rsum_out_valid;
   logic [15:0] rsum_out;
 
@@ -728,6 +729,7 @@ module CVO_sfu_unit (
     if (!rst_n || i_clear) begin
       rsum_count     <= 16'd0;
       rsum_accum     <= 16'd0;
+      rsum_active    <= 1'b0;
       rsum_out_valid <= 1'b0;
       rsum_out       <= 16'd0;
       rsum_in_valid  <= 1'b0;
@@ -760,13 +762,20 @@ module CVO_sfu_unit (
       if (IN_valid && (IN_func == CVO_REDUCE_SUM) && rsum_data_ready) begin
         rsum_in_valid <= 1'b1;
         rsum_in_data  <= IN_data;
-        rsum_in_last  <= (rsum_count == IN_length - 16'd1);
-        rsum_count    <= (rsum_count == IN_length - 16'd1) ? 16'd0 : rsum_count + 16'd1;
+        if (!rsum_active) begin
+          rsum_in_last <= (IN_length <= 16'd1);
+          rsum_count   <= (IN_length <= 16'd1) ? 16'd0 : (IN_length - 16'd1);
+          rsum_active  <= (IN_length > 16'd1);
+        end else begin
+          rsum_in_last <= (rsum_count == 16'd1);
+          rsum_count   <= rsum_count - 16'd1;
+          rsum_active  <= (rsum_count != 16'd1);
+        end
       end else begin
         rsum_in_valid <= 1'b0;
         if ((IN_func != CVO_REDUCE_SUM) && rsum_data_ready) begin
-          rsum_count <= 16'd0;
-          rsum_accum <= 16'd0;
+          rsum_active <= 1'b0;
+          rsum_accum  <= 16'd0;
         end
       end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 17 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 18 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -623,14 +623,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (17 stages) |=============================================
+  // ===| GELU Pipeline (18 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
   // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
   // conversion and Newton correction are split to keep 400 MHz boundaries real.
   // x is preserved in a 14-cycle delay chain.
 
-  localparam int GeluDelay = 14;
+  localparam int GeluDelay = 15;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -775,7 +775,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stages g7-g9: RECIP(1 + exp(-y)) = sigmoid
+  // Stages g7-g10: RECIP(1 + exp(-y)) = sigmoid
   logic        gelu_r1_valid;
   logic [15:0] gelu_r1_r0;
   logic [15:0] gelu_r1_x;
@@ -829,13 +829,47 @@ module CVO_sfu_unit (
 
   logic        gelu_r3_valid;
   logic [15:0] gelu_r3_sigmoid;
+  logic        gelu_r3m_valid;
+  logic        gelu_r3m_zero;
+  logic        gelu_r3m_sign;
+  logic [ 8:0] gelu_r3m_esum;
+  logic [15:0] gelu_r3m_mp;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_r3m_valid <= 1'b0;
+      gelu_r3m_zero  <= 1'b0;
+      gelu_r3m_sign  <= 1'b0;
+      gelu_r3m_esum  <= 9'd0;
+      gelu_r3m_mp    <= 16'd0;
+    end else begin
+      gelu_r3m_valid <= gelu_r3a_valid;
+      if (gelu_r3a_valid) begin
+        gelu_r3m_zero <= (gelu_r3a_r0[14:0] == 15'd0) ||
+                         (gelu_r3a_corr[14:0] == 15'd0);
+        gelu_r3m_sign <= gelu_r3a_r0[15] ^ gelu_r3a_corr[15];
+        gelu_r3m_esum <= {1'b0, gelu_r3a_r0[14:7]} +
+                         {1'b0, gelu_r3a_corr[14:7]};
+        gelu_r3m_mp   <= {1'b1, gelu_r3a_r0[6:0]} *
+                         {1'b1, gelu_r3a_corr[6:0]};
+      end
+    end
+  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       gelu_r3_valid <= 1'b0;
     end else begin
-      gelu_r3_valid   <= gelu_r3a_valid;
-      gelu_r3_sigmoid <= bf16_mul(gelu_r3a_r0, gelu_r3a_corr);
+      gelu_r3_valid <= gelu_r3m_valid;
+      if (gelu_r3m_valid) begin
+        if (gelu_r3m_zero) begin
+          gelu_r3_sigmoid <= 16'd0;
+        end else if (gelu_r3m_mp[15]) begin
+          gelu_r3_sigmoid <= {gelu_r3m_sign, 8'(gelu_r3m_esum - 9'd127 + 9'd1), gelu_r3m_mp[14:8]};
+        end else begin
+          gelu_r3_sigmoid <= {gelu_r3m_sign, 8'(gelu_r3m_esum - 9'd127), gelu_r3m_mp[13:7]};
+        end
+      end
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  5 cycles  (Newton-Raphson, 1 step)
+//   RECIP      :  6 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 19 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -335,7 +335,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| RECIP Pipeline (5 stages) |=============================================
+  // ===| RECIP Pipeline (6 stages) |=============================================
   // 1/x via 1 Newton-Raphson step: r1 = r0 * (2 - x*r0)
   // Initial estimate: exp flipped around 254, mantissa roughly inverted.
 
@@ -480,19 +480,50 @@ module CVO_sfu_unit (
   end
 
   logic        recip_s4_valid;
-  logic [15:0] recip_s4_result;
-
-  logic [15:0] recip_s3_mag_wire;
-  always_comb begin
-    recip_s3_mag_wire = bf16_mul(recip_s3_r0, recip_s3_corr);
-  end
+  logic        recip_s4_zero;
+  logic        recip_s4_sign;
+  logic [ 8:0] recip_s4_esum;
+  logic [15:0] recip_s4_mp;
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       recip_s4_valid <= 1'b0;
+      recip_s4_zero  <= 1'b1;
+      recip_s4_sign  <= 1'b0;
+      recip_s4_esum  <= 9'd0;
+      recip_s4_mp    <= 16'd0;
     end else begin
-      recip_s4_valid  <= recip_s3_valid;
-      recip_s4_result <= {recip_s3_sign, recip_s3_mag_wire[14:0]};
+      recip_s4_valid <= recip_s3_valid;
+      recip_s4_zero  <= (recip_s3_r0[14:0] == 15'd0) || (recip_s3_corr[14:0] == 15'd0);
+      recip_s4_sign  <= recip_s3_sign;
+      recip_s4_esum  <= {1'b0, recip_s3_r0[14:7]} + {1'b0, recip_s3_corr[14:7]};
+      recip_s4_mp    <= {1'b1, recip_s3_r0[6:0]} * {1'b1, recip_s3_corr[6:0]};
+    end
+  end
+
+  logic        recip_s5_valid;
+  logic [15:0] recip_s5_result;
+
+  logic [ 7:0] recip_s4_er_wire;
+  logic [ 6:0] recip_s4_mr_wire;
+
+  always_comb begin : comb_recip_mul_pack
+    if (recip_s4_mp[15]) begin
+      recip_s4_er_wire = 8'(recip_s4_esum - 9'd127 + 9'd1);
+      recip_s4_mr_wire = recip_s4_mp[14:8];
+    end else begin
+      recip_s4_er_wire = 8'(recip_s4_esum - 9'd127);
+      recip_s4_mr_wire = recip_s4_mp[13:7];
+    end
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s5_valid  <= 1'b0;
+      recip_s5_result <= 16'd0;
+    end else begin
+      recip_s5_valid  <= recip_s4_valid;
+      recip_s5_result <= recip_s4_zero ? 16'd0 : {recip_s4_sign, recip_s4_er_wire, recip_s4_mr_wire};
     end
   end
 
@@ -1102,8 +1133,8 @@ module CVO_sfu_unit (
         OUT_result_valid = gelu_out_valid;
       end
       CVO_RECIP: begin
-        OUT_result = recip_s4_result;
-        OUT_result_valid = recip_s4_valid;
+        OUT_result = recip_s5_result;
+        OUT_result_valid = recip_s5_valid;
       end
       CVO_SCALE: begin
         OUT_result = scale_s2_result;

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -12,12 +12,12 @@ import bf16_math_pkg::*;
 // Reset        : rst_n active-low; i_clear synchronous soft-clear.
 // BF16 layout  : {sign[15], exp[14:7], mant[6:0]}.
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
-//   EXP        :  4 cycles
+//   EXP        :  5 cycles
 //   SQRT       :  3 cycles
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (accumulates for IN_length cycles, then emits scalar)
-//   GELU       : 12 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 14 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready tied 1'b1 — combinational ready (sub-units
@@ -148,7 +148,7 @@ module CVO_sfu_unit (
     return v[6:0];
   endfunction
 
-  // ===| EXP Pipeline (4 stages) |===============================================
+  // ===| EXP Pipeline (5 stages) |===============================================
 
   // Stage 1 — unpack BF16
   logic       exp_s1_valid;
@@ -167,13 +167,11 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stage 2 — BF16 → Q8.7 fixed-point, then multiply by log2(e)
-  logic               exp_s2_valid;
-  logic        [ 8:0] exp_s2_n;  // integer part of x*log2e
-  logic        [ 6:0] exp_s2_frac;  // fractional 7-bit index for LUT
+  // Stage 2 — BF16 → Q8.7 fixed-point
+  logic               exp_s1f_valid;
+  logic signed [15:0] exp_s1f_xfixed;
 
   logic signed [15:0] exp_s1_xfixed_wire;  // Q8.7 signed
-  logic signed [23:0] exp_s1_y_wire;  // Q9.14: x*log2e
 
   always_comb begin : comb_exp_convert
     logic [15:0] mag;
@@ -185,20 +183,37 @@ module CVO_sfu_unit (
     else if (sh >= -7) mag = 16'({1'b1, exp_s1_mant, 7'b0} << (sh + 7));
     else mag = 16'({1'b1, exp_s1_mant, 7'b0} >> -(sh + 7));
     exp_s1_xfixed_wire = exp_s1_sign ? -$signed({1'b0, mag}) : $signed({1'b0, mag});
-    exp_s1_y_wire      = $signed(exp_s1_xfixed_wire) * $signed({1'b0, Log2EQ17});
   end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      exp_s1f_valid  <= 1'b0;
+      exp_s1f_xfixed <= '0;
+    end else begin
+      exp_s1f_valid  <= exp_s1_valid;
+      exp_s1f_xfixed <= exp_s1_xfixed_wire;
+    end
+  end
+
+  // Stage 3 — multiply by log2(e)
+  logic               exp_s2_valid;
+  logic        [ 8:0] exp_s2_n;  // integer part of x*log2e
+  logic        [ 6:0] exp_s2_frac;  // fractional 7-bit index for LUT
+
+  logic signed [23:0] exp_s1_y_wire;  // Q9.14: x*log2e
+  assign exp_s1_y_wire = $signed(exp_s1f_xfixed) * $signed({1'b0, Log2EQ17});
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       exp_s2_valid <= 1'b0;
     end else begin
-      exp_s2_valid <= exp_s1_valid;
+      exp_s2_valid <= exp_s1f_valid;
       exp_s2_n     <= 9'(exp_s1_y_wire[23:14]);
       exp_s2_frac  <= exp_s1_y_wire[13:7];
     end
   end
 
-  // Stage 3 — assemble output BF16
+  // Stage 4 — assemble output BF16
   logic        exp_s3_valid;
   logic [15:0] exp_s3_result;
 
@@ -425,12 +440,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (12 stages) |=============================================
+  // ===| GELU Pipeline (14 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
-  // Chain: MUL(1.702)[1] → NEG[0] → EXP[3] → ADD(1)[1] → RECIP[4] → MUL(x)[1] = 10+delay
-  // x is preserved in a 10-cycle delay chain.
+  // Chain: MUL(1.702)[1] -> NEG[0] -> EXP[3] -> ADD(1)[1] ->
+  // RECIP seed/Newton[4] -> MUL(x)[1]. The Newton correction and
+  // multiply are separated to keep the 400 MHz core timing boundary real.
+  // x is preserved in a 12-cycle delay chain.
 
-  localparam int GeluDelay = 10;
+  localparam int GeluDelay = 12;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -463,13 +480,15 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stages g3-g5: EXP(-y) — re-use combinational helpers, pipeline 3 stages
+  // Stages g3-g6: EXP(-y) — split BF16->fixed conversion from log2(e) multiply
   logic               gelu_e1_valid;
   logic        [ 8:0] gelu_e1_n;
   logic        [ 6:0] gelu_e1_frac;
 
+  logic               gelu_e0_valid;
+  logic signed [15:0] gelu_e0_xf;
   logic signed [15:0] gelu_g2_xf_wire;
-  logic signed [23:0] gelu_g2_y_wire;
+  logic signed [23:0] gelu_e0_y_wire;
 
   always_comb begin : comb_gelu_exp_convert
     logic [15:0] mag;
@@ -481,16 +500,27 @@ module CVO_sfu_unit (
     else if (sh >= -7) mag = 16'({1'b1, gelu_g2_neg_y[6:0], 7'b0} << (sh + 7));
     else mag = 16'({1'b1, gelu_g2_neg_y[6:0], 7'b0} >> -(sh + 7));
     gelu_g2_xf_wire = gelu_g2_neg_y[15] ? -$signed({1'b0, mag}) : $signed({1'b0, mag});
-    gelu_g2_y_wire  = $signed(gelu_g2_xf_wire) * $signed({1'b0, Log2EQ17});
   end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_e0_valid <= 1'b0;
+      gelu_e0_xf    <= '0;
+    end else begin
+      gelu_e0_valid <= gelu_g2_valid;
+      gelu_e0_xf    <= gelu_g2_xf_wire;
+    end
+  end
+
+  assign gelu_e0_y_wire = $signed(gelu_e0_xf) * $signed({1'b0, Log2EQ17});
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       gelu_e1_valid <= 1'b0;
     end else begin
-      gelu_e1_valid <= gelu_g2_valid;
-      gelu_e1_n     <= 9'(gelu_g2_y_wire[23:14]);
-      gelu_e1_frac  <= gelu_g2_y_wire[13:7];
+      gelu_e1_valid <= gelu_e0_valid;
+      gelu_e1_n     <= 9'(gelu_e0_y_wire[23:14]);
+      gelu_e1_frac  <= gelu_e0_y_wire[13:7];
     end
   end
 
@@ -562,6 +592,22 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        gelu_r3a_valid;
+  logic [15:0] gelu_r3a_r0;
+  logic [15:0] gelu_r3a_corr;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_r3a_valid <= 1'b0;
+      gelu_r3a_r0    <= 16'd0;
+      gelu_r3a_corr  <= 16'd0;
+    end else begin
+      gelu_r3a_valid <= gelu_r2_valid;
+      gelu_r3a_r0    <= gelu_r2_r0;
+      gelu_r3a_corr  <= bf16_add(Bf16Two, {1'b1, gelu_r2_xr0[14:0]});
+    end
+  end
+
   logic        gelu_r3_valid;
   logic [15:0] gelu_r3_sigmoid;
 
@@ -569,8 +615,8 @@ module CVO_sfu_unit (
     if (!rst_n || i_clear) begin
       gelu_r3_valid <= 1'b0;
     end else begin
-      gelu_r3_valid   <= gelu_r2_valid;
-      gelu_r3_sigmoid <= bf16_mul(gelu_r2_r0, bf16_add(Bf16Two, {1'b1, gelu_r2_xr0[14:0]}));
+      gelu_r3_valid   <= gelu_r3a_valid;
+      gelu_r3_sigmoid <= bf16_mul(gelu_r3a_r0, gelu_r3a_corr);
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -18,12 +18,12 @@ import bf16_math_pkg::*;
 //   SQRT       :  3 cycles
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
-//   REDUCE_SUM :  variable  (accumulates for IN_length cycles, then emits scalar)
+//   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 14 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
-// Handshake    : OUT_data_ready tied 1'b1 — combinational ready (sub-units
-//                are non-blocking pipelines).
+// Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
+//                local backpressure while the accumulator pipeline is busy.
 // Reset state  : All per-op pipeline registers cleared; output mux silent.
 // Errors       : EXP overflow saturates to +inf (16'h7F80); EXP underflow → 0.
 // Counters     : none.
@@ -418,26 +418,159 @@ module CVO_sfu_unit (
   logic        rsum_out_valid;
   logic [15:0] rsum_out;
 
+  logic        rsum_in_valid;
+  logic [15:0] rsum_in_data;
+  logic        rsum_in_last;
+
+  logic        rsum_a_valid;
+  logic        rsum_a_last;
+  logic        rsum_a_bypass;
+  logic [15:0] rsum_a_bypass_value;
+  logic        rsum_a_sa;
+  logic        rsum_a_sb;
+  logic [ 7:0] rsum_a_elarge;
+  logic [ 8:0] rsum_a_ma;
+  logic [ 8:0] rsum_a_mb;
+
+  logic        rsum_b_valid;
+  logic        rsum_b_last;
+  logic        rsum_b_bypass;
+  logic [15:0] rsum_b_bypass_value;
+  logic        rsum_b_sout;
+  logic [ 7:0] rsum_b_elarge;
+  logic [ 9:0] rsum_b_sum;
+
+  logic        rsum_p_valid;
+  logic        rsum_p_last;
+  logic [15:0] rsum_p_result;
+
+  logic        rsum_data_ready;
+  logic [15:0] rsum_packed_wire;
+
+  assign rsum_data_ready = !rsum_in_valid && !rsum_a_valid && !rsum_b_valid && !rsum_p_valid;
+
+  always_comb begin : comb_rsum_pack
+    rsum_packed_wire = 16'd0;
+    if (rsum_b_bypass) begin
+      rsum_packed_wire = rsum_b_bypass_value;
+    end else if (rsum_b_sum == 10'd0) begin
+      rsum_packed_wire = 16'd0;
+    end else if (rsum_b_sum[9]) begin
+      rsum_packed_wire = {rsum_b_sout, 8'(rsum_b_elarge + 8'd1), rsum_b_sum[9:3]};
+    end else if (rsum_b_sum[8]) begin
+      rsum_packed_wire = {rsum_b_sout, rsum_b_elarge, rsum_b_sum[8:2]};
+    end else begin
+      rsum_packed_wire = {rsum_b_sout, 8'(rsum_b_elarge - 8'd1), rsum_b_sum[7:1]};
+    end
+  end
+
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       rsum_count     <= 16'd0;
       rsum_accum     <= 16'd0;
       rsum_out_valid <= 1'b0;
       rsum_out       <= 16'd0;
+      rsum_in_valid  <= 1'b0;
+      rsum_in_data   <= 16'd0;
+      rsum_in_last   <= 1'b0;
+      rsum_a_valid   <= 1'b0;
+      rsum_a_last    <= 1'b0;
+      rsum_a_bypass  <= 1'b0;
+      rsum_a_bypass_value <= 16'd0;
+      rsum_a_sa      <= 1'b0;
+      rsum_a_sb      <= 1'b0;
+      rsum_a_elarge  <= 8'd0;
+      rsum_a_ma      <= 9'd0;
+      rsum_a_mb      <= 9'd0;
+      rsum_b_valid   <= 1'b0;
+      rsum_b_last    <= 1'b0;
+      rsum_b_bypass  <= 1'b0;
+      rsum_b_bypass_value <= 16'd0;
+      rsum_b_sout    <= 1'b0;
+      rsum_b_elarge  <= 8'd0;
+      rsum_b_sum     <= 10'd0;
+      rsum_p_valid   <= 1'b0;
+      rsum_p_last    <= 1'b0;
+      rsum_p_result  <= 16'd0;
     end else begin
       rsum_out_valid <= 1'b0;
-      if (IN_valid && IN_func == CVO_REDUCE_SUM) begin
-        rsum_count <= rsum_count + 16'd1;
-        rsum_accum <= bf16_add(rsum_accum, IN_data);
-        if (rsum_count == IN_length - 16'd1) begin
-          rsum_out       <= bf16_add(rsum_accum, IN_data);
-          rsum_out_valid <= 1'b1;
-          rsum_count     <= 16'd0;
-          rsum_accum     <= 16'd0;
+
+      // Stage 0: accept exactly one input while the dependent accumulator
+      // pipeline is empty. CVO_top already honors OUT_data_ready.
+      if (IN_valid && (IN_func == CVO_REDUCE_SUM) && rsum_data_ready) begin
+        rsum_in_valid <= 1'b1;
+        rsum_in_data  <= IN_data;
+        rsum_in_last  <= (rsum_count == IN_length - 16'd1);
+        rsum_count    <= (rsum_count == IN_length - 16'd1) ? 16'd0 : rsum_count + 16'd1;
+      end else begin
+        rsum_in_valid <= 1'b0;
+        if ((IN_func != CVO_REDUCE_SUM) && rsum_data_ready) begin
+          rsum_count <= 16'd0;
+          rsum_accum <= 16'd0;
         end
-      end else if (IN_func != CVO_REDUCE_SUM) begin
-        rsum_count <= 16'd0;
-        rsum_accum <= 16'd0;
+      end
+
+      // Stage 1: unpack, exponent-align mantissas, and carry zero bypasses.
+      rsum_a_valid <= rsum_in_valid;
+      rsum_a_last  <= rsum_in_last;
+      if (rsum_accum[14:0] == 0 || rsum_in_data[14:0] == 0) begin
+        rsum_a_bypass       <= 1'b1;
+        rsum_a_bypass_value <= (rsum_accum[14:0] == 0) ? rsum_in_data : rsum_accum;
+        rsum_a_sa           <= 1'b0;
+        rsum_a_sb           <= 1'b0;
+        rsum_a_elarge       <= 8'd0;
+        rsum_a_ma           <= 9'd0;
+        rsum_a_mb           <= 9'd0;
+      end else begin
+        rsum_a_bypass       <= 1'b0;
+        rsum_a_bypass_value <= 16'd0;
+        rsum_a_sa           <= rsum_accum[15];
+        rsum_a_sb           <= rsum_in_data[15];
+        if (rsum_accum[14:7] >= rsum_in_data[14:7]) begin
+          rsum_a_elarge <= rsum_accum[14:7];
+          rsum_a_ma     <= {1'b0, 1'b1, rsum_accum[6:0]};
+          rsum_a_mb     <= 9'({1'b0, 1'b1, rsum_in_data[6:0]} >> (rsum_accum[14:7] - rsum_in_data[14:7]));
+        end else begin
+          rsum_a_elarge <= rsum_in_data[14:7];
+          rsum_a_ma     <= 9'({1'b0, 1'b1, rsum_accum[6:0]} >> (rsum_in_data[14:7] - rsum_accum[14:7]));
+          rsum_a_mb     <= {1'b0, 1'b1, rsum_in_data[6:0]};
+        end
+      end
+
+      // Stage 2: signed mantissa add/subtract.
+      rsum_b_valid        <= rsum_a_valid;
+      rsum_b_last         <= rsum_a_last;
+      rsum_b_bypass       <= rsum_a_bypass;
+      rsum_b_bypass_value <= rsum_a_bypass_value;
+      rsum_b_elarge       <= rsum_a_elarge;
+      if (rsum_a_bypass) begin
+        rsum_b_sout <= 1'b0;
+        rsum_b_sum  <= 10'd0;
+      end else if (rsum_a_sa == rsum_a_sb) begin
+        rsum_b_sout <= rsum_a_sa;
+        rsum_b_sum  <= {1'b0, rsum_a_ma} + {1'b0, rsum_a_mb};
+      end else if (rsum_a_ma >= rsum_a_mb) begin
+        rsum_b_sout <= rsum_a_sa;
+        rsum_b_sum  <= {1'b0, rsum_a_ma} - {1'b0, rsum_a_mb};
+      end else begin
+        rsum_b_sout <= rsum_a_sb;
+        rsum_b_sum  <= {1'b0, rsum_a_mb} - {1'b0, rsum_a_ma};
+      end
+
+      // Stage 3: normalize and pack BF16.
+      rsum_p_valid  <= rsum_b_valid;
+      rsum_p_last   <= rsum_b_last;
+      rsum_p_result <= rsum_packed_wire;
+
+      // Stage 4: commit accumulator or emit final scalar.
+      if (rsum_p_valid) begin
+        if (rsum_p_last) begin
+          rsum_out       <= rsum_p_result;
+          rsum_out_valid <= 1'b1;
+          rsum_accum     <= 16'd0;
+        end else begin
+          rsum_accum <= rsum_p_result;
+        end
       end
     end
   end
@@ -637,7 +770,7 @@ module CVO_sfu_unit (
 
   // ===| Output Mux |============================================================
   always_comb begin
-    OUT_data_ready   = 1'b1;
+    OUT_data_ready   = (IN_func == CVO_REDUCE_SUM) ? rsum_data_ready : 1'b1;
     OUT_result       = 16'd0;
     OUT_result_valid = 1'b0;
     case (IN_func)

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  8 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 21 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -844,14 +844,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (21 stages) |=============================================
+  // ===| GELU Pipeline (22 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
-  // ADD(1)[1] -> RECIP seed/Newton[5] -> MUL(x)[1]. The BF16-to-fixed
-  // conversion and Newton correction are split to keep 400 MHz boundaries real.
-  // x is preserved in a 18-cycle delay chain.
+  // ADD(1)[2] -> RECIP seed/Newton[5] -> MUL(x)[1]. The BF16-to-fixed
+  // conversion, denominator add, and Newton correction are split to keep
+  // 400 MHz boundaries real. x is preserved in a 19-cycle delay chain.
 
-  localparam int GeluDelay = 18;
+  localparam int GeluDelay = 19;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -983,16 +983,72 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stage g6: 1 + exp(-y)
+  // Stages g6a-g6b: 1 + exp(-y)
+  logic        gelu_g6a_valid;
+  logic        gelu_g6a_bypass;
+  logic [15:0] gelu_g6a_bypass_value;
+  logic [ 7:0] gelu_g6a_elarge;
+  logic [ 8:0] gelu_g6a_ma;
+  logic [ 8:0] gelu_g6a_mb;
+
   logic        gelu_g6_valid;
   logic [15:0] gelu_g6_denom;
 
+  logic [ 9:0] gelu_g6_sum_wire;
+  logic [15:0] gelu_g6_pack_wire;
+
+  assign gelu_g6_sum_wire = {1'b0, gelu_g6a_ma} + {1'b0, gelu_g6a_mb};
+
+  always_comb begin : comb_gelu_denom_pack
+    gelu_g6_pack_wire = 16'd0;
+    if (gelu_g6a_bypass) begin
+      gelu_g6_pack_wire = gelu_g6a_bypass_value;
+    end else if (gelu_g6_sum_wire == 10'd0) begin
+      gelu_g6_pack_wire = 16'd0;
+    end else if (gelu_g6_sum_wire[9]) begin
+      gelu_g6_pack_wire = {1'b0, 8'(gelu_g6a_elarge + 8'd1), gelu_g6_sum_wire[9:3]};
+    end else if (gelu_g6_sum_wire[8]) begin
+      gelu_g6_pack_wire = {1'b0, gelu_g6a_elarge, gelu_g6_sum_wire[8:2]};
+    end else begin
+      gelu_g6_pack_wire = {1'b0, 8'(gelu_g6a_elarge - 8'd1), gelu_g6_sum_wire[7:1]};
+    end
+  end
+
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
-      gelu_g6_valid <= 1'b0;
+      gelu_g6a_valid        <= 1'b0;
+      gelu_g6a_bypass       <= 1'b0;
+      gelu_g6a_bypass_value <= 16'd0;
+      gelu_g6a_elarge       <= 8'd0;
+      gelu_g6a_ma           <= 9'd0;
+      gelu_g6a_mb           <= 9'd0;
+      gelu_g6_valid         <= 1'b0;
+      gelu_g6_denom         <= 16'd0;
     end else begin
-      gelu_g6_valid <= gelu_e2_valid;
-      gelu_g6_denom <= bf16_add(Bf16One, gelu_e2_expval);
+      gelu_g6a_valid <= gelu_e2_valid;
+      if (gelu_e2_expval[14:0] == 15'd0) begin
+        gelu_g6a_bypass       <= 1'b1;
+        gelu_g6a_bypass_value <= Bf16One;
+        gelu_g6a_elarge       <= 8'd0;
+        gelu_g6a_ma           <= 9'd0;
+        gelu_g6a_mb           <= 9'd0;
+      end else if (8'd127 >= gelu_e2_expval[14:7]) begin
+        gelu_g6a_bypass       <= 1'b0;
+        gelu_g6a_bypass_value <= 16'd0;
+        gelu_g6a_elarge       <= 8'd127;
+        gelu_g6a_ma           <= {1'b0, 1'b1, Bf16One[6:0]};
+        gelu_g6a_mb           <= 9'({1'b0, 1'b1, gelu_e2_expval[6:0]} >>
+                                     (8'd127 - gelu_e2_expval[14:7]));
+      end else begin
+        gelu_g6a_bypass       <= 1'b0;
+        gelu_g6a_bypass_value <= 16'd0;
+        gelu_g6a_elarge       <= gelu_e2_expval[14:7];
+        gelu_g6a_ma           <= 9'({1'b0, 1'b1, Bf16One[6:0]} >>
+                                     (gelu_e2_expval[14:7] - 8'd127));
+        gelu_g6a_mb           <= {1'b0, 1'b1, gelu_e2_expval[6:0]};
+      end
+      gelu_g6_valid <= gelu_g6a_valid;
+      gelu_g6_denom <= gelu_g6_pack_wire;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
+//   RECIP      :  5 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 18 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -335,7 +335,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| RECIP Pipeline (4 stages) |=============================================
+  // ===| RECIP Pipeline (5 stages) |=============================================
   // 1/x via 1 Newton-Raphson step: r1 = r0 * (2 - x*r0)
   // Initial estimate: exp flipped around 254, mantissa roughly inverted.
 
@@ -379,19 +379,103 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        recip_s3a_valid;
+  logic        recip_s3a_bypass;
+  logic [15:0] recip_s3a_bypass_value;
+  logic [ 7:0] recip_s3a_elarge;
+  logic [ 8:0] recip_s3a_ma;
+  logic [ 8:0] recip_s3a_mb;
+  logic [15:0] recip_s3a_r0;
+  logic        recip_s3a_sign;
+
+  logic [ 7:0] recip_corr_elarge_wire;
+  logic [ 8:0] recip_corr_ma_wire;
+  logic [ 8:0] recip_corr_mb_wire;
+
+  always_comb begin : comb_recip_corr_align
+    if (8'd128 >= recip_s2_xr0[14:7]) begin
+      recip_corr_elarge_wire = 8'd128;
+      recip_corr_ma_wire     = {1'b0, 1'b1, 7'd0};
+      recip_corr_mb_wire     = 9'({1'b0, 1'b1, recip_s2_xr0[6:0]} >>
+                                   (8'd128 - recip_s2_xr0[14:7]));
+    end else begin
+      recip_corr_elarge_wire = recip_s2_xr0[14:7];
+      recip_corr_ma_wire     = 9'({1'b0, 1'b1, 7'd0} >>
+                                   (recip_s2_xr0[14:7] - 8'd128));
+      recip_corr_mb_wire     = {1'b0, 1'b1, recip_s2_xr0[6:0]};
+    end
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s3a_valid        <= 1'b0;
+      recip_s3a_bypass       <= 1'b0;
+      recip_s3a_bypass_value <= 16'd0;
+      recip_s3a_elarge       <= 8'd0;
+      recip_s3a_ma           <= 9'd0;
+      recip_s3a_mb           <= 9'd0;
+      recip_s3a_r0           <= 16'd0;
+      recip_s3a_sign         <= 1'b0;
+    end else begin
+      recip_s3a_valid        <= recip_s2_valid;
+      recip_s3a_bypass       <= (recip_s2_xr0[14:0] == 15'd0);
+      recip_s3a_bypass_value <= Bf16Two;
+      recip_s3a_elarge       <= recip_corr_elarge_wire;
+      recip_s3a_ma           <= recip_corr_ma_wire;
+      recip_s3a_mb           <= recip_corr_mb_wire;
+      recip_s3a_r0           <= recip_s2_r0;
+      recip_s3a_sign         <= recip_s2_sign;
+    end
+  end
+
   logic        recip_s3_valid;
   logic [15:0] recip_s3_corr;
   logic [15:0] recip_s3_r0;
   logic        recip_s3_sign;
 
+  logic [15:0] recip_corr_packed_wire;
+  logic        recip_corr_sout_wire;
+  logic [ 9:0] recip_corr_sum_wire;
+
+  always_comb begin : comb_recip_corr_pack
+    if (recip_s3a_ma >= recip_s3a_mb) begin
+      recip_corr_sout_wire = 1'b0;
+      recip_corr_sum_wire  = {1'b0, recip_s3a_ma} - {1'b0, recip_s3a_mb};
+    end else begin
+      recip_corr_sout_wire = 1'b1;
+      recip_corr_sum_wire  = {1'b0, recip_s3a_mb} - {1'b0, recip_s3a_ma};
+    end
+
+    if (recip_s3a_bypass) begin
+      recip_corr_packed_wire = recip_s3a_bypass_value;
+    end else if (recip_corr_sum_wire == 10'd0) begin
+      recip_corr_packed_wire = 16'd0;
+    end else if (recip_corr_sum_wire[9]) begin
+      recip_corr_packed_wire = {recip_corr_sout_wire,
+                                8'(recip_s3a_elarge + 8'd1),
+                                recip_corr_sum_wire[9:3]};
+    end else if (recip_corr_sum_wire[8]) begin
+      recip_corr_packed_wire = {recip_corr_sout_wire,
+                                recip_s3a_elarge,
+                                recip_corr_sum_wire[8:2]};
+    end else begin
+      recip_corr_packed_wire = {recip_corr_sout_wire,
+                                8'(recip_s3a_elarge - 8'd1),
+                                recip_corr_sum_wire[7:1]};
+    end
+  end
+
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       recip_s3_valid <= 1'b0;
+      recip_s3_corr  <= 16'd0;
+      recip_s3_r0    <= 16'd0;
+      recip_s3_sign  <= 1'b0;
     end else begin
-      recip_s3_valid <= recip_s2_valid;
-      recip_s3_corr  <= bf16_add(Bf16Two, {1'b1, recip_s2_xr0[14:0]});
-      recip_s3_r0    <= recip_s2_r0;
-      recip_s3_sign  <= recip_s2_sign;
+      recip_s3_valid <= recip_s3a_valid;
+      recip_s3_corr  <= recip_corr_packed_wire;
+      recip_s3_r0    <= recip_s3a_r0;
+      recip_s3_sign  <= recip_s3a_sign;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -14,7 +14,7 @@ import bf16_math_pkg::*;
 // Reset        : rst_n active-low; i_clear synchronous soft-clear.
 // BF16 layout  : {sign[15], exp[14:7], mant[6:0]}.
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
-//   EXP        :  5 cycles
+//   EXP        :  7 cycles
 //   SQRT       :  3 cycles
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
@@ -150,7 +150,7 @@ module CVO_sfu_unit (
     return v[6:0];
   endfunction
 
-  // ===| EXP Pipeline (5 stages) |===============================================
+  // ===| EXP Pipeline (7 stages) |===============================================
 
   // Stage 1 — unpack BF16
   logic       exp_s1_valid;
@@ -162,42 +162,90 @@ module CVO_sfu_unit (
     if (!rst_n || i_clear) begin
       exp_s1_valid <= 1'b0;
     end else begin
-      exp_s1_valid <= IN_valid && (IN_func == CVO_EXP || IN_func == CVO_GELU);
+      exp_s1_valid <= IN_valid && (IN_func == CVO_EXP);
       exp_s1_sign  <= IN_data[15];
       exp_s1_exp   <= IN_data[14:7];
       exp_s1_mant  <= IN_data[6:0];
     end
   end
 
-  // Stage 2 — BF16 → Q8.7 fixed-point
+  // Stages 2-4 — BF16 → Q8.7 fixed-point.
+  // The conversion is intentionally split before the DSP multiply boundary:
+  // exponent classify, variable shift, and sign handling were previously one
+  // setup path into the DSP A input.
+  logic        exp_s1a_valid;
+  logic        exp_s1a_sign;
+  logic        exp_s1a_zero;
+  logic        exp_s1a_sat;
+  logic        exp_s1a_shift_left;
+  logic [ 4:0] exp_s1a_shift_amt;
+  logic [15:0] exp_s1a_mant_ext;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      exp_s1a_valid      <= 1'b0;
+      exp_s1a_sign       <= 1'b0;
+      exp_s1a_zero       <= 1'b0;
+      exp_s1a_sat        <= 1'b0;
+      exp_s1a_shift_left <= 1'b0;
+      exp_s1a_shift_amt  <= 5'd0;
+      exp_s1a_mant_ext   <= 16'd0;
+    end else begin
+      int sh;
+      sh = int'(exp_s1_exp) - 127;
+
+      exp_s1a_valid      <= exp_s1_valid;
+      exp_s1a_sign       <= exp_s1_sign;
+      exp_s1a_mant_ext   <= {1'b1, exp_s1_mant, 7'b0};
+      exp_s1a_zero       <= (exp_s1_exp == 8'd0) || (sh <= -23);
+      exp_s1a_sat        <= (sh >= 8);
+      exp_s1a_shift_left <= (sh >= -7);
+      if (sh >= -7) begin
+        exp_s1a_shift_amt <= 5'(sh + 7);
+      end else begin
+        exp_s1a_shift_amt <= 5'((-sh) - 7);
+      end
+    end
+  end
+
+  logic        exp_s1b_valid;
+  logic        exp_s1b_sign;
+  logic [15:0] exp_s1b_mag;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      exp_s1b_valid <= 1'b0;
+      exp_s1b_sign  <= 1'b0;
+      exp_s1b_mag   <= 16'd0;
+    end else begin
+      exp_s1b_valid <= exp_s1a_valid;
+      exp_s1b_sign  <= exp_s1a_sign;
+      if (exp_s1a_zero) begin
+        exp_s1b_mag <= 16'd0;
+      end else if (exp_s1a_sat) begin
+        exp_s1b_mag <= 16'h7FFF;
+      end else if (exp_s1a_shift_left) begin
+        exp_s1b_mag <= exp_s1a_mant_ext << exp_s1a_shift_amt;
+      end else begin
+        exp_s1b_mag <= exp_s1a_mant_ext >> exp_s1a_shift_amt;
+      end
+    end
+  end
+
   logic               exp_s1f_valid;
   logic signed [15:0] exp_s1f_xfixed;
-
-  logic signed [15:0] exp_s1_xfixed_wire;  // Q8.7 signed
-
-  always_comb begin : comb_exp_convert
-    logic [15:0] mag;
-    int          sh;
-    sh  = int'(exp_s1_exp) - 127;
-    mag = 16'd0;
-    if (exp_s1_exp == 8'd0) mag = 16'd0;
-    else if (sh >= 8) mag = 16'h7FFF;
-    else if (sh >= -7) mag = 16'({1'b1, exp_s1_mant, 7'b0} << (sh + 7));
-    else mag = 16'({1'b1, exp_s1_mant, 7'b0} >> -(sh + 7));
-    exp_s1_xfixed_wire = exp_s1_sign ? -$signed({1'b0, mag}) : $signed({1'b0, mag});
-  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       exp_s1f_valid  <= 1'b0;
       exp_s1f_xfixed <= '0;
     end else begin
-      exp_s1f_valid  <= exp_s1_valid;
-      exp_s1f_xfixed <= exp_s1_xfixed_wire;
+      exp_s1f_valid  <= exp_s1b_valid;
+      exp_s1f_xfixed <= exp_s1b_sign ? -$signed({1'b0, exp_s1b_mag}) : $signed({1'b0, exp_s1b_mag});
     end
   end
 
-  // Stage 3 — multiply by log2(e)
+  // Stage 5 — multiply by log2(e)
   logic               exp_s2_valid;
   logic        [ 8:0] exp_s2_n;  // integer part of x*log2e
   logic        [ 6:0] exp_s2_frac;  // fractional 7-bit index for LUT
@@ -215,7 +263,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stage 4 — assemble output BF16
+  // Stage 6 — assemble output BF16
   logic        exp_s3_valid;
   logic [15:0] exp_s3_result;
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  6 cycles  (Newton-Raphson, 1 step)
+//   RECIP      :  7 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 19 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -335,7 +335,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| RECIP Pipeline (6 stages) |=============================================
+  // ===| RECIP Pipeline (7 stages) |=============================================
   // 1/x via 1 Newton-Raphson step: r1 = r0 * (2 - x*r0)
   // Initial estimate: exp flipped around 254, mantissa roughly inverted.
 
@@ -363,6 +363,47 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        recip_s2a_valid;
+  logic        recip_s2a_zero;
+  logic        recip_s2a_sign;
+  logic [ 8:0] recip_s2a_esum;
+  logic [15:0] recip_s2a_mp;
+  logic [15:0] recip_s2a_r0;
+  logic        recip_s2a_out_sign;
+
+  logic [ 7:0] recip_s2a_er_wire;
+  logic [ 6:0] recip_s2a_mr_wire;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s2a_valid    <= 1'b0;
+      recip_s2a_zero     <= 1'b1;
+      recip_s2a_sign     <= 1'b0;
+      recip_s2a_esum     <= 9'd0;
+      recip_s2a_mp       <= 16'd0;
+      recip_s2a_r0       <= 16'd0;
+      recip_s2a_out_sign <= 1'b0;
+    end else begin
+      recip_s2a_valid    <= recip_s1_valid;
+      recip_s2a_zero     <= (recip_s1_x[14:0] == 15'd0) || (recip_s1_r0[14:0] == 15'd0);
+      recip_s2a_sign     <= recip_s1_x[15] ^ recip_s1_r0[15];
+      recip_s2a_esum     <= {1'b0, recip_s1_x[14:7]} + {1'b0, recip_s1_r0[14:7]};
+      recip_s2a_mp       <= {1'b1, recip_s1_x[6:0]} * {1'b1, recip_s1_r0[6:0]};
+      recip_s2a_r0       <= recip_s1_r0;
+      recip_s2a_out_sign <= recip_s1_sign;
+    end
+  end
+
+  always_comb begin : comb_recip_xr0_pack
+    if (recip_s2a_mp[15]) begin
+      recip_s2a_er_wire = 8'(recip_s2a_esum - 9'd127 + 9'd1);
+      recip_s2a_mr_wire = recip_s2a_mp[14:8];
+    end else begin
+      recip_s2a_er_wire = 8'(recip_s2a_esum - 9'd127);
+      recip_s2a_mr_wire = recip_s2a_mp[13:7];
+    end
+  end
+
   logic        recip_s2_valid;
   logic [15:0] recip_s2_xr0;
   logic [15:0] recip_s2_r0;
@@ -371,11 +412,14 @@ module CVO_sfu_unit (
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       recip_s2_valid <= 1'b0;
+      recip_s2_xr0   <= 16'd0;
+      recip_s2_r0    <= 16'd0;
+      recip_s2_sign  <= 1'b0;
     end else begin
-      recip_s2_valid <= recip_s1_valid;
-      recip_s2_xr0   <= bf16_mul(recip_s1_x, recip_s1_r0);
-      recip_s2_r0    <= recip_s1_r0;
-      recip_s2_sign  <= recip_s1_sign;
+      recip_s2_valid <= recip_s2a_valid;
+      recip_s2_xr0   <= recip_s2a_zero ? 16'd0 : {recip_s2a_sign, recip_s2a_er_wire, recip_s2a_mr_wire};
+      recip_s2_r0    <= recip_s2a_r0;
+      recip_s2_sign  <= recip_s2a_out_sign;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -1086,6 +1086,13 @@ module CVO_sfu_unit (
   logic [15:0] gelu_corr_packed_wire;
   logic        gelu_corr_sout_wire;
   logic [ 9:0] gelu_corr_sum_wire;
+  logic        gelu_r3ab_valid;
+  logic        gelu_r3ab_bypass;
+  logic [15:0] gelu_r3ab_bypass_value;
+  logic [ 7:0] gelu_r3ab_elarge;
+  logic        gelu_r3ab_sout;
+  logic [ 9:0] gelu_r3ab_sum;
+  logic [15:0] gelu_r3ab_r0;
 
   always_comb begin : comb_gelu_corr_pack
     if (gelu_r3aa_ma >= gelu_r3aa_mb) begin
@@ -1114,14 +1121,6 @@ module CVO_sfu_unit (
                                gelu_r3ab_sum[7:1]};
     end
   end
-
-  logic        gelu_r3ab_valid;
-  logic        gelu_r3ab_bypass;
-  logic [15:0] gelu_r3ab_bypass_value;
-  logic [ 7:0] gelu_r3ab_elarge;
-  logic        gelu_r3ab_sout;
-  logic [ 9:0] gelu_r3ab_sum;
-  logic [15:0] gelu_r3ab_r0;
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 14 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 16 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -575,14 +575,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (14 stages) |=============================================
+  // ===| GELU Pipeline (16 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
-  // Chain: MUL(1.702)[1] -> NEG[0] -> EXP[3] -> ADD(1)[1] ->
-  // RECIP seed/Newton[4] -> MUL(x)[1]. The Newton correction and
-  // multiply are separated to keep the 400 MHz core timing boundary real.
-  // x is preserved in a 12-cycle delay chain.
+  // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
+  // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
+  // conversion and Newton correction are split to keep 400 MHz boundaries real.
+  // x is preserved in a 14-cycle delay chain.
 
-  localparam int GeluDelay = 12;
+  localparam int GeluDelay = 14;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -615,35 +615,71 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stages g3-g6: EXP(-y) — split BF16->fixed conversion from log2(e) multiply
+  // Stages g3-g8: EXP(-y) — classify, shift, sign, then log2(e) multiply
   logic               gelu_e1_valid;
   logic        [ 8:0] gelu_e1_n;
   logic        [ 6:0] gelu_e1_frac;
 
+  logic        gelu_e0a_valid;
+  logic        gelu_e0a_sign;
+  logic        gelu_e0a_zero;
+  logic        gelu_e0a_sat;
+  logic        gelu_e0a_shift_left;
+  logic [ 4:0] gelu_e0a_shift_amt;
+  logic [15:0] gelu_e0a_mant_ext;
+
+  logic        gelu_e0b_valid;
+  logic        gelu_e0b_sign;
+  logic [15:0] gelu_e0b_mag;
+
   logic               gelu_e0_valid;
   logic signed [15:0] gelu_e0_xf;
-  logic signed [15:0] gelu_g2_xf_wire;
   logic signed [23:0] gelu_e0_y_wire;
-
-  always_comb begin : comb_gelu_exp_convert
-    logic [15:0] mag;
-    int          sh;
-    sh  = int'(gelu_g2_neg_y[14:7]) - 127;
-    mag = 16'd0;
-    if (gelu_g2_neg_y[14:7] == 8'd0) mag = 16'd0;
-    else if (sh >= 8) mag = 16'h7FFF;
-    else if (sh >= -7) mag = 16'({1'b1, gelu_g2_neg_y[6:0], 7'b0} << (sh + 7));
-    else mag = 16'({1'b1, gelu_g2_neg_y[6:0], 7'b0} >> -(sh + 7));
-    gelu_g2_xf_wire = gelu_g2_neg_y[15] ? -$signed({1'b0, mag}) : $signed({1'b0, mag});
-  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
-      gelu_e0_valid <= 1'b0;
-      gelu_e0_xf    <= '0;
+      gelu_e0a_valid      <= 1'b0;
+      gelu_e0a_sign       <= 1'b0;
+      gelu_e0a_zero       <= 1'b0;
+      gelu_e0a_sat        <= 1'b0;
+      gelu_e0a_shift_left <= 1'b0;
+      gelu_e0a_shift_amt  <= 5'd0;
+      gelu_e0a_mant_ext   <= 16'd0;
+      gelu_e0b_valid      <= 1'b0;
+      gelu_e0b_sign       <= 1'b0;
+      gelu_e0b_mag        <= 16'd0;
+      gelu_e0_valid       <= 1'b0;
+      gelu_e0_xf          <= '0;
     end else begin
-      gelu_e0_valid <= gelu_g2_valid;
-      gelu_e0_xf    <= gelu_g2_xf_wire;
+      // Stage e0a: classify the BF16 exponent and register shift controls.
+      automatic int sh;
+      sh = int'(gelu_g2_neg_y[14:7]) - 127;
+      gelu_e0a_valid      <= gelu_g2_valid;
+      gelu_e0a_sign       <= gelu_g2_neg_y[15];
+      gelu_e0a_mant_ext   <= {1'b0, 1'b1, gelu_g2_neg_y[6:0], 7'b0};
+      gelu_e0a_zero       <= (gelu_g2_neg_y[14:7] == 8'd0) || (sh <= -23);
+      gelu_e0a_sat        <= (sh >= 8);
+      gelu_e0a_shift_left <= (sh >= -7);
+      if (sh >= -7) gelu_e0a_shift_amt <= 5'(sh + 7);
+      else gelu_e0a_shift_amt <= 5'(-(sh + 7));
+
+      // Stage e0b: perform only the variable shift / saturation.
+      gelu_e0b_valid <= gelu_e0a_valid;
+      gelu_e0b_sign  <= gelu_e0a_sign;
+      if (gelu_e0a_zero) begin
+        gelu_e0b_mag <= 16'd0;
+      end else if (gelu_e0a_sat) begin
+        gelu_e0b_mag <= 16'h7FFF;
+      end else if (gelu_e0a_shift_left) begin
+        gelu_e0b_mag <= 16'(gelu_e0a_mant_ext << gelu_e0a_shift_amt);
+      end else begin
+        gelu_e0b_mag <= 16'(gelu_e0a_mant_ext >> gelu_e0a_shift_amt);
+      end
+
+      // Stage e0c: apply sign before the DSP multiply input boundary.
+      gelu_e0_valid <= gelu_e0b_valid;
+      gelu_e0_xf    <= gelu_e0b_sign ? -$signed({1'b0, gelu_e0b_mag}) :
+                                      $signed({1'b0, gelu_e0b_mag});
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -17,7 +17,7 @@ import bf16_math_pkg::*;
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
 //   RECIP      :  8 cycles  (Newton-Raphson, 1 step)
-//   SCALE      :  4 cycles  (first input word = scalar, rest = data)
+//   SCALE      :  5 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
@@ -601,11 +601,15 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| SCALE Pipeline (4 stages) |=============================================
+  // ===| SCALE Pipeline (5 stages) |=============================================
   // First element received = scalar (or 1/scalar if FLAG_RECIP_SCALE).
 
   logic        scale_scalar_loaded;
   logic [15:0] scale_scalar;
+
+  logic        scale_s0_valid;
+  logic [15:0] scale_s0_data;
+  logic [15:0] scale_s0_scalar;
 
   logic        scale_s1_valid;
   logic        scale_s1_zero;
@@ -631,6 +635,9 @@ module CVO_sfu_unit (
     if (!rst_n || i_clear) begin
       scale_scalar_loaded <= 1'b0;
       scale_scalar        <= 16'd0;
+      scale_s0_valid      <= 1'b0;
+      scale_s0_data       <= 16'd0;
+      scale_s0_scalar     <= 16'd0;
       scale_s1_valid      <= 1'b0;
       scale_s1_zero       <= 1'b1;
       scale_s1_sign       <= 1'b0;
@@ -643,18 +650,22 @@ module CVO_sfu_unit (
         if (!scale_scalar_loaded) begin
           scale_scalar        <= scale_scalar_next_wire;
           scale_scalar_loaded <= 1'b1;
-          scale_s1_valid      <= 1'b0;
+          scale_s0_valid      <= 1'b0;
         end else begin
-          scale_s1_valid <= 1'b1;
-          scale_s1_zero  <= (IN_data[14:0] == 15'd0) || (scale_scalar[14:0] == 15'd0);
-          scale_s1_sign  <= IN_data[15] ^ scale_scalar[15];
-          scale_s1_esum  <= {1'b0, IN_data[14:7]} + {1'b0, scale_scalar[14:7]};
-          scale_s1_mp    <= {1'b1, IN_data[6:0]} * {1'b1, scale_scalar[6:0]};
+          scale_s0_valid  <= 1'b1;
+          scale_s0_data   <= IN_data;
+          scale_s0_scalar <= scale_scalar;
         end
       end else begin
         if (IN_func != CVO_SCALE) scale_scalar_loaded <= 1'b0;
-        scale_s1_valid <= 1'b0;
+        scale_s0_valid <= 1'b0;
       end
+
+      scale_s1_valid <= scale_s0_valid;
+      scale_s1_zero  <= (scale_s0_data[14:0] == 15'd0) || (scale_s0_scalar[14:0] == 15'd0);
+      scale_s1_sign  <= scale_s0_data[15] ^ scale_s0_scalar[15];
+      scale_s1_esum  <= {1'b0, scale_s0_data[14:7]} + {1'b0, scale_s0_scalar[14:7]};
+      scale_s1_mp    <= {1'b1, scale_s0_data[6:0]} * {1'b1, scale_s0_scalar[6:0]};
 
       scale_s2_valid  <= scale_s1_valid;
       scale_s2_result <= scale_s1_zero ? 16'd0 : {scale_s1_sign, scale_s1_er_wire, scale_s1_mr_wire};

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  7 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 19 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 20 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -805,14 +805,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (19 stages) |=============================================
+  // ===| GELU Pipeline (20 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
   // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
   // conversion and Newton correction are split to keep 400 MHz boundaries real.
   // x is preserved in a 14-cycle delay chain.
 
-  localparam int GeluDelay = 16;
+  localparam int GeluDelay = 17;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -957,7 +957,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stages g7-g11: RECIP(1 + exp(-y)) = sigmoid
+  // Stages g7-g12: RECIP(1 + exp(-y)) = sigmoid
   logic        gelu_r1_valid;
   logic [15:0] gelu_r1_r0;
   logic [15:0] gelu_r1_x;
@@ -979,6 +979,44 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        gelu_r2a_valid;
+  logic        gelu_r2a_zero;
+  logic        gelu_r2a_sign;
+  logic [ 8:0] gelu_r2a_esum;
+  logic [15:0] gelu_r2a_mp;
+  logic [15:0] gelu_r2a_r0;
+
+  logic [ 7:0] gelu_r2a_er_wire;
+  logic [ 6:0] gelu_r2a_mr_wire;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_r2a_valid <= 1'b0;
+      gelu_r2a_zero  <= 1'b1;
+      gelu_r2a_sign  <= 1'b0;
+      gelu_r2a_esum  <= 9'd0;
+      gelu_r2a_mp    <= 16'd0;
+      gelu_r2a_r0    <= 16'd0;
+    end else begin
+      gelu_r2a_valid <= gelu_r1_valid;
+      gelu_r2a_zero  <= (gelu_r1_x[14:0] == 15'd0) || (gelu_r1_r0[14:0] == 15'd0);
+      gelu_r2a_sign  <= gelu_r1_x[15] ^ gelu_r1_r0[15];
+      gelu_r2a_esum  <= {1'b0, gelu_r1_x[14:7]} + {1'b0, gelu_r1_r0[14:7]};
+      gelu_r2a_mp    <= {1'b1, gelu_r1_x[6:0]} * {1'b1, gelu_r1_r0[6:0]};
+      gelu_r2a_r0    <= gelu_r1_r0;
+    end
+  end
+
+  always_comb begin : comb_gelu_xr0_pack
+    if (gelu_r2a_mp[15]) begin
+      gelu_r2a_er_wire = 8'(gelu_r2a_esum - 9'd127 + 9'd1);
+      gelu_r2a_mr_wire = gelu_r2a_mp[14:8];
+    end else begin
+      gelu_r2a_er_wire = 8'(gelu_r2a_esum - 9'd127);
+      gelu_r2a_mr_wire = gelu_r2a_mp[13:7];
+    end
+  end
+
   logic        gelu_r2_valid;
   logic [15:0] gelu_r2_xr0;
   logic [15:0] gelu_r2_r0;
@@ -986,10 +1024,12 @@ module CVO_sfu_unit (
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       gelu_r2_valid <= 1'b0;
+      gelu_r2_xr0   <= 16'd0;
+      gelu_r2_r0    <= 16'd0;
     end else begin
-      gelu_r2_valid <= gelu_r1_valid;
-      gelu_r2_xr0   <= bf16_mul(gelu_r1_x, gelu_r1_r0);
-      gelu_r2_r0    <= gelu_r1_r0;
+      gelu_r2_valid <= gelu_r2a_valid;
+      gelu_r2_xr0   <= gelu_r2a_zero ? 16'd0 : {gelu_r2a_sign, gelu_r2a_er_wire, gelu_r2a_mr_wire};
+      gelu_r2_r0    <= gelu_r2a_r0;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  4 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 16 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 17 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -623,7 +623,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (16 stages) |=============================================
+  // ===| GELU Pipeline (17 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
   // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
@@ -839,7 +839,34 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stage g10: x * sigmoid = GELU(x)
+  // Stages g10a-g10b: x * sigmoid = GELU(x)
+  logic        gelu_m1_valid;
+  logic        gelu_m1_zero;
+  logic        gelu_m1_sign;
+  logic [ 8:0] gelu_m1_esum;
+  logic [15:0] gelu_m1_mp;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_m1_valid <= 1'b0;
+      gelu_m1_zero  <= 1'b0;
+      gelu_m1_sign  <= 1'b0;
+      gelu_m1_esum  <= 9'd0;
+      gelu_m1_mp    <= 16'd0;
+    end else begin
+      gelu_m1_valid <= gelu_r3_valid;
+      if (gelu_r3_valid) begin
+        gelu_m1_zero <= (gelu_x_pipe[GeluDelay-1][14:0] == 15'd0) ||
+                        (gelu_r3_sigmoid[14:0] == 15'd0);
+        gelu_m1_sign <= gelu_x_pipe[GeluDelay-1][15] ^ gelu_r3_sigmoid[15];
+        gelu_m1_esum <= {1'b0, gelu_x_pipe[GeluDelay-1][14:7]} +
+                        {1'b0, gelu_r3_sigmoid[14:7]};
+        gelu_m1_mp   <= {1'b1, gelu_x_pipe[GeluDelay-1][6:0]} *
+                        {1'b1, gelu_r3_sigmoid[6:0]};
+      end
+    end
+  end
+
   logic        gelu_out_valid;
   logic [15:0] gelu_out;
 
@@ -847,8 +874,16 @@ module CVO_sfu_unit (
     if (!rst_n || i_clear) begin
       gelu_out_valid <= 1'b0;
     end else begin
-      gelu_out_valid <= gelu_r3_valid;
-      gelu_out       <= bf16_mul(gelu_x_pipe[GeluDelay-1], gelu_r3_sigmoid);
+      gelu_out_valid <= gelu_m1_valid;
+      if (gelu_m1_valid) begin
+        if (gelu_m1_zero) begin
+          gelu_out <= 16'd0;
+        end else if (gelu_m1_mp[15]) begin
+          gelu_out <= {gelu_m1_sign, 8'(gelu_m1_esum - 9'd127 + 9'd1), gelu_m1_mp[14:8]};
+        end else begin
+          gelu_out <= {gelu_m1_sign, 8'(gelu_m1_esum - 9'd127), gelu_m1_mp[13:7]};
+        end
+      end
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  9 cycles  (Newton-Raphson, 1 step)
+//   RECIP      : 10 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  6 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -335,7 +335,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| RECIP Pipeline (8 stages) |=============================================
+  // ===| RECIP Pipeline (10 cycles) |============================================
   // 1/x via 1 Newton-Raphson step: r1 = r0 * (2 - x*r0)
   // Initial estimate: exp flipped around 254, mantissa roughly inverted.
 
@@ -589,11 +589,42 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        recip_s4a_valid;
+  logic        recip_s4a_zero;
+  logic        recip_s4a_sign;
+  logic [ 8:0] recip_s4a_esum;
+  logic [11:0] recip_s4a_mp_lo;
+  logic [11:0] recip_s4a_mp_hi;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s4a_valid <= 1'b0;
+      recip_s4a_zero  <= 1'b1;
+      recip_s4a_sign  <= 1'b0;
+      recip_s4a_esum  <= 9'd0;
+      recip_s4a_mp_lo <= 12'd0;
+      recip_s4a_mp_hi <= 12'd0;
+    end else begin
+      recip_s4a_valid <= recip_s3_valid;
+      recip_s4a_zero  <= (recip_s3_r0[14:0] == 15'd0) || (recip_s3_corr[14:0] == 15'd0);
+      recip_s4a_sign  <= recip_s3_sign;
+      recip_s4a_esum  <= {1'b0, recip_s3_r0[14:7]} + {1'b0, recip_s3_corr[14:7]};
+      recip_s4a_mp_lo <= 12'({1'b1, recip_s3_r0[6:0]} * recip_s3_corr[3:0]);
+      recip_s4a_mp_hi <= 12'({1'b1, recip_s3_r0[6:0]} * {1'b1, recip_s3_corr[6:4]});
+    end
+  end
+
   logic        recip_s4_valid;
   logic        recip_s4_zero;
   logic        recip_s4_sign;
   logic [ 8:0] recip_s4_esum;
   logic [15:0] recip_s4_mp;
+
+  logic [15:0] recip_s4_mp_wire;
+
+  always_comb begin : comb_recip_final_partial_sum
+    recip_s4_mp_wire = {4'd0, recip_s4a_mp_lo} + {recip_s4a_mp_hi, 4'd0};
+  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
@@ -603,11 +634,11 @@ module CVO_sfu_unit (
       recip_s4_esum  <= 9'd0;
       recip_s4_mp    <= 16'd0;
     end else begin
-      recip_s4_valid <= recip_s3_valid;
-      recip_s4_zero  <= (recip_s3_r0[14:0] == 15'd0) || (recip_s3_corr[14:0] == 15'd0);
-      recip_s4_sign  <= recip_s3_sign;
-      recip_s4_esum  <= {1'b0, recip_s3_r0[14:7]} + {1'b0, recip_s3_corr[14:7]};
-      recip_s4_mp    <= {1'b1, recip_s3_r0[6:0]} * {1'b1, recip_s3_corr[6:0]};
+      recip_s4_valid <= recip_s4a_valid;
+      recip_s4_zero  <= recip_s4a_zero;
+      recip_s4_sign  <= recip_s4a_sign;
+      recip_s4_esum  <= recip_s4a_esum;
+      recip_s4_mp    <= recip_s4_mp_wire;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GLOBAL_CONST.svh"
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  5 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  3 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 18 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 19 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -707,14 +707,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (18 stages) |=============================================
+  // ===| GELU Pipeline (19 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
   // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
   // conversion and Newton correction are split to keep 400 MHz boundaries real.
   // x is preserved in a 14-cycle delay chain.
 
-  localparam int GeluDelay = 15;
+  localparam int GeluDelay = 16;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -859,7 +859,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // Stages g7-g10: RECIP(1 + exp(-y)) = sigmoid
+  // Stages g7-g11: RECIP(1 + exp(-y)) = sigmoid
   logic        gelu_r1_valid;
   logic [15:0] gelu_r1_r0;
   logic [15:0] gelu_r1_x;
@@ -895,9 +895,87 @@ module CVO_sfu_unit (
     end
   end
 
+  logic        gelu_r3aa_valid;
+  logic        gelu_r3aa_bypass;
+  logic [15:0] gelu_r3aa_bypass_value;
+  logic [ 7:0] gelu_r3aa_elarge;
+  logic [ 8:0] gelu_r3aa_ma;
+  logic [ 8:0] gelu_r3aa_mb;
+  logic [15:0] gelu_r3aa_r0;
+
+  logic [ 7:0] gelu_corr_elarge_wire;
+  logic [ 8:0] gelu_corr_ma_wire;
+  logic [ 8:0] gelu_corr_mb_wire;
+
+  always_comb begin : comb_gelu_corr_align
+    if (8'd128 >= gelu_r2_xr0[14:7]) begin
+      gelu_corr_elarge_wire = 8'd128;
+      gelu_corr_ma_wire     = {1'b0, 1'b1, 7'd0};
+      gelu_corr_mb_wire     = 9'({1'b0, 1'b1, gelu_r2_xr0[6:0]} >>
+                                  (8'd128 - gelu_r2_xr0[14:7]));
+    end else begin
+      gelu_corr_elarge_wire = gelu_r2_xr0[14:7];
+      gelu_corr_ma_wire     = 9'({1'b0, 1'b1, 7'd0} >>
+                                  (gelu_r2_xr0[14:7] - 8'd128));
+      gelu_corr_mb_wire     = {1'b0, 1'b1, gelu_r2_xr0[6:0]};
+    end
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_r3aa_valid        <= 1'b0;
+      gelu_r3aa_bypass       <= 1'b0;
+      gelu_r3aa_bypass_value <= 16'd0;
+      gelu_r3aa_elarge       <= 8'd0;
+      gelu_r3aa_ma           <= 9'd0;
+      gelu_r3aa_mb           <= 9'd0;
+      gelu_r3aa_r0           <= 16'd0;
+    end else begin
+      gelu_r3aa_valid        <= gelu_r2_valid;
+      gelu_r3aa_bypass       <= (gelu_r2_xr0[14:0] == 15'd0);
+      gelu_r3aa_bypass_value <= Bf16Two;
+      gelu_r3aa_elarge       <= gelu_corr_elarge_wire;
+      gelu_r3aa_ma           <= gelu_corr_ma_wire;
+      gelu_r3aa_mb           <= gelu_corr_mb_wire;
+      gelu_r3aa_r0           <= gelu_r2_r0;
+    end
+  end
+
   logic        gelu_r3a_valid;
   logic [15:0] gelu_r3a_r0;
   logic [15:0] gelu_r3a_corr;
+
+  logic [15:0] gelu_corr_packed_wire;
+  logic        gelu_corr_sout_wire;
+  logic [ 9:0] gelu_corr_sum_wire;
+
+  always_comb begin : comb_gelu_corr_pack
+    if (gelu_r3aa_ma >= gelu_r3aa_mb) begin
+      gelu_corr_sout_wire = 1'b0;
+      gelu_corr_sum_wire  = {1'b0, gelu_r3aa_ma} - {1'b0, gelu_r3aa_mb};
+    end else begin
+      gelu_corr_sout_wire = 1'b1;
+      gelu_corr_sum_wire  = {1'b0, gelu_r3aa_mb} - {1'b0, gelu_r3aa_ma};
+    end
+
+    if (gelu_r3aa_bypass) begin
+      gelu_corr_packed_wire = gelu_r3aa_bypass_value;
+    end else if (gelu_corr_sum_wire == 10'd0) begin
+      gelu_corr_packed_wire = 16'd0;
+    end else if (gelu_corr_sum_wire[9]) begin
+      gelu_corr_packed_wire = {gelu_corr_sout_wire,
+                               8'(gelu_r3aa_elarge + 8'd1),
+                               gelu_corr_sum_wire[9:3]};
+    end else if (gelu_corr_sum_wire[8]) begin
+      gelu_corr_packed_wire = {gelu_corr_sout_wire,
+                               gelu_r3aa_elarge,
+                               gelu_corr_sum_wire[8:2]};
+    end else begin
+      gelu_corr_packed_wire = {gelu_corr_sout_wire,
+                               8'(gelu_r3aa_elarge - 8'd1),
+                               gelu_corr_sum_wire[7:1]};
+    end
+  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
@@ -905,9 +983,9 @@ module CVO_sfu_unit (
       gelu_r3a_r0    <= 16'd0;
       gelu_r3a_corr  <= 16'd0;
     end else begin
-      gelu_r3a_valid <= gelu_r2_valid;
-      gelu_r3a_r0    <= gelu_r2_r0;
-      gelu_r3a_corr  <= bf16_add(Bf16Two, {1'b1, gelu_r2_xr0[14:0]});
+      gelu_r3a_valid <= gelu_r3aa_valid;
+      gelu_r3a_r0    <= gelu_r3aa_r0;
+      gelu_r3a_corr  <= gelu_corr_packed_wire;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -16,7 +16,7 @@ import bf16_math_pkg::*;
 // Pipelines    : Independent per-op pipelines, multiplexed at the output:
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
-//   RECIP      :  7 cycles  (Newton-Raphson, 1 step)
+//   RECIP      :  8 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 21 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
@@ -335,7 +335,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| RECIP Pipeline (7 stages) |=============================================
+  // ===| RECIP Pipeline (8 stages) |=============================================
   // 1/x via 1 Newton-Raphson step: r1 = r0 * (2 - x*r0)
   // Initial estimate: exp flipped around 254, mantissa roughly inverted.
 
@@ -480,6 +480,14 @@ module CVO_sfu_unit (
   logic [15:0] recip_corr_packed_wire;
   logic        recip_corr_sout_wire;
   logic [ 9:0] recip_corr_sum_wire;
+  logic        recip_s3b_valid;
+  logic        recip_s3b_bypass;
+  logic [15:0] recip_s3b_bypass_value;
+  logic [ 7:0] recip_s3b_elarge;
+  logic        recip_s3b_sout;
+  logic [ 9:0] recip_s3b_sum;
+  logic [15:0] recip_s3b_r0;
+  logic        recip_s3b_sign;
 
   always_comb begin : comb_recip_corr_pack
     if (recip_s3a_ma >= recip_s3a_mb) begin
@@ -490,22 +498,44 @@ module CVO_sfu_unit (
       recip_corr_sum_wire  = {1'b0, recip_s3a_mb} - {1'b0, recip_s3a_ma};
     end
 
-    if (recip_s3a_bypass) begin
-      recip_corr_packed_wire = recip_s3a_bypass_value;
-    end else if (recip_corr_sum_wire == 10'd0) begin
+    if (recip_s3b_bypass) begin
+      recip_corr_packed_wire = recip_s3b_bypass_value;
+    end else if (recip_s3b_sum == 10'd0) begin
       recip_corr_packed_wire = 16'd0;
-    end else if (recip_corr_sum_wire[9]) begin
-      recip_corr_packed_wire = {recip_corr_sout_wire,
-                                8'(recip_s3a_elarge + 8'd1),
-                                recip_corr_sum_wire[9:3]};
-    end else if (recip_corr_sum_wire[8]) begin
-      recip_corr_packed_wire = {recip_corr_sout_wire,
-                                recip_s3a_elarge,
-                                recip_corr_sum_wire[8:2]};
+    end else if (recip_s3b_sum[9]) begin
+      recip_corr_packed_wire = {recip_s3b_sout,
+                                8'(recip_s3b_elarge + 8'd1),
+                                recip_s3b_sum[9:3]};
+    end else if (recip_s3b_sum[8]) begin
+      recip_corr_packed_wire = {recip_s3b_sout,
+                                recip_s3b_elarge,
+                                recip_s3b_sum[8:2]};
     end else begin
-      recip_corr_packed_wire = {recip_corr_sout_wire,
-                                8'(recip_s3a_elarge - 8'd1),
-                                recip_corr_sum_wire[7:1]};
+      recip_corr_packed_wire = {recip_s3b_sout,
+                                8'(recip_s3b_elarge - 8'd1),
+                                recip_s3b_sum[7:1]};
+    end
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      recip_s3b_valid        <= 1'b0;
+      recip_s3b_bypass       <= 1'b0;
+      recip_s3b_bypass_value <= 16'd0;
+      recip_s3b_elarge       <= 8'd0;
+      recip_s3b_sout         <= 1'b0;
+      recip_s3b_sum          <= 10'd0;
+      recip_s3b_r0           <= 16'd0;
+      recip_s3b_sign         <= 1'b0;
+    end else begin
+      recip_s3b_valid        <= recip_s3a_valid;
+      recip_s3b_bypass       <= recip_s3a_bypass;
+      recip_s3b_bypass_value <= recip_s3a_bypass_value;
+      recip_s3b_elarge       <= recip_s3a_elarge;
+      recip_s3b_sout         <= recip_corr_sout_wire;
+      recip_s3b_sum          <= recip_corr_sum_wire;
+      recip_s3b_r0           <= recip_s3a_r0;
+      recip_s3b_sign         <= recip_s3a_sign;
     end
   end
 
@@ -516,10 +546,10 @@ module CVO_sfu_unit (
       recip_s3_r0    <= 16'd0;
       recip_s3_sign  <= 1'b0;
     end else begin
-      recip_s3_valid <= recip_s3a_valid;
+      recip_s3_valid <= recip_s3b_valid;
       recip_s3_corr  <= recip_corr_packed_wire;
-      recip_s3_r0    <= recip_s3a_r0;
-      recip_s3_sign  <= recip_s3a_sign;
+      recip_s3_r0    <= recip_s3b_r0;
+      recip_s3_sign  <= recip_s3b_sign;
     end
   end
 

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -19,7 +19,7 @@ import bf16_math_pkg::*;
 //   RECIP      :  7 cycles  (Newton-Raphson, 1 step)
 //   SCALE      :  4 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
-//   GELU       : 20 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
+//   GELU       : 21 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
 //                per IN_length elements.
 // Handshake    : OUT_data_ready is 1'b1 for streaming ops; REDUCE_SUM applies
@@ -805,14 +805,14 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| GELU Pipeline (20 stages) |=============================================
+  // ===| GELU Pipeline (21 stages) |=============================================
   // GELU(x) ≈ x * sigmoid(1.702*x),  sigmoid(y) = 1/(1+exp(-y))
   // Chain: MUL(1.702)[1] -> NEG[0] -> EXP convert[3] -> EXP lut[2] ->
-  // ADD(1)[1] -> RECIP seed/Newton[4] -> MUL(x)[1]. The BF16-to-fixed
+  // ADD(1)[1] -> RECIP seed/Newton[5] -> MUL(x)[1]. The BF16-to-fixed
   // conversion and Newton correction are split to keep 400 MHz boundaries real.
-  // x is preserved in a 14-cycle delay chain.
+  // x is preserved in a 18-cycle delay chain.
 
-  localparam int GeluDelay = 17;
+  localparam int GeluDelay = 18;
 
   logic [15:0] gelu_x_pipe   [GeluDelay];
 
@@ -1096,22 +1096,50 @@ module CVO_sfu_unit (
       gelu_corr_sum_wire  = {1'b0, gelu_r3aa_mb} - {1'b0, gelu_r3aa_ma};
     end
 
-    if (gelu_r3aa_bypass) begin
-      gelu_corr_packed_wire = gelu_r3aa_bypass_value;
-    end else if (gelu_corr_sum_wire == 10'd0) begin
+    if (gelu_r3ab_bypass) begin
+      gelu_corr_packed_wire = gelu_r3ab_bypass_value;
+    end else if (gelu_r3ab_sum == 10'd0) begin
       gelu_corr_packed_wire = 16'd0;
-    end else if (gelu_corr_sum_wire[9]) begin
-      gelu_corr_packed_wire = {gelu_corr_sout_wire,
-                               8'(gelu_r3aa_elarge + 8'd1),
-                               gelu_corr_sum_wire[9:3]};
-    end else if (gelu_corr_sum_wire[8]) begin
-      gelu_corr_packed_wire = {gelu_corr_sout_wire,
-                               gelu_r3aa_elarge,
-                               gelu_corr_sum_wire[8:2]};
+    end else if (gelu_r3ab_sum[9]) begin
+      gelu_corr_packed_wire = {gelu_r3ab_sout,
+                               8'(gelu_r3ab_elarge + 8'd1),
+                               gelu_r3ab_sum[9:3]};
+    end else if (gelu_r3ab_sum[8]) begin
+      gelu_corr_packed_wire = {gelu_r3ab_sout,
+                               gelu_r3ab_elarge,
+                               gelu_r3ab_sum[8:2]};
     end else begin
-      gelu_corr_packed_wire = {gelu_corr_sout_wire,
-                               8'(gelu_r3aa_elarge - 8'd1),
-                               gelu_corr_sum_wire[7:1]};
+      gelu_corr_packed_wire = {gelu_r3ab_sout,
+                               8'(gelu_r3ab_elarge - 8'd1),
+                               gelu_r3ab_sum[7:1]};
+    end
+  end
+
+  logic        gelu_r3ab_valid;
+  logic        gelu_r3ab_bypass;
+  logic [15:0] gelu_r3ab_bypass_value;
+  logic [ 7:0] gelu_r3ab_elarge;
+  logic        gelu_r3ab_sout;
+  logic [ 9:0] gelu_r3ab_sum;
+  logic [15:0] gelu_r3ab_r0;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      gelu_r3ab_valid        <= 1'b0;
+      gelu_r3ab_bypass       <= 1'b0;
+      gelu_r3ab_bypass_value <= 16'd0;
+      gelu_r3ab_elarge       <= 8'd0;
+      gelu_r3ab_sout         <= 1'b0;
+      gelu_r3ab_sum          <= 10'd0;
+      gelu_r3ab_r0           <= 16'd0;
+    end else begin
+      gelu_r3ab_valid        <= gelu_r3aa_valid;
+      gelu_r3ab_bypass       <= gelu_r3aa_bypass;
+      gelu_r3ab_bypass_value <= gelu_r3aa_bypass_value;
+      gelu_r3ab_elarge       <= gelu_r3aa_elarge;
+      gelu_r3ab_sout         <= gelu_corr_sout_wire;
+      gelu_r3ab_sum          <= gelu_corr_sum_wire;
+      gelu_r3ab_r0           <= gelu_r3aa_r0;
     end
   end
 
@@ -1121,8 +1149,8 @@ module CVO_sfu_unit (
       gelu_r3a_r0    <= 16'd0;
       gelu_r3a_corr  <= 16'd0;
     end else begin
-      gelu_r3a_valid <= gelu_r3aa_valid;
-      gelu_r3a_r0    <= gelu_r3aa_r0;
+      gelu_r3a_valid <= gelu_r3ab_valid;
+      gelu_r3a_r0    <= gelu_r3ab_r0;
       gelu_r3a_corr  <= gelu_corr_packed_wire;
     end
   end

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -17,7 +17,7 @@ import bf16_math_pkg::*;
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
 //   RECIP      : 10 cycles  (Newton-Raphson, 1 step)
-//   SCALE      :  6 cycles  (first input word = scalar, rest = data)
+//   SCALE      :  7 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
@@ -668,7 +668,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| SCALE Pipeline (6 stages) |=============================================
+  // ===| SCALE Pipeline (7 cycles) |=============================================
   // First element received = scalar (or 1/scalar if FLAG_RECIP_SCALE).
 
   logic        scale_scalar_loaded;
@@ -685,6 +685,13 @@ module CVO_sfu_unit (
   logic [ 7:0] scale_s1_ma;
   logic [ 7:0] scale_s1_mb;
 
+  logic        scale_s2a_valid;
+  logic        scale_s2a_zero;
+  logic        scale_s2a_sign;
+  logic [ 8:0] scale_s2a_esum;
+  logic [11:0] scale_s2a_mp_lo;
+  logic [11:0] scale_s2a_mp_hi;
+
   logic        scale_s2_valid;
   logic        scale_s2_zero;
   logic        scale_s2_sign;
@@ -695,6 +702,7 @@ module CVO_sfu_unit (
   logic [15:0] scale_s3_result;
 
   logic [15:0] scale_scalar_next_wire;
+  logic [15:0] scale_s2_mp_wire;
   logic [ 7:0] scale_s2_er_wire;
   logic [ 6:0] scale_s2_mr_wire;
 
@@ -718,6 +726,12 @@ module CVO_sfu_unit (
       scale_s1_esum       <= 9'd0;
       scale_s1_ma         <= 8'd0;
       scale_s1_mb         <= 8'd0;
+      scale_s2a_valid     <= 1'b0;
+      scale_s2a_zero      <= 1'b1;
+      scale_s2a_sign      <= 1'b0;
+      scale_s2a_esum      <= 9'd0;
+      scale_s2a_mp_lo     <= 12'd0;
+      scale_s2a_mp_hi     <= 12'd0;
       scale_s2_valid      <= 1'b0;
       scale_s2_zero       <= 1'b1;
       scale_s2_sign       <= 1'b0;
@@ -748,15 +762,26 @@ module CVO_sfu_unit (
       scale_s1_ma    <= {1'b1, scale_s0_data[6:0]};
       scale_s1_mb    <= {1'b1, scale_s0_scalar[6:0]};
 
-      scale_s2_valid <= scale_s1_valid;
-      scale_s2_zero  <= scale_s1_zero;
-      scale_s2_sign  <= scale_s1_sign;
-      scale_s2_esum  <= scale_s1_esum;
-      scale_s2_mp    <= scale_s1_ma * scale_s1_mb;
+      scale_s2a_valid <= scale_s1_valid;
+      scale_s2a_zero  <= scale_s1_zero;
+      scale_s2a_sign  <= scale_s1_sign;
+      scale_s2a_esum  <= scale_s1_esum;
+      scale_s2a_mp_lo <= 12'(scale_s1_ma * scale_s1_mb[3:0]);
+      scale_s2a_mp_hi <= 12'(scale_s1_ma * scale_s1_mb[7:4]);
+
+      scale_s2_valid <= scale_s2a_valid;
+      scale_s2_zero  <= scale_s2a_zero;
+      scale_s2_sign  <= scale_s2a_sign;
+      scale_s2_esum  <= scale_s2a_esum;
+      scale_s2_mp    <= scale_s2_mp_wire;
 
       scale_s3_valid  <= scale_s2_valid;
       scale_s3_result <= scale_s2_zero ? 16'd0 : {scale_s2_sign, scale_s2_er_wire, scale_s2_mr_wire};
     end
+  end
+
+  always_comb begin : comb_scale_partial_sum
+    scale_s2_mp_wire = {4'd0, scale_s2a_mp_lo} + {scale_s2a_mp_hi, 4'd0};
   end
 
   always_comb begin : comb_scale_mul_pack

--- a/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
+++ b/hw/rtl/CVO_CORE/CVO_sfu_unit.sv
@@ -17,7 +17,7 @@ import bf16_math_pkg::*;
 //   EXP        :  7 cycles
 //   SQRT       :  3 cycles
 //   RECIP      :  9 cycles  (Newton-Raphson, 1 step)
-//   SCALE      :  5 cycles  (first input word = scalar, rest = data)
+//   SCALE      :  6 cycles  (first input word = scalar, rest = data)
 //   REDUCE_SUM :  variable  (ready-gated BF16 add pipeline, emits scalar)
 //   GELU       : 22 cycles  (MUL + NEG + EXP + ADD + RECIP + MUL chain)
 // Throughput   : 1 result/cycle for streaming ops; REDUCE_SUM emits 1 scalar
@@ -637,7 +637,7 @@ module CVO_sfu_unit (
     end
   end
 
-  // ===| SCALE Pipeline (5 stages) |=============================================
+  // ===| SCALE Pipeline (6 stages) |=============================================
   // First element received = scalar (or 1/scalar if FLAG_RECIP_SCALE).
 
   logic        scale_scalar_loaded;
@@ -651,14 +651,21 @@ module CVO_sfu_unit (
   logic        scale_s1_zero;
   logic        scale_s1_sign;
   logic [ 8:0] scale_s1_esum;
-  logic [15:0] scale_s1_mp;
+  logic [ 7:0] scale_s1_ma;
+  logic [ 7:0] scale_s1_mb;
 
   logic        scale_s2_valid;
-  logic [15:0] scale_s2_result;
+  logic        scale_s2_zero;
+  logic        scale_s2_sign;
+  logic [ 8:0] scale_s2_esum;
+  logic [15:0] scale_s2_mp;
+
+  logic        scale_s3_valid;
+  logic [15:0] scale_s3_result;
 
   logic [15:0] scale_scalar_next_wire;
-  logic [ 7:0] scale_s1_er_wire;
-  logic [ 6:0] scale_s1_mr_wire;
+  logic [ 7:0] scale_s2_er_wire;
+  logic [ 6:0] scale_s2_mr_wire;
 
   always_comb begin
     // Approximate 1/scalar for recip_scale mode: flip exponent + invert mantissa
@@ -678,9 +685,15 @@ module CVO_sfu_unit (
       scale_s1_zero       <= 1'b1;
       scale_s1_sign       <= 1'b0;
       scale_s1_esum       <= 9'd0;
-      scale_s1_mp         <= 16'd0;
+      scale_s1_ma         <= 8'd0;
+      scale_s1_mb         <= 8'd0;
       scale_s2_valid      <= 1'b0;
-      scale_s2_result     <= 16'd0;
+      scale_s2_zero       <= 1'b1;
+      scale_s2_sign       <= 1'b0;
+      scale_s2_esum       <= 9'd0;
+      scale_s2_mp         <= 16'd0;
+      scale_s3_valid      <= 1'b0;
+      scale_s3_result     <= 16'd0;
     end else begin
       if (IN_valid && IN_func == CVO_SCALE) begin
         if (!scale_scalar_loaded) begin
@@ -701,20 +714,27 @@ module CVO_sfu_unit (
       scale_s1_zero  <= (scale_s0_data[14:0] == 15'd0) || (scale_s0_scalar[14:0] == 15'd0);
       scale_s1_sign  <= scale_s0_data[15] ^ scale_s0_scalar[15];
       scale_s1_esum  <= {1'b0, scale_s0_data[14:7]} + {1'b0, scale_s0_scalar[14:7]};
-      scale_s1_mp    <= {1'b1, scale_s0_data[6:0]} * {1'b1, scale_s0_scalar[6:0]};
+      scale_s1_ma    <= {1'b1, scale_s0_data[6:0]};
+      scale_s1_mb    <= {1'b1, scale_s0_scalar[6:0]};
 
-      scale_s2_valid  <= scale_s1_valid;
-      scale_s2_result <= scale_s1_zero ? 16'd0 : {scale_s1_sign, scale_s1_er_wire, scale_s1_mr_wire};
+      scale_s2_valid <= scale_s1_valid;
+      scale_s2_zero  <= scale_s1_zero;
+      scale_s2_sign  <= scale_s1_sign;
+      scale_s2_esum  <= scale_s1_esum;
+      scale_s2_mp    <= scale_s1_ma * scale_s1_mb;
+
+      scale_s3_valid  <= scale_s2_valid;
+      scale_s3_result <= scale_s2_zero ? 16'd0 : {scale_s2_sign, scale_s2_er_wire, scale_s2_mr_wire};
     end
   end
 
   always_comb begin : comb_scale_mul_pack
-    if (scale_s1_mp[15]) begin
-      scale_s1_er_wire = 8'(scale_s1_esum - 9'd127 + 9'd1);
-      scale_s1_mr_wire = scale_s1_mp[14:8];
+    if (scale_s2_mp[15]) begin
+      scale_s2_er_wire = 8'(scale_s2_esum - 9'd127 + 9'd1);
+      scale_s2_mr_wire = scale_s2_mp[14:8];
     end else begin
-      scale_s1_er_wire = 8'(scale_s1_esum - 9'd127);
-      scale_s1_mr_wire = scale_s1_mp[13:7];
+      scale_s2_er_wire = 8'(scale_s2_esum - 9'd127);
+      scale_s2_mr_wire = scale_s2_mp[13:7];
     end
   end
 
@@ -1413,8 +1433,8 @@ module CVO_sfu_unit (
         OUT_result_valid = recip_s5_valid;
       end
       CVO_SCALE: begin
-        OUT_result = scale_s2_result;
-        OUT_result_valid = scale_s2_valid;
+        OUT_result = scale_s3_result;
+        OUT_result_valid = scale_s3_valid;
       end
       CVO_REDUCE_SUM: begin
         OUT_result = rsum_out;

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -30,7 +30,7 @@ import bf16_math_pkg::*;
 //                surfaces it via OUT_accm.
 // FSM states   : IDLE → RUNNING → DONE → IDLE.
 // Latency      : Sub-unit latency (see CVO_sfu_unit / CVO_cordic_unit
-//                contracts) + 1 output register cycle.
+//                contracts) + CVO input/output pipeline registers.
 // Throughput   : 1 result per cycle in steady state for non-CORDIC ops.
 // Backpressure : OUT_data_ready ANDs sub-unit ready with (state == RUNNING).
 // Reset state  : ST_IDLE, OUT_result = 0, OUT_result_valid = 0, OUT_done = 0.
@@ -125,23 +125,32 @@ module CVO_top (
   // stages because a full BF16 align/add/normalize chain does not meet the
   // 400 MHz core target as one combinational block.
 
-  function automatic logic [15:0] pack_bf16_mag(input logic        out_sign,
-                                                input logic [7:0]  emax,
-                                                input logic [23:0] mag);
-    int          lead;
+  function automatic logic [4:0] lead_index24(input logic [23:0] mag);
+    int lead;
+
+    lead = 23;
+    while (lead > 0 && mag[lead] == 1'b0) lead = lead - 1;
+
+    return 5'(lead);
+  endfunction
+
+  function automatic logic [15:0] pack_bf16_mag_with_lead(input logic        out_sign,
+                                                          input logic [7:0]  emax,
+                                                          input logic [23:0] mag,
+                                                          input logic [4:0]  lead);
+    int          lead_i;
     logic [7:0]  out_exp;
     logic [6:0]  out_mant;
 
     if (mag == 24'd0) return 16'd0;
 
-    lead = 23;
-    while (lead > 0 && mag[lead] == 1'b0) lead = lead - 1;
+    lead_i = int'(lead);
 
-    out_exp = emax + 8'(lead - 15);
-    if (lead >= 7)
-      out_mant = mag[lead-1-:7];
+    out_exp = emax + 8'(lead_i - 15);
+    if (lead_i >= 7)
+      out_mant = mag[lead_i-1-:7];
     else
-      out_mant = 7'(mag << (7 - lead));
+      out_mant = 7'(mag << (7 - lead_i));
 
     return {out_sign, out_exp, out_mant};
   endfunction
@@ -374,6 +383,51 @@ module CVO_top (
     end
   end
 
+  logic [4:0] sub_s4_lead_wire;
+
+  always_comb begin : comb_sub_emax_pack_prepare
+    sub_s4_lead_wire = lead_index24(sub_s3_mag);
+  end
+
+  logic        sub_s4_valid;
+  logic        sub_s4_do_sub;
+  logic [15:0] sub_s4_passthrough;
+  logic [7:0]  sub_s4_emax;
+  logic        sub_s4_sign;
+  logic [23:0] sub_s4_mag;
+  logic [4:0]  sub_s4_lead;
+  cvo_func_e   sub_s4_func;
+  cvo_flags_t  sub_s4_flags;
+  logic [15:0] sub_s4_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s4_valid       <= 1'b0;
+      sub_s4_do_sub      <= 1'b0;
+      sub_s4_passthrough <= 16'd0;
+      sub_s4_emax        <= 8'd0;
+      sub_s4_sign        <= 1'b0;
+      sub_s4_mag         <= 24'd0;
+      sub_s4_lead        <= 5'd0;
+      sub_s4_func        <= CVO_EXP;
+      sub_s4_flags       <= '0;
+      sub_s4_length      <= 16'd0;
+    end else begin
+      sub_s4_valid <= sub_s3_valid;
+      if (sub_s3_valid) begin
+        sub_s4_do_sub      <= sub_s3_do_sub;
+        sub_s4_passthrough <= sub_s3_passthrough;
+        sub_s4_emax        <= sub_s3_emax;
+        sub_s4_sign        <= sub_s3_sign;
+        sub_s4_mag         <= sub_s3_mag;
+        sub_s4_lead        <= sub_s4_lead_wire;
+        sub_s4_func        <= sub_s3_func;
+        sub_s4_flags       <= sub_s3_flags;
+        sub_s4_length      <= sub_s3_length;
+      end
+    end
+  end
+
 	  // ===| Input to sub-units (after optional e_max subtraction) |=================
 	  logic        data_valid_to_unit_wire;
 	  logic [15:0] unit_data;
@@ -394,13 +448,14 @@ module CVO_top (
       unit_flags  <= '0;
       unit_length <= 16'd0;
     end else begin
-      unit_valid <= sub_s3_valid;
-      if (sub_s3_valid) begin
-        unit_data   <= sub_s3_do_sub ? pack_bf16_mag(sub_s3_sign, sub_s3_emax, sub_s3_mag) :
-                                       sub_s3_passthrough;
-        unit_func   <= sub_s3_func;
-        unit_flags  <= sub_s3_flags;
-        unit_length <= sub_s3_length;
+      unit_valid <= sub_s4_valid;
+      if (sub_s4_valid) begin
+        unit_data   <= sub_s4_do_sub ? pack_bf16_mag_with_lead(sub_s4_sign, sub_s4_emax,
+                                                               sub_s4_mag, sub_s4_lead) :
+                                       sub_s4_passthrough;
+        unit_func   <= sub_s4_func;
+        unit_flags  <= sub_s4_flags;
+        unit_length <= sub_s4_length;
       end
     end
   end

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -193,12 +193,78 @@ module CVO_top (
     end
   end
 
+  logic [22:0] sub_s1p_mag_a_wire;
+  logic [22:0] sub_s1p_mag_b_wire;
+  logic [7:0]  sub_s1p_shift_a_wire;
+  logic [7:0]  sub_s1p_shift_b_wire;
+
+  always_comb begin : comb_sub_emax_shift_prepare
+    sub_s1p_mag_a_wire   = {1'b1, sub_s0_a.mantissa, 15'd0};
+    sub_s1p_mag_b_wire   = {1'b1, sub_s0_b.mantissa, 15'd0};
+    sub_s1p_shift_a_wire = sub_s0_emax - sub_s0_a.exp;
+    sub_s1p_shift_b_wire = sub_s0_emax - sub_s0_b.exp;
+  end
+
+  logic        sub_s1p_valid;
+  logic        sub_s1p_do_sub;
+  logic [15:0] sub_s1p_passthrough;
+  logic [7:0]  sub_s1p_emax;
+  logic        sub_s1p_sign_a;
+  logic        sub_s1p_sign_b;
+  logic [22:0] sub_s1p_mag_a;
+  logic [22:0] sub_s1p_mag_b;
+  logic [7:0]  sub_s1p_shift_a;
+  logic [7:0]  sub_s1p_shift_b;
+  cvo_func_e   sub_s1p_func;
+  cvo_flags_t  sub_s1p_flags;
+  logic [15:0] sub_s1p_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s1p_valid       <= 1'b0;
+      sub_s1p_do_sub      <= 1'b0;
+      sub_s1p_passthrough <= 16'd0;
+      sub_s1p_emax        <= 8'd0;
+      sub_s1p_sign_a      <= 1'b0;
+      sub_s1p_sign_b      <= 1'b0;
+      sub_s1p_mag_a       <= 23'd0;
+      sub_s1p_mag_b       <= 23'd0;
+      sub_s1p_shift_a     <= 8'd0;
+      sub_s1p_shift_b     <= 8'd0;
+      sub_s1p_func        <= CVO_EXP;
+      sub_s1p_flags       <= '0;
+      sub_s1p_length      <= 16'd0;
+    end else begin
+      sub_s1p_valid <= sub_s0_valid;
+      if (sub_s0_valid) begin
+        sub_s1p_do_sub      <= sub_s0_do_sub;
+        sub_s1p_passthrough <= sub_s0_passthrough;
+        sub_s1p_emax        <= sub_s0_emax;
+        sub_s1p_sign_a      <= sub_s0_a.sign;
+        sub_s1p_sign_b      <= sub_s0_b.sign;
+        sub_s1p_mag_a       <= sub_s1p_mag_a_wire;
+        sub_s1p_mag_b       <= sub_s1p_mag_b_wire;
+        sub_s1p_shift_a     <= sub_s1p_shift_a_wire;
+        sub_s1p_shift_b     <= sub_s1p_shift_b_wire;
+        sub_s1p_func        <= sub_s0_func;
+        sub_s1p_flags       <= sub_s0_flags;
+        sub_s1p_length      <= sub_s0_length;
+      end
+    end
+  end
+
+  logic [22:0] sub_shifted_a_wire;
+  logic [22:0] sub_shifted_b_wire;
   logic [23:0] sub_aligned_a_wire;
   logic [23:0] sub_aligned_b_wire;
 
   always_comb begin : comb_sub_emax_align
-    sub_aligned_a_wire = align_to_emax(sub_s0_a, sub_s0_emax);
-    sub_aligned_b_wire = align_to_emax(sub_s0_b, sub_s0_emax);
+    sub_shifted_a_wire = sub_s1p_mag_a >> sub_s1p_shift_a;
+    sub_shifted_b_wire = sub_s1p_mag_b >> sub_s1p_shift_b;
+    sub_aligned_a_wire = sub_s1p_sign_a ? (~{1'b0, sub_shifted_a_wire} + 24'd1) :
+                                          {1'b0, sub_shifted_a_wire};
+    sub_aligned_b_wire = sub_s1p_sign_b ? (~{1'b0, sub_shifted_b_wire} + 24'd1) :
+                                          {1'b0, sub_shifted_b_wire};
   end
 
   logic        sub_s1_valid;
@@ -223,16 +289,16 @@ module CVO_top (
       sub_s1_flags       <= '0;
       sub_s1_length      <= 16'd0;
     end else begin
-      sub_s1_valid <= sub_s0_valid;
-      if (sub_s0_valid) begin
-        sub_s1_do_sub      <= sub_s0_do_sub;
-        sub_s1_passthrough <= sub_s0_passthrough;
-        sub_s1_emax        <= sub_s0_emax;
+      sub_s1_valid <= sub_s1p_valid;
+      if (sub_s1p_valid) begin
+        sub_s1_do_sub      <= sub_s1p_do_sub;
+        sub_s1_passthrough <= sub_s1p_passthrough;
+        sub_s1_emax        <= sub_s1p_emax;
         sub_s1_aligned_a   <= sub_aligned_a_wire;
         sub_s1_aligned_b   <= sub_aligned_b_wire;
-        sub_s1_func        <= sub_s0_func;
-        sub_s1_flags       <= sub_s0_flags;
-        sub_s1_length      <= sub_s0_length;
+        sub_s1_func        <= sub_s1p_func;
+        sub_s1_flags       <= sub_s1p_flags;
+        sub_s1_length      <= sub_s1p_length;
       end
     end
   end

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -149,18 +149,59 @@ module CVO_top (
     return {out_sign, out_exp, out_mant};
   endfunction
 
-  bf16_t       sub_a_wire;
-  bf16_t       sub_b_wire;
-  logic [7:0]  sub_emax_wire;
+  bf16_t      sub_s0_a_wire;
+  bf16_t      sub_s0_b_wire;
+  logic [7:0] sub_s0_emax_wire;
+
+  always_comb begin : comb_sub_emax_classify
+    sub_s0_a_wire    = to_bf16(unit_in_data);
+    sub_s0_b_wire    = to_bf16({~unit_in_e_max[15], unit_in_e_max[14:0]});
+    sub_s0_emax_wire = (sub_s0_a_wire.exp > sub_s0_b_wire.exp) ?
+                       sub_s0_a_wire.exp : sub_s0_b_wire.exp;
+  end
+
+  logic        sub_s0_valid;
+  logic        sub_s0_do_sub;
+  logic [15:0] sub_s0_passthrough;
+  logic [7:0]  sub_s0_emax;
+  bf16_t       sub_s0_a;
+  bf16_t       sub_s0_b;
+  cvo_func_e   sub_s0_func;
+  cvo_flags_t  sub_s0_flags;
+  logic [15:0] sub_s0_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s0_valid       <= 1'b0;
+      sub_s0_do_sub      <= 1'b0;
+      sub_s0_passthrough <= 16'd0;
+      sub_s0_emax        <= 8'd0;
+      sub_s0_a           <= '0;
+      sub_s0_b           <= '0;
+      sub_s0_func        <= CVO_EXP;
+      sub_s0_flags       <= '0;
+      sub_s0_length      <= 16'd0;
+    end else begin
+      sub_s0_valid <= unit_in_valid;
+      if (unit_in_valid) begin
+        sub_s0_do_sub      <= unit_in_flags.sub_emax;
+        sub_s0_passthrough <= unit_in_data;
+        sub_s0_emax        <= sub_s0_emax_wire;
+        sub_s0_a           <= sub_s0_a_wire;
+        sub_s0_b           <= sub_s0_b_wire;
+        sub_s0_func        <= unit_in_func;
+        sub_s0_flags       <= unit_in_flags;
+        sub_s0_length      <= unit_in_length;
+      end
+    end
+  end
+
   logic [23:0] sub_aligned_a_wire;
   logic [23:0] sub_aligned_b_wire;
 
   always_comb begin : comb_sub_emax_align
-    sub_a_wire         = to_bf16(unit_in_data);
-    sub_b_wire         = to_bf16({~unit_in_e_max[15], unit_in_e_max[14:0]});
-    sub_emax_wire      = (sub_a_wire.exp > sub_b_wire.exp) ? sub_a_wire.exp : sub_b_wire.exp;
-    sub_aligned_a_wire = align_to_emax(sub_a_wire, sub_emax_wire);
-    sub_aligned_b_wire = align_to_emax(sub_b_wire, sub_emax_wire);
+    sub_aligned_a_wire = align_to_emax(sub_s0_a, sub_s0_emax);
+    sub_aligned_b_wire = align_to_emax(sub_s0_b, sub_s0_emax);
   end
 
   logic        sub_s1_valid;
@@ -185,16 +226,16 @@ module CVO_top (
       sub_s1_flags       <= '0;
       sub_s1_length      <= 16'd0;
     end else begin
-      sub_s1_valid <= unit_in_valid;
-      if (unit_in_valid) begin
-        sub_s1_do_sub      <= unit_in_flags.sub_emax;
-        sub_s1_passthrough <= unit_in_data;
-        sub_s1_emax        <= sub_emax_wire;
+      sub_s1_valid <= sub_s0_valid;
+      if (sub_s0_valid) begin
+        sub_s1_do_sub      <= sub_s0_do_sub;
+        sub_s1_passthrough <= sub_s0_passthrough;
+        sub_s1_emax        <= sub_s0_emax;
         sub_s1_aligned_a   <= sub_aligned_a_wire;
         sub_s1_aligned_b   <= sub_aligned_b_wire;
-        sub_s1_func        <= unit_in_func;
-        sub_s1_flags       <= unit_in_flags;
-        sub_s1_length      <= unit_in_length;
+        sub_s1_func        <= sub_s0_func;
+        sub_s1_flags       <= sub_s0_flags;
+        sub_s1_length      <= sub_s0_length;
       end
     end
   end

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -125,16 +125,13 @@ module CVO_top (
   // stages because a full BF16 align/add/normalize chain does not meet the
   // 400 MHz core target as one combinational block.
 
-  function automatic logic [15:0] pack_bf16_sum(input logic [7:0] emax,
-                                                input logic signed [24:0] sum);
-    logic        out_sign;
-    logic [23:0] mag;
+  function automatic logic [15:0] pack_bf16_mag(input logic        out_sign,
+                                                input logic [7:0]  emax,
+                                                input logic [23:0] mag);
     int          lead;
     logic [7:0]  out_exp;
     logic [6:0]  out_mant;
 
-    out_sign = sum[24];
-    mag      = out_sign ? (~sum[23:0] + 24'd1) : sum[23:0];
     if (mag == 24'd0) return 16'd0;
 
     lead = 23;
@@ -271,13 +268,50 @@ module CVO_top (
         sub_s2_flags       <= sub_s1_flags;
         sub_s2_length      <= sub_s1_length;
       end
+	    end
+	  end
+
+  logic        sub_s3_valid;
+  logic        sub_s3_do_sub;
+  logic [15:0] sub_s3_passthrough;
+  logic [7:0]  sub_s3_emax;
+  logic        sub_s3_sign;
+  logic [23:0] sub_s3_mag;
+  cvo_func_e   sub_s3_func;
+  cvo_flags_t  sub_s3_flags;
+  logic [15:0] sub_s3_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s3_valid       <= 1'b0;
+      sub_s3_do_sub      <= 1'b0;
+      sub_s3_passthrough <= 16'd0;
+      sub_s3_emax        <= 8'd0;
+      sub_s3_sign        <= 1'b0;
+      sub_s3_mag         <= 24'd0;
+      sub_s3_func        <= CVO_EXP;
+      sub_s3_flags       <= '0;
+      sub_s3_length      <= 16'd0;
+    end else begin
+      sub_s3_valid <= sub_s2_valid;
+      if (sub_s2_valid) begin
+        sub_s3_do_sub      <= sub_s2_do_sub;
+        sub_s3_passthrough <= sub_s2_passthrough;
+        sub_s3_emax        <= sub_s2_emax;
+        sub_s3_sign        <= sub_s2_sum[24];
+        sub_s3_mag         <= sub_s2_sum[24] ? (~sub_s2_sum[23:0] + 24'd1) :
+                                               sub_s2_sum[23:0];
+        sub_s3_func        <= sub_s2_func;
+        sub_s3_flags       <= sub_s2_flags;
+        sub_s3_length      <= sub_s2_length;
+      end
     end
   end
 
-  // ===| Input to sub-units (after optional e_max subtraction) |=================
-  logic        data_valid_to_unit_wire;
-  logic [15:0] unit_data;
-  logic        unit_valid;
+	  // ===| Input to sub-units (after optional e_max subtraction) |=================
+	  logic        data_valid_to_unit_wire;
+	  logic [15:0] unit_data;
+	  logic        unit_valid;
   cvo_func_e   unit_func;
   cvo_flags_t  unit_flags;
   logic [15:0] unit_length;
@@ -294,13 +328,13 @@ module CVO_top (
       unit_flags  <= '0;
       unit_length <= 16'd0;
     end else begin
-      unit_valid <= sub_s2_valid;
-      if (sub_s2_valid) begin
-        unit_data   <= sub_s2_do_sub ? pack_bf16_sum(sub_s2_emax, sub_s2_sum) :
-                                       sub_s2_passthrough;
-        unit_func   <= sub_s2_func;
-        unit_flags  <= sub_s2_flags;
-        unit_length <= sub_s2_length;
+      unit_valid <= sub_s3_valid;
+      if (sub_s3_valid) begin
+        unit_data   <= sub_s3_do_sub ? pack_bf16_mag(sub_s3_sign, sub_s3_emax, sub_s3_mag) :
+                                       sub_s3_passthrough;
+        unit_func   <= sub_s3_func;
+        unit_flags  <= sub_s3_flags;
+        unit_length <= sub_s3_length;
       end
     end
   end

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -83,29 +83,189 @@ module CVO_top (
   logic [15:0] uop_length;
   logic [15:0] elem_count;   // elements processed in current operation
 
-  // ===| BF16 subtract e_max (combinational) |===================================
-  // Implements x - e_max in BF16 via bf16_add(x, -e_max).
+  // ===| Registered Unit Input Boundary |========================================
+  // The L2 bridge deserializes 128-bit words into a 16-bit BF16 stream. Keep that
+  // muxing on the bridge side of a flop so the SFU/CORDIC arithmetic paths start
+  // from a local CVO register rather than from the L2 deser buffer.
 
-  logic [15:0] sub_emax_result_wire;
+  logic        unit_in_valid;
+  logic [15:0] unit_in_data;
+  logic [15:0] unit_in_e_max;
+  cvo_func_e   unit_in_func;
+  cvo_flags_t  unit_in_flags;
+  logic [15:0] unit_in_length;
+  logic        input_accept_wire;
 
-  always_comb begin : comb_sub_emax
-    // Negate e_max by flipping sign bit, then add to x
-    sub_emax_result_wire = bf16_add(IN_data, {~IN_e_max[15], IN_e_max[14:0]});
+  assign input_accept_wire = (state == ST_RUNNING) && IN_data_valid && OUT_data_ready;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      unit_in_valid  <= 1'b0;
+      unit_in_data   <= 16'd0;
+      unit_in_e_max  <= 16'd0;
+      unit_in_func   <= CVO_EXP;
+      unit_in_flags  <= '0;
+      unit_in_length <= 16'd0;
+    end else begin
+      unit_in_valid <= input_accept_wire;
+      if (input_accept_wire) begin
+        unit_in_data   <= IN_data;
+        unit_in_e_max  <= IN_e_max;
+        unit_in_func   <= uop_func;
+        unit_in_flags  <= uop_flags;
+        unit_in_length <= uop_length;
+      end
+    end
+  end
+
+  // ===| Pipelined BF16 subtract e_max |=========================================
+  // Implements x - e_max for FLAG_SUB_EMAX. This is intentionally split across
+  // stages because a full BF16 align/add/normalize chain does not meet the
+  // 400 MHz core target as one combinational block.
+
+  function automatic logic [15:0] pack_bf16_sum(input logic [7:0] emax,
+                                                input logic signed [24:0] sum);
+    logic        out_sign;
+    logic [23:0] mag;
+    int          lead;
+    logic [7:0]  out_exp;
+    logic [6:0]  out_mant;
+
+    out_sign = sum[24];
+    mag      = out_sign ? (~sum[23:0] + 24'd1) : sum[23:0];
+    if (mag == 24'd0) return 16'd0;
+
+    lead = 23;
+    while (lead > 0 && mag[lead] == 1'b0) lead = lead - 1;
+
+    out_exp = emax + 8'(lead - 15);
+    if (lead >= 7)
+      out_mant = mag[lead-1-:7];
+    else
+      out_mant = 7'(mag << (7 - lead));
+
+    return {out_sign, out_exp, out_mant};
+  endfunction
+
+  bf16_t       sub_a_wire;
+  bf16_t       sub_b_wire;
+  logic [7:0]  sub_emax_wire;
+  logic [23:0] sub_aligned_a_wire;
+  logic [23:0] sub_aligned_b_wire;
+
+  always_comb begin : comb_sub_emax_align
+    sub_a_wire         = to_bf16(unit_in_data);
+    sub_b_wire         = to_bf16({~unit_in_e_max[15], unit_in_e_max[14:0]});
+    sub_emax_wire      = (sub_a_wire.exp > sub_b_wire.exp) ? sub_a_wire.exp : sub_b_wire.exp;
+    sub_aligned_a_wire = align_to_emax(sub_a_wire, sub_emax_wire);
+    sub_aligned_b_wire = align_to_emax(sub_b_wire, sub_emax_wire);
+  end
+
+  logic        sub_s1_valid;
+  logic        sub_s1_do_sub;
+  logic [15:0] sub_s1_passthrough;
+  logic [7:0]  sub_s1_emax;
+  logic [23:0] sub_s1_aligned_a;
+  logic [23:0] sub_s1_aligned_b;
+  cvo_func_e   sub_s1_func;
+  cvo_flags_t  sub_s1_flags;
+  logic [15:0] sub_s1_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s1_valid       <= 1'b0;
+      sub_s1_do_sub      <= 1'b0;
+      sub_s1_passthrough <= 16'd0;
+      sub_s1_emax        <= 8'd0;
+      sub_s1_aligned_a   <= 24'd0;
+      sub_s1_aligned_b   <= 24'd0;
+      sub_s1_func        <= CVO_EXP;
+      sub_s1_flags       <= '0;
+      sub_s1_length      <= 16'd0;
+    end else begin
+      sub_s1_valid <= unit_in_valid;
+      if (unit_in_valid) begin
+        sub_s1_do_sub      <= unit_in_flags.sub_emax;
+        sub_s1_passthrough <= unit_in_data;
+        sub_s1_emax        <= sub_emax_wire;
+        sub_s1_aligned_a   <= sub_aligned_a_wire;
+        sub_s1_aligned_b   <= sub_aligned_b_wire;
+        sub_s1_func        <= unit_in_func;
+        sub_s1_flags       <= unit_in_flags;
+        sub_s1_length      <= unit_in_length;
+      end
+    end
+  end
+
+  logic              sub_s2_valid;
+  logic              sub_s2_do_sub;
+  logic [15:0]       sub_s2_passthrough;
+  logic [7:0]        sub_s2_emax;
+  logic signed [24:0] sub_s2_sum;
+  cvo_func_e         sub_s2_func;
+  cvo_flags_t        sub_s2_flags;
+  logic [15:0]       sub_s2_length;
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      sub_s2_valid       <= 1'b0;
+      sub_s2_do_sub      <= 1'b0;
+      sub_s2_passthrough <= 16'd0;
+      sub_s2_emax        <= 8'd0;
+      sub_s2_sum         <= 25'sd0;
+      sub_s2_func        <= CVO_EXP;
+      sub_s2_flags       <= '0;
+      sub_s2_length      <= 16'd0;
+    end else begin
+      sub_s2_valid <= sub_s1_valid;
+      if (sub_s1_valid) begin
+        sub_s2_do_sub      <= sub_s1_do_sub;
+        sub_s2_passthrough <= sub_s1_passthrough;
+        sub_s2_emax        <= sub_s1_emax;
+        sub_s2_sum         <= $signed({sub_s1_aligned_a[23], sub_s1_aligned_a}) +
+                              $signed({sub_s1_aligned_b[23], sub_s1_aligned_b});
+        sub_s2_func        <= sub_s1_func;
+        sub_s2_flags       <= sub_s1_flags;
+        sub_s2_length      <= sub_s1_length;
+      end
+    end
   end
 
   // ===| Input to sub-units (after optional e_max subtraction) |=================
-  logic [15:0] data_to_unit_wire;
   logic        data_valid_to_unit_wire;
+  logic [15:0] unit_data;
+  logic        unit_valid;
+  cvo_func_e   unit_func;
+  cvo_flags_t  unit_flags;
+  logic [15:0] unit_length;
 
   always_comb begin
-    data_to_unit_wire    = uop_flags.sub_emax ? sub_emax_result_wire : IN_data;
-    data_valid_to_unit_wire = (state == ST_RUNNING) && IN_data_valid;
+    data_valid_to_unit_wire = unit_valid;
+  end
+
+  always_ff @(posedge clk) begin
+    if (!rst_n || i_clear) begin
+      unit_valid  <= 1'b0;
+      unit_data   <= 16'd0;
+      unit_func   <= CVO_EXP;
+      unit_flags  <= '0;
+      unit_length <= 16'd0;
+    end else begin
+      unit_valid <= sub_s2_valid;
+      if (sub_s2_valid) begin
+        unit_data   <= sub_s2_do_sub ? pack_bf16_sum(sub_s2_emax, sub_s2_sum) :
+                                       sub_s2_passthrough;
+        unit_func   <= sub_s2_func;
+        unit_flags  <= sub_s2_flags;
+        unit_length <= sub_s2_length;
+      end
+    end
   end
 
   // ===| Opcode Routing (declared ahead of units that use it as a gating term) |
   logic is_cordic_op_wire;
   always_comb begin
-    is_cordic_op_wire = (uop_func == CVO_SIN) || (uop_func == CVO_COS);
+    is_cordic_op_wire = (unit_func == CVO_SIN) || (unit_func == CVO_COS);
   end
 
   // ===| SFU Instantiation |=====================================================
@@ -118,11 +278,11 @@ module CVO_top (
       .rst_n           (rst_n),
       .i_clear         (i_clear),
 
-      .IN_func         (uop_func),
-      .IN_length       (uop_length),
-      .IN_flags        (uop_flags),
+      .IN_func         (unit_func),
+      .IN_length       (unit_length),
+      .IN_flags        (unit_flags),
 
-      .IN_data         (data_to_unit_wire),
+      .IN_data         (unit_data),
       .IN_valid        (data_valid_to_unit_wire && !is_cordic_op_wire),
       .OUT_data_ready  (sfu_ready),
 
@@ -139,7 +299,7 @@ module CVO_top (
       .clk          (clk),
       .rst_n        (rst_n),
 
-      .IN_angle_bf16(data_to_unit_wire),
+      .IN_angle_bf16(unit_data),
       .IN_valid     (data_valid_to_unit_wire && is_cordic_op_wire),
 
       .OUT_sin_bf16 (cordic_sin),

--- a/hw/rtl/CVO_CORE/CVO_top.sv
+++ b/hw/rtl/CVO_CORE/CVO_top.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GLOBAL_CONST.svh"
 

--- a/hw/rtl/MAT_CORE/GEMM_systolic_top.sv
+++ b/hw/rtl/MAT_CORE/GEMM_systolic_top.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 
 `include "GLOBAL_CONST.svh"

--- a/hw/rtl/MAT_CORE/GEMM_systolic_top.sv
+++ b/hw/rtl/MAT_CORE/GEMM_systolic_top.sv
@@ -176,28 +176,33 @@ module GEMM_systolic_top #(
 
   // ===| e_max Delay Pipe for Normalization alignment |=======
   localparam TOTAL_LATENCY = `SYSTOLIC_TOTAL_LATENCY;
-  logic [`BF16_EXP_WIDTH-1:0] emax_pipe[0:`ARRAY_SIZE_H-1][0:TOTAL_LATENCY-1];
+  localparam int EMAX_PIPE_WIDTH = `ARRAY_SIZE_H * `BF16_EXP_WIDTH;
+  logic [EMAX_PIPE_WIDTH-1:0] emax_pipe[0:TOTAL_LATENCY-1];
+  logic [EMAX_PIPE_WIDTH-1:0] emax_pipe_in;
+
+  always_comb begin
+    for (int c = 0; c < `ARRAY_SIZE_H; c++) begin
+      emax_pipe_in[c*`BF16_EXP_WIDTH+:`BF16_EXP_WIDTH] = IN_cached_emax_out[c];
+    end
+  end
 
   always_ff @(posedge clk) begin
     if (!rst_n) begin
-      for (int c = 0; c < `ARRAY_SIZE_H; c++) begin
-        for (int d = 0; d < TOTAL_LATENCY; d++) begin
-          emax_pipe[c][d] <= 0;
-        end
+      for (int d = 0; d < TOTAL_LATENCY; d++) begin
+        emax_pipe[d] <= '0;
       end
     end else begin
-      for (int c = 0; c < `ARRAY_SIZE_H; c++) begin
-        emax_pipe[c][0] <= IN_cached_emax_out[c];
-        for (int d = 1; d < TOTAL_LATENCY; d++) begin
-          emax_pipe[c][d] <= emax_pipe[c][d-1];
-        end
+      emax_pipe[0] <= emax_pipe_in;
+      for (int d = 1; d < TOTAL_LATENCY; d++) begin
+        emax_pipe[d] <= emax_pipe[d-1];
       end
     end
   end
 
   always_comb begin
     for (int c = 0; c < `ARRAY_SIZE_H; c++) begin
-      delayed_emax_32[c] = emax_pipe[c][TOTAL_LATENCY-1];
+      delayed_emax_32[c] =
+        emax_pipe[TOTAL_LATENCY-1][c*`BF16_EXP_WIDTH+:`BF16_EXP_WIDTH];
     end
   end
 

--- a/hw/rtl/MEM_control/memory/mem_BUFFER.sv
+++ b/hw/rtl/MEM_control/memory/mem_BUFFER.sv
@@ -37,6 +37,14 @@ module mem_BUFFER (
   //fine Tiny Depth for BRAM CDC
   localparam int BRAM_FIFO_DEPTH = 32;
 
+  // The current datapath moves fixed-width 128-bit beats only. XPM carries
+  // data/valid/ready here; terminate sidebands deterministically so top-level
+  // AXIS contracts never synthesize with floating tkeep/tlast pins.
+  assign M_CORE_ACP_RX.tkeep    = '1;
+  assign M_CORE_ACP_RX.tlast    = 1'b0;
+  assign M_AXIS_ACP_RESULT.tkeep = '1;
+  assign M_AXIS_ACP_RESULT.tlast = 1'b0;
+
   // [1] ACP RX FIFO (CDC only: AXI -> Core)
   // FMAP/KV is handled by the massive L2 URAM Cache, so these CDC FIFOs stay TINY.
   xpm_fifo_axis #(

--- a/hw/rtl/MEM_control/memory/mem_BUFFER.sv
+++ b/hw/rtl/MEM_control/memory/mem_BUFFER.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"
 `include "GLOBAL_CONST.svh"

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -21,7 +21,7 @@ import isa_pkg::*;
 // Arbitration  : Port B is driven externally via IN_npu_* signals; the
 //                upstream mem_dispatcher mux (final_npu_*) decides which
 //                producer (NPU FSM vs CVO bridge) wins port B per cycle.
-// Latency      : ACP read = URAM_LATENCY (3) cycles after acp_is_busy & ~we;
+// Latency      : ACP/NPU read = URAM_LATENCY cycles after read issue;
 //                tracked via acp_rd_valid_pipe.
 // Throughput   : 1 ACP transaction + 1 NPU transaction in flight in parallel.
 // Address unit : 128-bit words (address 0 = first 128-bit line).
@@ -83,18 +83,20 @@ module mem_GLOBAL_cache (
 
   assign OUT_acp_is_busy = acp_is_busy;
 
-  // ACP read pipeline: URAM READ_LATENCY=3
-  logic [2:0] acp_rd_valid_pipe;
+  localparam int URAM_LATENCY = 4;
+
+  // ACP read pipeline: tracks mem_L2_cache_fmap READ_LATENCY.
+  logic [URAM_LATENCY-1:0] acp_rd_valid_pipe;
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
-      acp_rd_valid_pipe <= 3'b000;
+      acp_rd_valid_pipe <= '0;
     end else begin
-      acp_rd_valid_pipe <= {acp_rd_valid_pipe[1:0], (acp_is_busy & ~acp_write_en)};
+      acp_rd_valid_pipe <= {acp_rd_valid_pipe[URAM_LATENCY-2:0], (acp_is_busy & ~acp_write_en)};
     end
   end
 
-  assign core_acp_tx_bus.tvalid = acp_rd_valid_pipe[2];
+  assign core_acp_tx_bus.tvalid = acp_rd_valid_pipe[URAM_LATENCY-1];
   assign core_acp_tx_bus.tkeep  = '1;
   assign core_acp_tx_bus.tlast  = 1'b0;
 
@@ -133,8 +135,8 @@ module mem_GLOBAL_cache (
   logic        npu_write_en;
   logic        npu_is_busy;
   logic [16:0] npu_end_addr;
-  logic [2:0]  npu_rd_valid_pipe;
-  logic [2:0]  npu_rd_last_pipe;
+  logic [URAM_LATENCY-1:0] npu_rd_valid_pipe;
+  logic [URAM_LATENCY-1:0] npu_rd_last_pipe;
   logic        npu_read_fire;
   logic        npu_write_fire;
 
@@ -143,17 +145,17 @@ module mem_GLOBAL_cache (
   assign npu_write_fire  = npu_is_busy &  npu_write_en;
 
   assign M_AXIS_NPU_FMAP.tdata  = OUT_npu_rdata;
-  assign M_AXIS_NPU_FMAP.tvalid = npu_rd_valid_pipe[2];
-  assign M_AXIS_NPU_FMAP.tlast  = npu_rd_last_pipe[2];
+  assign M_AXIS_NPU_FMAP.tvalid = npu_rd_valid_pipe[URAM_LATENCY-1];
+  assign M_AXIS_NPU_FMAP.tlast  = npu_rd_last_pipe[URAM_LATENCY-1];
   assign M_AXIS_NPU_FMAP.tkeep  = '1;
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
-      npu_rd_valid_pipe <= 3'b000;
-      npu_rd_last_pipe  <= 3'b000;
+      npu_rd_valid_pipe <= '0;
+      npu_rd_last_pipe  <= '0;
     end else begin
-      npu_rd_valid_pipe <= {npu_rd_valid_pipe[1:0], npu_read_fire};
-      npu_rd_last_pipe  <= {npu_rd_last_pipe[1:0], (npu_read_fire && (npu_ptr + 17'd1 >= npu_end_addr))};
+      npu_rd_valid_pipe <= {npu_rd_valid_pipe[URAM_LATENCY-2:0], npu_read_fire};
+      npu_rd_last_pipe  <= {npu_rd_last_pipe[URAM_LATENCY-2:0], (npu_read_fire && (npu_ptr + 17'd1 >= npu_end_addr))};
     end
   end
 

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -89,8 +89,12 @@ module mem_GLOBAL_cache (
   logic        acp_write_en;
   logic        acp_is_busy;
   logic [16:0] acp_end_addr;
+  logic        acp_cmd_pending;
+  logic        acp_cmd_write_en;
+  logic [16:0] acp_cmd_base_addr;
+  logic [16:0] acp_cmd_end_addr;
 
-  assign OUT_acp_is_busy = acp_is_busy;
+  assign OUT_acp_is_busy = acp_is_busy | acp_cmd_pending;
 
   localparam int URAM_LATENCY = 7;
 
@@ -117,6 +121,10 @@ module mem_GLOBAL_cache (
       acp_end_addr <= '0;
       acp_is_busy  <= 1'b0;
       acp_write_en <= 1'b0;
+      acp_cmd_pending   <= 1'b0;
+      acp_cmd_write_en  <= 1'b0;
+      acp_cmd_base_addr <= '0;
+      acp_cmd_end_addr  <= '0;
     end else begin
       if (acp_is_busy) begin
         if (acp_write_en) begin
@@ -130,11 +138,17 @@ module mem_GLOBAL_cache (
             if (acp_ptr + 17'd1 >= acp_end_addr) acp_is_busy <= 1'b0;
           end
         end
+      end else if (acp_cmd_pending) begin
+        acp_ptr         <= acp_cmd_base_addr;
+        acp_end_addr    <= acp_cmd_end_addr;
+        acp_is_busy     <= 1'b1;
+        acp_write_en    <= acp_cmd_write_en;
+        acp_cmd_pending <= 1'b0;
       end else if (IN_acp_rx_start) begin
-        acp_ptr      <= IN_acp_base_addr;
-        acp_end_addr <= IN_acp_end_addr;
-        acp_is_busy  <= 1'b1;
-        acp_write_en <= IN_acp_write_en;
+        acp_cmd_base_addr <= IN_acp_base_addr;
+        acp_cmd_end_addr  <= IN_acp_end_addr;
+        acp_cmd_write_en  <= IN_acp_write_en;
+        acp_cmd_pending   <= 1'b1;
       end
     end
   end

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -19,8 +19,8 @@ import isa_pkg::*;
 //   Port A — ACP DMA : host DDR4 ↔ L2 via AXI-Stream (CDC via mem_BUFFER).
 //   Port B — NPU     : compute engines (GEMM / GEMV / CVO) streaming R/W.
 // Arbitration  : Port B is driven externally via IN_npu_* signals; the
-//                upstream mem_dispatcher mux (final_npu_*) decides which
-//                producer (NPU FSM vs CVO bridge) wins port B per cycle.
+//                upstream mem_dispatcher drives IN_npu_direct_* when the CVO
+//                bridge owns port B; otherwise the local NPU FSM owns it.
 // Latency      : ACP/NPU read = URAM_LATENCY cycles after read issue;
 //                tracked via acp_rd_valid_pipe.
 // Throughput   : 1 ACP transaction + 1 NPU transaction in flight in parallel.
@@ -55,6 +55,13 @@ module mem_GLOBAL_cache (
     input  logic         IN_npu_rx_start,
     input  logic  [16:0] IN_npu_end_addr,
     output logic         OUT_npu_is_busy,
+
+    // Direct port-B owner: CVO bridge in mem_dispatcher. When asserted, the
+    // local NPU FSM is held so the bridge can issue explicit L2 reads/writes.
+    input  logic         IN_npu_direct_en,
+    input  logic         IN_npu_direct_we,
+    input  logic  [16:0] IN_npu_direct_addr,
+    input  logic [127:0] IN_npu_direct_wdata,
 
     input  logic [127:0] IN_npu_wdata,
     output logic [127:0] OUT_npu_rdata
@@ -139,10 +146,15 @@ module mem_GLOBAL_cache (
   logic [URAM_LATENCY-1:0] npu_rd_last_pipe;
   logic        npu_read_fire;
   logic        npu_write_fire;
+  logic        npu_direct_active;
+  logic        l2_npu_we;
+  logic [16:0] l2_npu_addr;
+  logic [127:0] l2_npu_wdata;
 
   assign OUT_npu_is_busy = npu_is_busy;
-  assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready;
-  assign npu_write_fire  = npu_is_busy &  npu_write_en;
+  assign npu_direct_active = IN_npu_direct_en;
+  assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready & ~npu_direct_active;
+  assign npu_write_fire  = npu_is_busy &  npu_write_en & ~npu_direct_active;
 
   assign M_AXIS_NPU_FMAP.tdata  = OUT_npu_rdata;
   assign M_AXIS_NPU_FMAP.tvalid = npu_rd_valid_pipe[URAM_LATENCY-1];
@@ -180,6 +192,18 @@ module mem_GLOBAL_cache (
     end
   end
 
+  always_comb begin
+    l2_npu_we    = npu_write_fire;
+    l2_npu_addr  = npu_ptr;
+    l2_npu_wdata = IN_npu_wdata;
+
+    if (npu_direct_active) begin
+      l2_npu_we    = IN_npu_direct_we;
+      l2_npu_addr  = IN_npu_direct_addr;
+      l2_npu_wdata = IN_npu_direct_wdata;
+    end
+  end
+
   // ===| L2 URAM (port B shared between ACP read-out and NPU compute) |=========
   // Port A → ACP DMA (write when host→L2, read when L2→host)
   // Port B → NPU compute (fmap broadcast, CVO streaming)
@@ -196,9 +220,9 @@ module mem_GLOBAL_cache (
       .OUT_acp_rdata(core_acp_tx_bus.tdata),
 
       // Port B — NPU compute
-      .IN_npu_we    (npu_write_fire),
-      .IN_npu_addr  (npu_ptr),
-      .IN_npu_wdata (IN_npu_wdata),
+      .IN_npu_we    (l2_npu_we),
+      .IN_npu_addr  (l2_npu_addr),
+      .IN_npu_wdata (l2_npu_wdata),
       .OUT_npu_rdata(OUT_npu_rdata)
   );
 

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -56,9 +56,11 @@ module mem_GLOBAL_cache (
     input  logic  [16:0] IN_npu_end_addr,
     output logic         OUT_npu_is_busy,
 
-    // Direct port-B owner: CVO bridge in mem_dispatcher. When asserted, the
-    // local NPU FSM is held so the bridge can issue explicit L2 reads/writes.
+    // Direct port-B owner: CVO bridge in mem_dispatcher. IN_npu_direct_en
+    // holds the local NPU FSM; IN_npu_direct_valid selects an explicit L2
+    // command so bridge FSM state does not sit in the URAM address mux.
     input  logic         IN_npu_direct_en,
+    input  logic         IN_npu_direct_valid,
     input  logic         IN_npu_direct_we,
     input  logic  [16:0] IN_npu_direct_addr,
     input  logic [127:0] IN_npu_direct_wdata,
@@ -149,12 +151,14 @@ module mem_GLOBAL_cache (
   logic        npu_write_fire;
   logic        npu_on_last_word;
   logic        npu_direct_active;
+  logic        npu_direct_cmd;
   logic        l2_npu_we;
   logic [16:0] l2_npu_addr;
   logic [127:0] l2_npu_wdata;
 
   assign OUT_npu_is_busy = npu_is_busy;
   assign npu_direct_active = IN_npu_direct_en;
+  assign npu_direct_cmd = IN_npu_direct_en & IN_npu_direct_valid;
   assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready & ~npu_direct_active;
   assign npu_write_fire  = npu_is_busy &  npu_write_en & ~npu_direct_active;
   assign npu_on_last_word = (npu_ptr >= npu_last_addr);
@@ -202,7 +206,7 @@ module mem_GLOBAL_cache (
     l2_npu_addr  = npu_ptr;
     l2_npu_wdata = IN_npu_wdata;
 
-    if (npu_direct_active) begin
+    if (npu_direct_cmd) begin
       l2_npu_we    = IN_npu_direct_we;
       l2_npu_addr  = IN_npu_direct_addr;
       l2_npu_wdata = IN_npu_direct_wdata;

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -57,8 +57,8 @@ module mem_GLOBAL_cache (
     output logic         OUT_npu_is_busy,
 
     // Direct port-B owner: CVO bridge in mem_dispatcher. IN_npu_direct_en
-    // holds the local NPU FSM; IN_npu_direct_valid selects an explicit L2
-    // command so bridge FSM state does not sit in the URAM address mux.
+    // holds the local NPU FSM; registered IN_npu_direct_valid selects an
+    // explicit L2 command so bridge FSM state does not sit in the URAM muxes.
     input  logic         IN_npu_direct_en,
     input  logic         IN_npu_direct_valid,
     input  logic         IN_npu_direct_we,
@@ -158,7 +158,7 @@ module mem_GLOBAL_cache (
 
   assign OUT_npu_is_busy = npu_is_busy;
   assign npu_direct_active = IN_npu_direct_en;
-  assign npu_direct_cmd = IN_npu_direct_en & IN_npu_direct_valid;
+  assign npu_direct_cmd = IN_npu_direct_valid;
   assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready & ~npu_direct_active;
   assign npu_write_fire  = npu_is_busy &  npu_write_en & ~npu_direct_active;
   assign npu_on_last_word = (npu_ptr >= npu_last_addr);

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -57,8 +57,7 @@ module mem_GLOBAL_cache (
     output logic         OUT_npu_is_busy,
 
     // Direct port-B owner: CVO bridge in mem_dispatcher. IN_npu_direct_en
-    // holds the local NPU FSM; registered IN_npu_direct_valid selects an
-    // explicit L2 command so bridge FSM state does not sit in the URAM muxes.
+    // holds the local NPU FSM while a bridge op is active.
     input  logic         IN_npu_direct_en,
     input  logic         IN_npu_direct_valid,
     input  logic         IN_npu_direct_we,
@@ -166,13 +165,17 @@ module mem_GLOBAL_cache (
   logic        npu_on_last_word;
   logic        npu_direct_active;
   logic        npu_direct_cmd;
+  logic        npu_direct_cmd_q;
+  logic        npu_direct_we_q;
+  logic [16:0] npu_direct_addr_q;
+  logic [127:0] npu_direct_wdata_q;
   logic        l2_npu_we;
   logic [16:0] l2_npu_addr;
   logic [127:0] l2_npu_wdata;
 
   assign OUT_npu_is_busy = npu_is_busy;
-  assign npu_direct_active = IN_npu_direct_en;
-  assign npu_direct_cmd = IN_npu_direct_valid;
+  assign npu_direct_active = IN_npu_direct_en | npu_direct_cmd_q;
+  assign npu_direct_cmd = npu_direct_cmd_q;
   assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready & ~npu_direct_active;
   assign npu_write_fire  = npu_is_busy &  npu_write_en & ~npu_direct_active;
   assign npu_on_last_word = (npu_ptr >= npu_last_addr);
@@ -189,6 +192,22 @@ module mem_GLOBAL_cache (
     end else begin
       npu_rd_valid_pipe <= {npu_rd_valid_pipe[URAM_LATENCY-2:0], npu_read_fire};
       npu_rd_last_pipe  <= {npu_rd_last_pipe[URAM_LATENCY-2:0], (npu_read_fire && npu_on_last_word)};
+    end
+  end
+
+  // Stage CVO direct commands next to the L2 port-B mux so the bridge FSM valid
+  // pulse does not fan out directly into the URAM write-control net.
+  always_ff @(posedge clk_core) begin
+    if (!rst_n_core) begin
+      npu_direct_cmd_q   <= 1'b0;
+      npu_direct_we_q    <= 1'b0;
+      npu_direct_addr_q  <= '0;
+      npu_direct_wdata_q <= '0;
+    end else begin
+      npu_direct_cmd_q   <= IN_npu_direct_valid;
+      npu_direct_we_q    <= IN_npu_direct_we;
+      npu_direct_addr_q  <= IN_npu_direct_addr;
+      npu_direct_wdata_q <= IN_npu_direct_wdata;
     end
   end
 
@@ -221,9 +240,9 @@ module mem_GLOBAL_cache (
     l2_npu_wdata = IN_npu_wdata;
 
     if (npu_direct_cmd) begin
-      l2_npu_we    = IN_npu_direct_we;
-      l2_npu_addr  = IN_npu_direct_addr;
-      l2_npu_wdata = IN_npu_direct_wdata;
+      l2_npu_we    = npu_direct_we_q;
+      l2_npu_addr  = npu_direct_addr_q;
+      l2_npu_wdata = npu_direct_wdata_q;
     end
   end
 

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -38,6 +38,7 @@ module mem_GLOBAL_cache (
     // ===| AXI-Stream ACP (external, AXI clock domain) |========================
     axis_if.slave  S_AXIS_ACP_FMAP,    // feature map in  (128-bit, from PS/DDR4)
     axis_if.master M_AXIS_ACP_RESULT,  // result out       (128-bit, to PS/DDR4)
+    axis_if.master M_AXIS_NPU_FMAP,    // L2 -> preprocess fmap stream
 
     // ===| Port A — ACP DMA control |============================================
     input  logic        IN_acp_write_en,   // 1=write (DDR→L2), 0=read (L2→DDR)
@@ -130,8 +131,29 @@ module mem_GLOBAL_cache (
   logic        npu_write_en;
   logic        npu_is_busy;
   logic [16:0] npu_end_addr;
+  logic [2:0]  npu_rd_valid_pipe;
+  logic [2:0]  npu_rd_last_pipe;
+  logic        npu_read_fire;
+  logic        npu_write_fire;
 
   assign OUT_npu_is_busy = npu_is_busy;
+  assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready;
+  assign npu_write_fire  = npu_is_busy &  npu_write_en;
+
+  assign M_AXIS_NPU_FMAP.tdata  = OUT_npu_rdata;
+  assign M_AXIS_NPU_FMAP.tvalid = npu_rd_valid_pipe[2];
+  assign M_AXIS_NPU_FMAP.tlast  = npu_rd_last_pipe[2];
+  assign M_AXIS_NPU_FMAP.tkeep  = '1;
+
+  always_ff @(posedge clk_core) begin
+    if (!rst_n_core) begin
+      npu_rd_valid_pipe <= 3'b000;
+      npu_rd_last_pipe  <= 3'b000;
+    end else begin
+      npu_rd_valid_pipe <= {npu_rd_valid_pipe[1:0], npu_read_fire};
+      npu_rd_last_pipe  <= {npu_rd_last_pipe[1:0], (npu_read_fire && (npu_ptr + 17'd1 >= npu_end_addr))};
+    end
+  end
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
@@ -141,8 +163,10 @@ module mem_GLOBAL_cache (
       npu_write_en <= 1'b0;
     end else begin
       if (npu_is_busy) begin
-        npu_ptr <= npu_ptr + 17'd1;
-        if (npu_ptr + 17'd1 >= npu_end_addr) npu_is_busy <= 1'b0;
+        if (npu_write_fire || npu_read_fire) begin
+          npu_ptr <= npu_ptr + 17'd1;
+          if (npu_ptr + 17'd1 >= npu_end_addr) npu_is_busy <= 1'b0;
+        end
       end else if (IN_npu_rx_start) begin
         npu_ptr      <= IN_npu_base_addr;
         npu_end_addr <= IN_npu_end_addr;
@@ -168,7 +192,7 @@ module mem_GLOBAL_cache (
       .OUT_acp_rdata(core_acp_tx_bus.tdata),
 
       // Port B — NPU compute
-      .IN_npu_we    (npu_write_en & npu_is_busy),
+      .IN_npu_we    (npu_write_fire),
       .IN_npu_addr  (npu_ptr),
       .IN_npu_wdata (IN_npu_wdata),
       .OUT_npu_rdata(OUT_npu_rdata)

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -83,7 +83,7 @@ module mem_GLOBAL_cache (
 
   assign OUT_acp_is_busy = acp_is_busy;
 
-  localparam int URAM_LATENCY = 5;
+  localparam int URAM_LATENCY = 7;
 
   // ACP read pipeline: tracks mem_L2_cache_fmap READ_LATENCY.
   logic [URAM_LATENCY-1:0] acp_rd_valid_pipe;

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -83,7 +83,7 @@ module mem_GLOBAL_cache (
 
   assign OUT_acp_is_busy = acp_is_busy;
 
-  localparam int URAM_LATENCY = 4;
+  localparam int URAM_LATENCY = 5;
 
   // ACP read pipeline: tracks mem_L2_cache_fmap READ_LATENCY.
   logic [URAM_LATENCY-1:0] acp_rd_valid_pipe;

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"
 `include "GLOBAL_CONST.svh"

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -142,10 +142,12 @@ module mem_GLOBAL_cache (
   logic        npu_write_en;
   logic        npu_is_busy;
   logic [16:0] npu_end_addr;
+  logic [16:0] npu_last_addr;
   logic [URAM_LATENCY-1:0] npu_rd_valid_pipe;
   logic [URAM_LATENCY-1:0] npu_rd_last_pipe;
   logic        npu_read_fire;
   logic        npu_write_fire;
+  logic        npu_on_last_word;
   logic        npu_direct_active;
   logic        l2_npu_we;
   logic [16:0] l2_npu_addr;
@@ -155,6 +157,7 @@ module mem_GLOBAL_cache (
   assign npu_direct_active = IN_npu_direct_en;
   assign npu_read_fire   = npu_is_busy & ~npu_write_en & M_AXIS_NPU_FMAP.tready & ~npu_direct_active;
   assign npu_write_fire  = npu_is_busy &  npu_write_en & ~npu_direct_active;
+  assign npu_on_last_word = (npu_ptr >= npu_last_addr);
 
   assign M_AXIS_NPU_FMAP.tdata  = OUT_npu_rdata;
   assign M_AXIS_NPU_FMAP.tvalid = npu_rd_valid_pipe[URAM_LATENCY-1];
@@ -167,7 +170,7 @@ module mem_GLOBAL_cache (
       npu_rd_last_pipe  <= '0;
     end else begin
       npu_rd_valid_pipe <= {npu_rd_valid_pipe[URAM_LATENCY-2:0], npu_read_fire};
-      npu_rd_last_pipe  <= {npu_rd_last_pipe[URAM_LATENCY-2:0], (npu_read_fire && (npu_ptr + 17'd1 >= npu_end_addr))};
+      npu_rd_last_pipe  <= {npu_rd_last_pipe[URAM_LATENCY-2:0], (npu_read_fire && npu_on_last_word)};
     end
   end
 
@@ -175,17 +178,19 @@ module mem_GLOBAL_cache (
     if (!rst_n_core) begin
       npu_ptr      <= '0;
       npu_end_addr <= '0;
+      npu_last_addr <= '0;
       npu_is_busy  <= 1'b0;
       npu_write_en <= 1'b0;
     end else begin
       if (npu_is_busy) begin
         if (npu_write_fire || npu_read_fire) begin
           npu_ptr <= npu_ptr + 17'd1;
-          if (npu_ptr + 17'd1 >= npu_end_addr) npu_is_busy <= 1'b0;
+          if (npu_on_last_word) npu_is_busy <= 1'b0;
         end
       end else if (IN_npu_rx_start) begin
         npu_ptr      <= IN_npu_base_addr;
         npu_end_addr <= IN_npu_end_addr;
+        npu_last_addr <= IN_npu_end_addr - 17'd1;
         npu_is_busy  <= 1'b1;
         npu_write_en <= IN_npu_write_en;
       end

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -43,7 +43,8 @@ module mem_CVO_stream_bridge (
     output logic             OUT_done,
 
     // ===| L2 port B direct interface (128-bit) |================================
-    // Single-address mux: write takes priority over read.
+    // Single-address mux: valid command only; write takes priority over read.
+    output logic         OUT_l2_valid,
     output logic         OUT_l2_we,
     output logic [ 16:0] OUT_l2_addr,
     output logic [127:0] OUT_l2_wdata,
@@ -164,6 +165,7 @@ module mem_CVO_stream_bridge (
       OUT_done     <= 1'b0;
     end else begin
       OUT_done      <= 1'b0;
+      rd_word_valid <= 1'b0;
       wr_word_valid <= 1'b0;
 
       case (state)
@@ -192,8 +194,6 @@ module mem_CVO_stream_bridge (
 
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
-          rd_word_valid <= 1'b0;
-
           // Advance latency shift register
           rd_lat_pipe <= {rd_lat_pipe[5:0], rd_word_valid};
 
@@ -267,6 +267,7 @@ module mem_CVO_stream_bridge (
   // ===| L2 port B output mux ===================================================
   // Priority: write (WRITE phase) > read (READ phase)
   always_comb begin
+    OUT_l2_valid = 1'b0;
     OUT_l2_we    = 1'b0;
     OUT_l2_addr  = '0;
     OUT_l2_wdata = '0;
@@ -274,11 +275,13 @@ module mem_CVO_stream_bridge (
     if (wr_word_valid) begin
       // Write registered 128-bit result word to dst.  Keeping write data
       // registered avoids a count-controlled 128-bit mux on the URAM DIN path.
+      OUT_l2_valid = 1'b1;
       OUT_l2_we    = 1'b1;
       OUT_l2_addr  = wr_word_addr;
       OUT_l2_wdata = wr_word_data;
-    end else if (state == ST_READ && rd_word_valid) begin
+    end else if (rd_word_valid) begin
       // Issue registered read for next 128-bit word from src.
+      OUT_l2_valid = 1'b1;
       OUT_l2_we   = 1'b0;
       OUT_l2_addr = rd_word_addr;
     end

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -93,8 +93,11 @@ module mem_CVO_stream_bridge (
   logic [127:0] rd_deser_buf;  // latched 128-bit L2 word
   logic         rd_buf_valid;  // deser buffer holds valid data
   logic [ 15:0] elems_fed;  // elements delivered to CVO
+  logic         rd_word_valid;  // registered one-cycle L2 read command
+  logic [ 16:0] rd_word_addr;  // registered source word address
 
-  // 7-cycle read latency tracking
+  // 7-cycle read latency tracking after the registered address command is
+  // presented to the synchronous URAM port-B input.
   logic [  6:0] rd_lat_pipe;  // shift register: [6]=oldest, [0]=newest
 
   // ===| Write-side state |======================================================
@@ -147,6 +150,8 @@ module mem_CVO_stream_bridge (
       rd_elem_idx  <= '0;
       rd_deser_buf <= '0;
       rd_buf_valid <= 1'b0;
+      rd_word_valid <= 1'b0;
+      rd_word_addr  <= '0;
       rd_lat_pipe  <= 7'b0;
       elems_fed    <= '0;
       wr_elem_idx  <= '0;
@@ -172,6 +177,8 @@ module mem_CVO_stream_bridge (
             rd_word_cnt  <= '0;
             rd_elem_idx  <= '0;
             rd_buf_valid <= 1'b0;
+            rd_word_valid <= 1'b0;
+            rd_word_addr  <= 17'(IN_cvo_uop.src_addr >> 3);
             rd_lat_pipe  <= 7'b0;
             elems_fed    <= '0;
             wr_elem_idx  <= '0;
@@ -185,13 +192,18 @@ module mem_CVO_stream_bridge (
 
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
-          // Advance latency shift register
-          rd_lat_pipe <= {rd_lat_pipe[5:0], 1'b0};
+          rd_word_valid <= 1'b0;
 
-          // Issue next L2 read when deser buffer is empty (pre-fetch when 3 left)
+          // Advance latency shift register
+          rd_lat_pipe <= {rd_lat_pipe[5:0], rd_word_valid};
+
+          // Issue next L2 read from a registered address boundary.  The prior
+          // combinational rd_base+rd_word_cnt path drove the URAM cascade
+          // address directly and became the post-synth top setup path.
           if (!rd_buf_valid && rd_word_cnt < 13'(total_words)) begin
-            rd_lat_pipe[0] <= 1'b1;  // mark new read outstanding
-            rd_word_cnt    <= rd_word_cnt + 13'd1;
+            rd_word_addr  <= 17'(rd_base + rd_word_cnt);
+            rd_word_valid <= 1'b1;
+            rd_word_cnt   <= rd_word_cnt + 13'd1;
           end
 
           // Capture L2 data 7 cycles after read issued
@@ -265,10 +277,10 @@ module mem_CVO_stream_bridge (
       OUT_l2_we    = 1'b1;
       OUT_l2_addr  = wr_word_addr;
       OUT_l2_wdata = wr_word_data;
-    end else if (state == ST_READ && rd_lat_pipe[0]) begin
-      // Issue read for next 128-bit word from src
+    end else if (state == ST_READ && rd_word_valid) begin
+      // Issue registered read for next 128-bit word from src.
       OUT_l2_we   = 1'b0;
-      OUT_l2_addr = 17'(rd_base + (rd_word_cnt - 13'd1));
+      OUT_l2_addr = rd_word_addr;
     end
   end
 

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -19,7 +19,7 @@ import isa_pkg::*;
 //   Phase 2 — WRITE: drain FIFO → serialise 8 × 16-bit → 128-bit bursts
 //                    → write to L2[dst_addr..dst_addr+N_words-1].
 // L2 addr unit : 128-bit words. base_addr N ↔ bytes [16*N .. 16*N+15].
-// L2 read lat  : 5 clocks (URAM READ_LATENCY_B = 5) — tracked via rd_lat_pipe.
+// L2 read lat  : 7 clocks (URAM READ_LATENCY_B = 7) — tracked via rd_lat_pipe.
 // Max vec len  : ResultFifoDepth × 16-bit = 32 KB (1 BRAM36 instance) — the
 //                FIFO depth caps the longest CVO op vector.
 // Handshake    : OUT_cvo_valid asserts during READ phase only;
@@ -47,7 +47,7 @@ module mem_CVO_stream_bridge (
     output logic         OUT_l2_we,
     output logic [ 16:0] OUT_l2_addr,
     output logic [127:0] OUT_l2_wdata,
-    input  logic [127:0] IN_l2_rdata,   // valid 4 cycles after OUT_l2_addr+~we
+    input  logic [127:0] IN_l2_rdata,   // valid 7 cycles after OUT_l2_addr+~we
 
     // ===| CVO data stream (to CVO_top.IN_data) |=================================
     output logic [15:0] OUT_cvo_data,
@@ -94,8 +94,8 @@ module mem_CVO_stream_bridge (
   logic         rd_buf_valid;  // deser buffer holds valid data
   logic [ 15:0] elems_fed;  // elements delivered to CVO
 
-  // 5-cycle read latency tracking
-  logic [  4:0] rd_lat_pipe;  // shift register: [4]=oldest, [0]=newest
+  // 7-cycle read latency tracking
+  logic [  6:0] rd_lat_pipe;  // shift register: [6]=oldest, [0]=newest
 
   // ===| Write-side state |======================================================
   logic [  2:0] wr_elem_idx;  // accumulation index 0..7
@@ -147,7 +147,7 @@ module mem_CVO_stream_bridge (
       rd_elem_idx  <= '0;
       rd_deser_buf <= '0;
       rd_buf_valid <= 1'b0;
-      rd_lat_pipe  <= 5'b0;
+      rd_lat_pipe  <= 7'b0;
       elems_fed    <= '0;
       wr_elem_idx  <= '0;
       wr_ser_buf   <= '0;
@@ -172,7 +172,7 @@ module mem_CVO_stream_bridge (
             rd_word_cnt  <= '0;
             rd_elem_idx  <= '0;
             rd_buf_valid <= 1'b0;
-            rd_lat_pipe  <= 5'b0;
+            rd_lat_pipe  <= 7'b0;
             elems_fed    <= '0;
             wr_elem_idx  <= '0;
             wr_ser_buf   <= '0;
@@ -186,7 +186,7 @@ module mem_CVO_stream_bridge (
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
           // Advance latency shift register
-          rd_lat_pipe <= {rd_lat_pipe[3:0], 1'b0};
+          rd_lat_pipe <= {rd_lat_pipe[5:0], 1'b0};
 
           // Issue next L2 read when deser buffer is empty (pre-fetch when 3 left)
           if (!rd_buf_valid && rd_word_cnt < 13'(total_words)) begin
@@ -194,8 +194,8 @@ module mem_CVO_stream_bridge (
             rd_word_cnt    <= rd_word_cnt + 13'd1;
           end
 
-          // Capture L2 data 5 cycles after read issued
-          if (rd_lat_pipe[4]) begin
+          // Capture L2 data 7 cycles after read issued
+          if (rd_lat_pipe[6]) begin
             rd_deser_buf <= IN_l2_rdata;
             rd_buf_valid <= 1'b1;
             rd_elem_idx  <= 3'd0;

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GLOBAL_CONST.svh"
 
@@ -17,7 +19,7 @@ import isa_pkg::*;
 //   Phase 2 — WRITE: drain FIFO → serialise 8 × 16-bit → 128-bit bursts
 //                    → write to L2[dst_addr..dst_addr+N_words-1].
 // L2 addr unit : 128-bit words. base_addr N ↔ bytes [16*N .. 16*N+15].
-// L2 read lat  : 3 clocks (URAM READ_LATENCY_B = 3) — tracked via rd_lat_pipe.
+// L2 read lat  : 4 clocks (URAM READ_LATENCY_B = 4) — tracked via rd_lat_pipe.
 // Max vec len  : ResultFifoDepth × 16-bit = 32 KB (1 BRAM36 instance) — the
 //                FIFO depth caps the longest CVO op vector.
 // Handshake    : OUT_cvo_valid asserts during READ phase only;
@@ -45,7 +47,7 @@ module mem_CVO_stream_bridge (
     output logic         OUT_l2_we,
     output logic [ 16:0] OUT_l2_addr,
     output logic [127:0] OUT_l2_wdata,
-    input  logic [127:0] IN_l2_rdata,   // valid 3 cycles after OUT_l2_addr+~we
+    input  logic [127:0] IN_l2_rdata,   // valid 4 cycles after OUT_l2_addr+~we
 
     // ===| CVO data stream (to CVO_top.IN_data) |=================================
     output logic [15:0] OUT_cvo_data,
@@ -93,7 +95,7 @@ module mem_CVO_stream_bridge (
   logic [ 15:0] elems_fed;  // elements delivered to CVO
 
   // 3-cycle read latency tracking
-  logic [  2:0] rd_lat_pipe;  // shift register: [2]=oldest, [0]=newest
+  logic [  3:0] rd_lat_pipe;  // shift register: [3]=oldest, [0]=newest
 
   // ===| Write-side state |======================================================
   logic [  2:0] wr_elem_idx;  // accumulation index 0..7
@@ -142,7 +144,7 @@ module mem_CVO_stream_bridge (
       rd_elem_idx  <= '0;
       rd_deser_buf <= '0;
       rd_buf_valid <= 1'b0;
-      rd_lat_pipe  <= 3'b0;
+      rd_lat_pipe  <= 4'b0;
       elems_fed    <= '0;
       wr_elem_idx  <= '0;
       wr_ser_buf   <= '0;
@@ -163,7 +165,7 @@ module mem_CVO_stream_bridge (
             rd_word_cnt  <= '0;
             rd_elem_idx  <= '0;
             rd_buf_valid <= 1'b0;
-            rd_lat_pipe  <= 3'b0;
+            rd_lat_pipe  <= 4'b0;
             elems_fed    <= '0;
             wr_elem_idx  <= '0;
             wr_ser_buf   <= '0;
@@ -176,7 +178,7 @@ module mem_CVO_stream_bridge (
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
           // Advance latency shift register
-          rd_lat_pipe <= {rd_lat_pipe[1:0], 1'b0};
+          rd_lat_pipe <= {rd_lat_pipe[2:0], 1'b0};
 
           // Issue next L2 read when deser buffer is empty (pre-fetch when 3 left)
           if (!rd_buf_valid && rd_word_cnt < 13'(total_words)) begin
@@ -184,8 +186,8 @@ module mem_CVO_stream_bridge (
             rd_word_cnt    <= rd_word_cnt + 13'd1;
           end
 
-          // Capture L2 data 3 cycles after read issued
-          if (rd_lat_pipe[2]) begin
+          // Capture L2 data 4 cycles after read issued
+          if (rd_lat_pipe[3]) begin
             rd_deser_buf <= IN_l2_rdata;
             rd_buf_valid <= 1'b1;
             rd_elem_idx  <= 3'd0;

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -19,7 +19,8 @@ import isa_pkg::*;
 //   Phase 2 — WRITE: drain FIFO → serialise 8 × 16-bit → 128-bit bursts
 //                    → write to L2[dst_addr..dst_addr+N_words-1].
 // L2 addr unit : 128-bit words. base_addr N ↔ bytes [16*N .. 16*N+15].
-// L2 read lat  : 7 clocks (URAM READ_LATENCY_B = 7) — tracked via rd_lat_pipe.
+// L2 read lat  : 8 clocks (1 registered direct-command handoff +
+//                URAM READ_LATENCY_B = 7) — tracked via rd_lat_pipe.
 // Max vec len  : ResultFifoDepth × 16-bit = 32 KB (1 BRAM36 instance) — the
 //                FIFO depth caps the longest CVO op vector.
 // Handshake    : OUT_cvo_valid asserts during READ phase only;
@@ -97,9 +98,10 @@ module mem_CVO_stream_bridge (
   logic         rd_word_valid;  // registered one-cycle L2 read command
   logic [ 16:0] rd_word_addr;  // registered source word address
 
-  // 7-cycle read latency tracking after the registered address command is
-  // presented to the synchronous URAM port-B input.
-  logic [  6:0] rd_lat_pipe;  // shift register: [6]=oldest, [0]=newest
+  // Read latency tracking after the registered address command is presented to
+  // mem_GLOBAL_cache, which stages CVO direct commands once before the URAM.
+  localparam int L2ReadLatencyCycles = 8;
+  logic [L2ReadLatencyCycles-1:0] rd_lat_pipe;
 
   // ===| Write-side state |======================================================
   logic [  2:0] wr_elem_idx;  // accumulation index 0..7
@@ -153,7 +155,7 @@ module mem_CVO_stream_bridge (
       rd_buf_valid <= 1'b0;
       rd_word_valid <= 1'b0;
       rd_word_addr  <= '0;
-      rd_lat_pipe  <= 7'b0;
+      rd_lat_pipe  <= '0;
       elems_fed    <= '0;
       wr_elem_idx  <= '0;
       wr_ser_buf   <= '0;
@@ -181,7 +183,7 @@ module mem_CVO_stream_bridge (
             rd_buf_valid <= 1'b0;
             rd_word_valid <= 1'b0;
             rd_word_addr  <= 17'(IN_cvo_uop.src_addr >> 3);
-            rd_lat_pipe  <= 7'b0;
+            rd_lat_pipe  <= '0;
             elems_fed    <= '0;
             wr_elem_idx  <= '0;
             wr_ser_buf   <= '0;
@@ -195,7 +197,7 @@ module mem_CVO_stream_bridge (
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
           // Advance latency shift register
-          rd_lat_pipe <= {rd_lat_pipe[5:0], rd_word_valid};
+          rd_lat_pipe <= {rd_lat_pipe[L2ReadLatencyCycles-2:0], rd_word_valid};
 
           // Issue next L2 read from a registered address boundary.  The prior
           // combinational rd_base+rd_word_cnt path drove the URAM cascade
@@ -206,8 +208,8 @@ module mem_CVO_stream_bridge (
             rd_word_cnt   <= rd_word_cnt + 13'd1;
           end
 
-          // Capture L2 data 7 cycles after read issued
-          if (rd_lat_pipe[6]) begin
+          // Capture L2 data after the direct-command handoff and URAM latency.
+          if (rd_lat_pipe[L2ReadLatencyCycles-1]) begin
             rd_deser_buf <= IN_l2_rdata;
             rd_buf_valid <= 1'b1;
             rd_elem_idx  <= 3'd0;

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -19,7 +19,7 @@ import isa_pkg::*;
 //   Phase 2 — WRITE: drain FIFO → serialise 8 × 16-bit → 128-bit bursts
 //                    → write to L2[dst_addr..dst_addr+N_words-1].
 // L2 addr unit : 128-bit words. base_addr N ↔ bytes [16*N .. 16*N+15].
-// L2 read lat  : 4 clocks (URAM READ_LATENCY_B = 4) — tracked via rd_lat_pipe.
+// L2 read lat  : 5 clocks (URAM READ_LATENCY_B = 5) — tracked via rd_lat_pipe.
 // Max vec len  : ResultFifoDepth × 16-bit = 32 KB (1 BRAM36 instance) — the
 //                FIFO depth caps the longest CVO op vector.
 // Handshake    : OUT_cvo_valid asserts during READ phase only;
@@ -94,8 +94,8 @@ module mem_CVO_stream_bridge (
   logic         rd_buf_valid;  // deser buffer holds valid data
   logic [ 15:0] elems_fed;  // elements delivered to CVO
 
-  // 3-cycle read latency tracking
-  logic [  3:0] rd_lat_pipe;  // shift register: [3]=oldest, [0]=newest
+  // 5-cycle read latency tracking
+  logic [  4:0] rd_lat_pipe;  // shift register: [4]=oldest, [0]=newest
 
   // ===| Write-side state |======================================================
   logic [  2:0] wr_elem_idx;  // accumulation index 0..7
@@ -144,7 +144,7 @@ module mem_CVO_stream_bridge (
       rd_elem_idx  <= '0;
       rd_deser_buf <= '0;
       rd_buf_valid <= 1'b0;
-      rd_lat_pipe  <= 4'b0;
+      rd_lat_pipe  <= 5'b0;
       elems_fed    <= '0;
       wr_elem_idx  <= '0;
       wr_ser_buf   <= '0;
@@ -165,7 +165,7 @@ module mem_CVO_stream_bridge (
             rd_word_cnt  <= '0;
             rd_elem_idx  <= '0;
             rd_buf_valid <= 1'b0;
-            rd_lat_pipe  <= 4'b0;
+            rd_lat_pipe  <= 5'b0;
             elems_fed    <= '0;
             wr_elem_idx  <= '0;
             wr_ser_buf   <= '0;
@@ -178,7 +178,7 @@ module mem_CVO_stream_bridge (
         // ===| READ: stream L2 → CVO; capture results in FIFO |================
         ST_READ: begin
           // Advance latency shift register
-          rd_lat_pipe <= {rd_lat_pipe[2:0], 1'b0};
+          rd_lat_pipe <= {rd_lat_pipe[3:0], 1'b0};
 
           // Issue next L2 read when deser buffer is empty (pre-fetch when 3 left)
           if (!rd_buf_valid && rd_word_cnt < 13'(total_words)) begin
@@ -186,8 +186,8 @@ module mem_CVO_stream_bridge (
             rd_word_cnt    <= rd_word_cnt + 13'd1;
           end
 
-          // Capture L2 data 4 cycles after read issued
-          if (rd_lat_pipe[3]) begin
+          // Capture L2 data 5 cycles after read issued
+          if (rd_lat_pipe[4]) begin
             rd_deser_buf <= IN_l2_rdata;
             rd_buf_valid <= 1'b1;
             rd_elem_idx  <= 3'd0;

--- a/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
+++ b/hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv
@@ -102,6 +102,9 @@ module mem_CVO_stream_bridge (
   logic [127:0] wr_ser_buf;  // serialisation buffer
   logic [ 12:0] wr_word_cnt;  // words written so far
   logic [ 15:0] elems_result;  // results drained from FIFO
+  logic         wr_word_valid;  // registered one-cycle L2 write command
+  logic [ 16:0] wr_word_addr;  // registered destination word address
+  logic [127:0] wr_word_data;  // registered 128-bit word written to L2
 
   // ===| Output FIFO (CVO results → write buffer) |==============================
   // XPM FIFO sync, depth=2048, width=16 bit (max 32 KB = 1 BRAM36)
@@ -150,9 +153,13 @@ module mem_CVO_stream_bridge (
       wr_ser_buf   <= '0;
       wr_word_cnt  <= '0;
       elems_result <= '0;
+      wr_word_valid <= 1'b0;
+      wr_word_addr  <= '0;
+      wr_word_data  <= '0;
       OUT_done     <= 1'b0;
     end else begin
-      OUT_done <= 1'b0;
+      OUT_done      <= 1'b0;
+      wr_word_valid <= 1'b0;
 
       case (state)
         // ===| IDLE: latch uop, convert element addresses to word addresses |===
@@ -171,6 +178,7 @@ module mem_CVO_stream_bridge (
             wr_ser_buf   <= '0;
             wr_word_cnt  <= '0;
             elems_result <= '0;
+            wr_word_valid <= 1'b0;
             state        <= ST_READ;
           end
         end
@@ -218,8 +226,11 @@ module mem_CVO_stream_bridge (
 
           // When 8 elements accumulated (or last partial word), write to L2
           if (wr_elem_idx == 3'd7 || elems_result == total_elems) begin
-            wr_word_cnt <= wr_word_cnt + 13'd1;
-            wr_elem_idx <= 3'd0;
+            wr_word_valid <= 1'b1;
+            wr_word_addr  <= 17'(wr_base + wr_word_cnt);
+            wr_word_data  <= {fifo_dout, wr_ser_buf[127:16]};
+            wr_word_cnt   <= wr_word_cnt + 13'd1;
+            wr_elem_idx   <= 3'd0;
           end
 
           if (elems_result == total_elems && fifo_empty) begin
@@ -248,11 +259,12 @@ module mem_CVO_stream_bridge (
     OUT_l2_addr  = '0;
     OUT_l2_wdata = '0;
 
-    if (state == ST_WRITE && wr_elem_idx == 3'd0 && wr_word_cnt > 0) begin
-      // Write accumulated 128-bit word to dst
+    if (wr_word_valid) begin
+      // Write registered 128-bit result word to dst.  Keeping write data
+      // registered avoids a count-controlled 128-bit mux on the URAM DIN path.
       OUT_l2_we    = 1'b1;
-      OUT_l2_addr  = 17'(wr_base + (wr_word_cnt - 13'd1));
-      OUT_l2_wdata = wr_ser_buf;
+      OUT_l2_addr  = wr_word_addr;
+      OUT_l2_wdata = wr_word_data;
     end else if (state == ST_READ && rd_lat_pipe[0]) begin
       // Issue read for next 128-bit word from src
       OUT_l2_we   = 1'b0;

--- a/hw/rtl/MEM_control/top/mem_HP_buffer.sv
+++ b/hw/rtl/MEM_control/top/mem_HP_buffer.sv
@@ -47,6 +47,18 @@ module mem_HP_buffer #(
   // ine Large Depth for URAM (4096 uses 2 URAM blocks per FIFO)
   localparam int URAM_FIFO_DEPTH = 4096;
 
+  // Weight streams are fixed-width, continuous beat streams in this v002
+  // boundary. The FIFO instances move data/valid/ready; terminate sidebands
+  // so downstream AXIS ports have a deterministic contract in synthesis.
+  assign M_CORE_HP0_WEIGHT.tkeep = '1;
+  assign M_CORE_HP0_WEIGHT.tlast = 1'b0;
+  assign M_CORE_HP1_WEIGHT.tkeep = '1;
+  assign M_CORE_HP1_WEIGHT.tlast = 1'b0;
+  assign M_CORE_HP2_WEIGHT.tkeep = '1;
+  assign M_CORE_HP2_WEIGHT.tlast = 1'b0;
+  assign M_CORE_HP3_WEIGHT.tkeep = '1;
+  assign M_CORE_HP3_WEIGHT.tlast = 1'b0;
+
   // [1] HP0 Weight FIFO (URAM based - Massive 64KB)
   xpm_fifo_axis #(
       .FIFO_DEPTH      (URAM_FIFO_DEPTH),

--- a/hw/rtl/MEM_control/top/mem_HP_buffer.sv
+++ b/hw/rtl/MEM_control/top/mem_HP_buffer.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"
 `include "GLOBAL_CONST.svh"

--- a/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
+++ b/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GLOBAL_CONST.svh"
 
@@ -11,7 +13,7 @@
 // Ports        :
 //   Port A — ACP DMA path (host DDR4 ↔ L2 via ACP)
 //   Port B — NPU compute  (GEMM / GEMV / CVO streaming R/W)
-// Latency      : READ_LATENCY = 3 cycles (URAM registered output, 400 MHz).
+// Latency      : READ_LATENCY = 4 cycles (URAM registered output, 400 MHz).
 // Throughput   : 1 read + 1 write per port per cycle (true dual-port).
 // Write policy : WRITE_MODE = no_change on both ports (URAM TDP requirement);
 //                read-then-write on the SAME address in the SAME cycle is
@@ -58,8 +60,9 @@ module mem_L2_cache_fmap #(
       // ===| Implementation |===
       .MEMORY_PRIMITIVE   ("ultra"),      // Force URAM on UltraScale+
       .CLOCKING_MODE      ("common_clock"),
-      .READ_LATENCY_A     (3),
-      .READ_LATENCY_B     (3),
+      .CASCADE_HEIGHT     (4),            // Reduce URAM cascade timing depth at 400 MHz
+      .READ_LATENCY_A     (4),
+      .READ_LATENCY_B     (4),
       // URAM true-dual-port requires no-change mode on both ports.
       .WRITE_MODE_A       ("no_change"),
       .WRITE_MODE_B       ("no_change"),

--- a/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
+++ b/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
@@ -13,7 +13,7 @@
 // Ports        :
 //   Port A — ACP DMA path (host DDR4 ↔ L2 via ACP)
 //   Port B — NPU compute  (GEMM / GEMV / CVO streaming R/W)
-// Latency      : READ_LATENCY = 4 cycles (URAM registered output, 400 MHz).
+// Latency      : READ_LATENCY = 5 cycles (URAM cascade/output pipe, 400 MHz).
 // Throughput   : 1 read + 1 write per port per cycle (true dual-port).
 // Write policy : WRITE_MODE = no_change on both ports (URAM TDP requirement);
 //                read-then-write on the SAME address in the SAME cycle is
@@ -61,8 +61,8 @@ module mem_L2_cache_fmap #(
       .MEMORY_PRIMITIVE   ("ultra"),      // Force URAM on UltraScale+
       .CLOCKING_MODE      ("common_clock"),
       .CASCADE_HEIGHT     (4),            // Reduce URAM cascade timing depth at 400 MHz
-      .READ_LATENCY_A     (4),
-      .READ_LATENCY_B     (4),
+      .READ_LATENCY_A     (5),
+      .READ_LATENCY_B     (5),
       // URAM true-dual-port requires no-change mode on both ports.
       .WRITE_MODE_A       ("no_change"),
       .WRITE_MODE_B       ("no_change"),

--- a/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
+++ b/hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv
@@ -13,7 +13,7 @@
 // Ports        :
 //   Port A — ACP DMA path (host DDR4 ↔ L2 via ACP)
 //   Port B — NPU compute  (GEMM / GEMV / CVO streaming R/W)
-// Latency      : READ_LATENCY = 5 cycles (URAM cascade/output pipe, 400 MHz).
+// Latency      : READ_LATENCY = 7 cycles (URAM cascade/output pipe, 400 MHz).
 // Throughput   : 1 read + 1 write per port per cycle (true dual-port).
 // Write policy : WRITE_MODE = no_change on both ports (URAM TDP requirement);
 //                read-then-write on the SAME address in the SAME cycle is
@@ -60,9 +60,9 @@ module mem_L2_cache_fmap #(
       // ===| Implementation |===
       .MEMORY_PRIMITIVE   ("ultra"),      // Force URAM on UltraScale+
       .CLOCKING_MODE      ("common_clock"),
-      .CASCADE_HEIGHT     (4),            // Reduce URAM cascade timing depth at 400 MHz
-      .READ_LATENCY_A     (5),
-      .READ_LATENCY_B     (5),
+      .CASCADE_HEIGHT     (2),            // Shorten URAM cascade timing depth at 400 MHz
+      .READ_LATENCY_A     (7),
+      .READ_LATENCY_B     (7),
       // URAM true-dual-port requires no-change mode on both ports.
       .WRITE_MODE_A       ("no_change"),
       .WRITE_MODE_B       ("no_change"),

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -192,8 +192,10 @@ module mem_dispatcher #() (
   //   s1: capture route/base/shape
   //   s2: compute X*Y
   //   s3: keep the low product operands required by the 17-bit word contract
-  //   s4: compute low 20 bits of X*Y*Z
-  //   s5: compute ceil(X*Y*Z/8) and enqueue descriptor
+  //   s4: register low X*Y and Z from the first product DSP
+  //   s5: register operands at the second product DSP input boundary
+  //   s6: compute low 20 bits of X*Y*Z
+  //   s7: compute ceil(X*Y*Z/8) and enqueue descriptor
   //   issue: enqueue ACP/NPU descriptor
   // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
   // from the 400 MHz core cycle while preserving the external command contract.
@@ -229,27 +231,43 @@ module mem_dispatcher #() (
   logic [16:0] load_s3_base_addr;
   logic [19:0] load_s3_shape_xy_low;
   logic [16:0] load_s3_shape_z;
-  logic [36:0] load_s3_elem_low_product;
 
   logic        load_s4_valid;
   logic        load_s4_to_acp;
   logic        load_s4_to_npu;
   logic        load_s4_write_en;
   logic [16:0] load_s4_base_addr;
-  logic [19:0] load_s4_elem_low20;
-  logic [16:0] load_s4_word_floor;
-  logic        load_s4_word_round;
+  logic [19:0] load_s4_shape_xy_low;
+  logic [16:0] load_s4_shape_z;
 
   logic        load_s5_valid;
   logic        load_s5_to_acp;
   logic        load_s5_to_npu;
   logic        load_s5_write_en;
   logic [16:0] load_s5_base_addr;
-  logic [16:0] load_s5_word_total;
+  logic [19:0] load_s5_shape_xy_low;
+  logic [16:0] load_s5_shape_z;
+  logic [36:0] load_s5_elem_low_product;
 
-  assign load_s3_elem_low_product = load_s3_shape_xy_low * load_s3_shape_z;
-  assign load_s4_word_floor       = load_s4_elem_low20[19:3];
-  assign load_s4_word_round       = |load_s4_elem_low20[2:0];
+  logic        load_s6_valid;
+  logic        load_s6_to_acp;
+  logic        load_s6_to_npu;
+  logic        load_s6_write_en;
+  logic [16:0] load_s6_base_addr;
+  logic [19:0] load_s6_elem_low20;
+  logic [16:0] load_s6_word_floor;
+  logic        load_s6_word_round;
+
+  logic        load_s7_valid;
+  logic        load_s7_to_acp;
+  logic        load_s7_to_npu;
+  logic        load_s7_write_en;
+  logic [16:0] load_s7_base_addr;
+  logic [16:0] load_s7_word_total;
+
+  assign load_s5_elem_low_product = load_s5_shape_xy_low * load_s5_shape_z;
+  assign load_s6_word_floor       = load_s6_elem_low20[19:3];
+  assign load_s6_word_round       = |load_s6_elem_low20[2:0];
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
@@ -286,13 +304,27 @@ module mem_dispatcher #() (
       load_s4_to_npu     <= 1'b0;
       load_s4_write_en   <= 1'b0;
       load_s4_base_addr  <= '0;
-      load_s4_elem_low20 <= '0;
+      load_s4_shape_xy_low <= '0;
+      load_s4_shape_z      <= '0;
       load_s5_valid      <= 1'b0;
       load_s5_to_acp     <= 1'b0;
       load_s5_to_npu     <= 1'b0;
       load_s5_write_en   <= 1'b0;
       load_s5_base_addr  <= '0;
-      load_s5_word_total <= '0;
+      load_s5_shape_xy_low <= '0;
+      load_s5_shape_z      <= '0;
+      load_s6_valid      <= 1'b0;
+      load_s6_to_acp     <= 1'b0;
+      load_s6_to_npu     <= 1'b0;
+      load_s6_write_en   <= 1'b0;
+      load_s6_base_addr  <= '0;
+      load_s6_elem_low20 <= '0;
+      load_s7_valid      <= 1'b0;
+      load_s7_to_acp     <= 1'b0;
+      load_s7_to_npu     <= 1'b0;
+      load_s7_write_en   <= 1'b0;
+      load_s7_base_addr  <= '0;
+      load_s7_word_total <= '0;
     end else begin
       acp_rx_start <= 1'b0;
       npu_rx_start <= 1'b0;
@@ -368,30 +400,46 @@ module mem_dispatcher #() (
       load_s4_to_npu     <= load_s3_to_npu;
       load_s4_write_en   <= load_s3_write_en;
       load_s4_base_addr  <= load_s3_base_addr;
-      load_s4_elem_low20 <= load_s3_elem_low_product[19:0];
+      load_s4_shape_xy_low <= load_s3_shape_xy_low;
+      load_s4_shape_z      <= load_s3_shape_z;
 
       load_s5_valid      <= load_s4_valid;
       load_s5_to_acp     <= load_s4_to_acp;
       load_s5_to_npu     <= load_s4_to_npu;
       load_s5_write_en   <= load_s4_write_en;
       load_s5_base_addr  <= load_s4_base_addr;
-      load_s5_word_total <= load_s4_word_floor + 17'(load_s4_word_round);
+      load_s5_shape_xy_low <= load_s4_shape_xy_low;
+      load_s5_shape_z      <= load_s4_shape_z;
 
-      if (load_s5_valid && load_s5_to_acp) begin
+      load_s6_valid      <= load_s5_valid;
+      load_s6_to_acp     <= load_s5_to_acp;
+      load_s6_to_npu     <= load_s5_to_npu;
+      load_s6_write_en   <= load_s5_write_en;
+      load_s6_base_addr  <= load_s5_base_addr;
+      load_s6_elem_low20 <= load_s5_elem_low_product[19:0];
+
+      load_s7_valid      <= load_s6_valid;
+      load_s7_to_acp     <= load_s6_to_acp;
+      load_s7_to_npu     <= load_s6_to_npu;
+      load_s7_write_en   <= load_s6_write_en;
+      load_s7_base_addr  <= load_s6_base_addr;
+      load_s7_word_total <= load_s6_word_floor + 17'(load_s6_word_round);
+
+      if (load_s7_valid && load_s7_to_acp) begin
         acp_uop <= '{
-            write_en  : load_s5_write_en,
-            base_addr : load_s5_base_addr,
-            end_addr  : load_s5_base_addr + load_s5_word_total
+            write_en  : load_s7_write_en,
+            base_addr : load_s7_base_addr,
+            end_addr  : load_s7_base_addr + load_s7_word_total
         };
         acp_rx_start <= 1'b1;
         IN_acp_rdy   <= 1'b1;
       end
 
-      if (load_s5_valid && load_s5_to_npu) begin
+      if (load_s7_valid && load_s7_to_npu) begin
         npu_uop <= '{
-            write_en  : load_s5_write_en,
-            base_addr : load_s5_base_addr,
-            end_addr  : load_s5_base_addr + load_s5_word_total
+            write_en  : load_s7_write_en,
+            base_addr : load_s7_base_addr,
+            end_addr  : load_s7_base_addr + load_s7_word_total
         };
         npu_rx_start <= 1'b1;
         IN_npu_rdy   <= 1'b1;

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -191,7 +191,8 @@ module mem_dispatcher #() (
   // 128-bit word counts. Keep that arithmetic behind a registered boundary:
   //   s1: capture route/base/shape
   //   s2: compute X*Y
-  //   s3: compute ceil(X*Y*Z/8)
+  //   s3: compute X*Y*Z
+  //   s4: compute ceil(X*Y*Z/8)
   //   issue: enqueue ACP/NPU descriptor
   // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
   // from the 400 MHz core cycle while preserving the external command contract.
@@ -225,10 +226,14 @@ module mem_dispatcher #() (
   logic        load_s3_to_npu;
   logic        load_s3_write_en;
   logic [16:0] load_s3_base_addr;
-  logic [16:0] load_s3_word_total;
-  logic [50:0] load_s2_words_plus7;
+  logic [50:0] load_s3_word_product;
 
-  assign load_s2_words_plus7 = (load_s2_shape_xy * load_s2_shape_z) + 51'd7;
+  logic        load_s4_valid;
+  logic        load_s4_to_acp;
+  logic        load_s4_to_npu;
+  logic        load_s4_write_en;
+  logic [16:0] load_s4_base_addr;
+  logic [16:0] load_s4_word_total;
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
@@ -258,7 +263,13 @@ module mem_dispatcher #() (
       load_s3_to_npu    <= 1'b0;
       load_s3_write_en  <= 1'b0;
       load_s3_base_addr <= '0;
-      load_s3_word_total <= '0;
+      load_s3_word_product <= '0;
+      load_s4_valid     <= 1'b0;
+      load_s4_to_acp    <= 1'b0;
+      load_s4_to_npu    <= 1'b0;
+      load_s4_write_en  <= 1'b0;
+      load_s4_base_addr <= '0;
+      load_s4_word_total <= '0;
     end else begin
       acp_rx_start <= 1'b0;
       npu_rx_start <= 1'b0;
@@ -326,23 +337,30 @@ module mem_dispatcher #() (
       load_s3_to_npu     <= load_s2_to_npu;
       load_s3_write_en   <= load_s2_write_en;
       load_s3_base_addr  <= load_s2_base_addr;
-      load_s3_word_total <= load_s2_words_plus7[19:3];
+      load_s3_word_product <= load_s2_shape_xy * load_s2_shape_z;
 
-      if (load_s3_valid && load_s3_to_acp) begin
+      load_s4_valid      <= load_s3_valid;
+      load_s4_to_acp     <= load_s3_to_acp;
+      load_s4_to_npu     <= load_s3_to_npu;
+      load_s4_write_en   <= load_s3_write_en;
+      load_s4_base_addr  <= load_s3_base_addr;
+      load_s4_word_total <= load_s3_word_product[19:3] + {16'd0, |load_s3_word_product[2:0]};
+
+      if (load_s4_valid && load_s4_to_acp) begin
         acp_uop <= '{
-            write_en  : load_s3_write_en,
-            base_addr : load_s3_base_addr,
-            end_addr  : load_s3_base_addr + load_s3_word_total
+            write_en  : load_s4_write_en,
+            base_addr : load_s4_base_addr,
+            end_addr  : load_s4_base_addr + load_s4_word_total
         };
         acp_rx_start <= 1'b1;
         IN_acp_rdy   <= 1'b1;
       end
 
-      if (load_s3_valid && load_s3_to_npu) begin
+      if (load_s4_valid && load_s4_to_npu) begin
         npu_uop <= '{
-            write_en  : load_s3_write_en,
-            base_addr : load_s3_base_addr,
-            end_addr  : load_s3_base_addr + load_s3_word_total
+            write_en  : load_s4_write_en,
+            base_addr : load_s4_base_addr,
+            end_addr  : load_s4_base_addr + load_s4_word_total
         };
         npu_rx_start <= 1'b1;
         IN_npu_rdy   <= 1'b1;

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -43,6 +43,7 @@ module mem_dispatcher #() (
     // ===| AXI-Stream ACP (external) |==========================================
     axis_if.slave  S_AXIS_ACP_FMAP,
     axis_if.master M_AXIS_ACP_RESULT,
+    axis_if.master M_AXIS_L1_FMAP,
 
     // ===| Engine uop inputs |===================================================
     input  memory_control_uop_t IN_LOAD_uop,
@@ -183,78 +184,125 @@ module mem_dispatcher #() (
       .rd_xyz(weight_shape_rd_xyz)
   );
 
-  // ===| Shape totals (word counts for DMA) |====================================
-  logic [16:0] fmap_word_total;
-  logic [16:0] weight_word_total;
-
-  // Total BF16 elements → 128-bit words: ceil(X*Y*Z / 8)
-  assign fmap_word_total   = (fmap_read_arr_shape_X   * fmap_read_arr_shape_Y   * fmap_read_arr_shape_Z   + 7) >> 3;
-  assign weight_word_total = (weight_read_arr_shape_X * weight_read_arr_shape_Y * weight_read_arr_shape_Z + 7) >> 3;
-
   // ===| LOAD uop → ACP / NPU command translation |==============================
-  logic    IN_acp_rdy;
+  // The shape RAM returns BF16 element dimensions, but ACP/NPU commands need
+  // 128-bit word counts. Keep that arithmetic behind a registered boundary:
+  //   s1: capture route/base/shape
+  //   s2: compute X*Y
+  //   s3: compute ceil(X*Y*Z/8)
+  //   issue: enqueue ACP/NPU descriptor
+  // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
+  // from the 400 MHz core cycle while preserving the external command contract.
+  logic        IN_acp_rdy;
   acp_uop_t acp_uop;
-  logic    acp_rx_start;
+  logic        acp_rx_start;
 
-  logic    IN_npu_rdy;
+  logic        IN_npu_rdy;
   npu_uop_t npu_uop;
-  logic    npu_rx_start;
+  logic        npu_rx_start;
+
+  logic        load_s1_valid;
+  logic        load_s1_to_acp;
+  logic        load_s1_to_npu;
+  logic        load_s1_write_en;
+  logic [16:0] load_s1_base_addr;
+  logic [16:0] load_s1_shape_x;
+  logic [16:0] load_s1_shape_y;
+  logic [16:0] load_s1_shape_z;
+
+  logic        load_s2_valid;
+  logic        load_s2_to_acp;
+  logic        load_s2_to_npu;
+  logic        load_s2_write_en;
+  logic [16:0] load_s2_base_addr;
+  logic [33:0] load_s2_shape_xy;
+  logic [16:0] load_s2_shape_z;
+
+  logic        load_s3_valid;
+  logic        load_s3_to_acp;
+  logic        load_s3_to_npu;
+  logic        load_s3_write_en;
+  logic [16:0] load_s3_base_addr;
+  logic [16:0] load_s3_word_total;
+  logic [50:0] load_s2_words_plus7;
+
+  assign load_s2_words_plus7 = (load_s2_shape_xy * load_s2_shape_z) + 51'd7;
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
-      acp_rx_start <= 1'b0;
-      npu_rx_start <= 1'b0;
-      IN_acp_rdy   <= 1'b0;
-      IN_npu_rdy   <= 1'b0;
+      acp_rx_start      <= 1'b0;
+      npu_rx_start      <= 1'b0;
+      IN_acp_rdy        <= 1'b0;
+      IN_npu_rdy        <= 1'b0;
+      acp_uop           <= '0;
+      npu_uop           <= '0;
+      load_s1_valid     <= 1'b0;
+      load_s1_to_acp    <= 1'b0;
+      load_s1_to_npu    <= 1'b0;
+      load_s1_write_en  <= 1'b0;
+      load_s1_base_addr <= '0;
+      load_s1_shape_x   <= '0;
+      load_s1_shape_y   <= '0;
+      load_s1_shape_z   <= '0;
+      load_s2_valid     <= 1'b0;
+      load_s2_to_acp    <= 1'b0;
+      load_s2_to_npu    <= 1'b0;
+      load_s2_write_en  <= 1'b0;
+      load_s2_base_addr <= '0;
+      load_s2_shape_xy  <= '0;
+      load_s2_shape_z   <= '0;
+      load_s3_valid     <= 1'b0;
+      load_s3_to_acp    <= 1'b0;
+      load_s3_to_npu    <= 1'b0;
+      load_s3_write_en  <= 1'b0;
+      load_s3_base_addr <= '0;
+      load_s3_word_total <= '0;
     end else begin
       acp_rx_start <= 1'b0;
       npu_rx_start <= 1'b0;
       IN_acp_rdy   <= 1'b0;
       IN_npu_rdy   <= 1'b0;
 
+      load_s1_valid     <= 1'b0;
+      load_s1_to_acp    <= 1'b0;
+      load_s1_to_npu    <= 1'b0;
+      load_s1_write_en  <= 1'b0;
+      load_s1_base_addr <= '0;
+      load_s1_shape_x   <= fmap_read_arr_shape_X;
+      load_s1_shape_y   <= fmap_read_arr_shape_Y;
+      load_s1_shape_z   <= fmap_read_arr_shape_Z;
+
       case (IN_LOAD_uop.data_dest)
         // Host DDR4 → L2 (feature map DMA in)
         from_host_to_L2: begin
-          acp_uop <= '{
-              write_en  : `PORT_MOD_E_WRITE,
-              base_addr : IN_LOAD_uop.dest_addr,
-              end_addr  : IN_LOAD_uop.dest_addr + 17'(fmap_word_total)
-          };
-          acp_rx_start <= 1'b1;
-          IN_acp_rdy   <= 1'b1;
+          load_s1_valid     <= 1'b1;
+          load_s1_to_acp    <= 1'b1;
+          load_s1_write_en  <= `PORT_MOD_E_WRITE;
+          load_s1_base_addr <= IN_LOAD_uop.dest_addr;
         end
 
         // L2 → host DDR4 (result DMA out)
         from_L2_to_host: begin
-          acp_uop <= '{
-              write_en  : `PORT_MOD_E_READ,
-              base_addr : IN_LOAD_uop.src_addr,
-              end_addr  : IN_LOAD_uop.src_addr + 17'(fmap_word_total)
-          };
-          acp_rx_start <= 1'b1;
-          IN_acp_rdy   <= 1'b1;
+          load_s1_valid     <= 1'b1;
+          load_s1_to_acp    <= 1'b1;
+          load_s1_write_en  <= `PORT_MOD_E_READ;
+          load_s1_base_addr <= IN_LOAD_uop.src_addr;
         end
 
         // L2 → GEMM fmap broadcast
         from_L2_to_L1_GEMM: begin
-          npu_uop <= '{
-              write_en  : `PORT_MOD_E_READ,
-              base_addr : IN_LOAD_uop.src_addr,
-              end_addr  : IN_LOAD_uop.src_addr + 17'(fmap_word_total)
-          };
-          npu_rx_start <= 1'b1;
-          IN_npu_rdy   <= 1'b1;
+          load_s1_valid     <= 1'b1;
+          load_s1_to_npu    <= 1'b1;
+          load_s1_write_en  <= `PORT_MOD_E_READ;
+          load_s1_base_addr <= IN_LOAD_uop.src_addr;
         end
 
         // L2 → GEMV fmap broadcast
         from_L2_to_L1_GEMV: begin
-          npu_uop <= '{
-              write_en  : `PORT_MOD_E_READ,
-              base_addr : IN_LOAD_uop.src_addr,
-              end_addr  : IN_LOAD_uop.src_addr + 17'(fmap_word_total)
-          };
-          npu_rx_start <= 1'b1;
-          IN_npu_rdy   <= 1'b1;
+          load_s1_valid     <= 1'b1;
+          load_s1_to_npu    <= 1'b1;
+          load_s1_write_en  <= `PORT_MOD_E_READ;
+          load_s1_base_addr <= IN_LOAD_uop.src_addr;
         end
 
         // L2 → CVO input (handled by mem_CVO_stream_bridge below)
@@ -262,6 +310,41 @@ module mem_dispatcher #() (
 
         default: ;
       endcase
+
+      load_s2_valid     <= load_s1_valid;
+      load_s2_to_acp    <= load_s1_to_acp;
+      load_s2_to_npu    <= load_s1_to_npu;
+      load_s2_write_en  <= load_s1_write_en;
+      load_s2_base_addr <= load_s1_base_addr;
+      load_s2_shape_xy  <= load_s1_shape_x * load_s1_shape_y;
+      load_s2_shape_z   <= load_s1_shape_z;
+
+      load_s3_valid      <= load_s2_valid;
+      load_s3_to_acp     <= load_s2_to_acp;
+      load_s3_to_npu     <= load_s2_to_npu;
+      load_s3_write_en   <= load_s2_write_en;
+      load_s3_base_addr  <= load_s2_base_addr;
+      load_s3_word_total <= load_s2_words_plus7[19:3];
+
+      if (load_s3_valid && load_s3_to_acp) begin
+        acp_uop <= '{
+            write_en  : load_s3_write_en,
+            base_addr : load_s3_base_addr,
+            end_addr  : load_s3_base_addr + load_s3_word_total
+        };
+        acp_rx_start <= 1'b1;
+        IN_acp_rdy   <= 1'b1;
+      end
+
+      if (load_s3_valid && load_s3_to_npu) begin
+        npu_uop <= '{
+            write_en  : load_s3_write_en,
+            base_addr : load_s3_base_addr,
+            end_addr  : load_s3_base_addr + load_s3_word_total
+        };
+        npu_rx_start <= 1'b1;
+        IN_npu_rdy   <= 1'b1;
+      end
     end
   end
 
@@ -303,6 +386,11 @@ module mem_dispatcher #() (
   logic [127:0] npu_l2_wdata;
   logic [127:0] npu_l2_rdata;
 
+  // Direct NPU writes into L2 are reserved for the result-writeback phase.
+  // Until that producer is wired, keep the inactive write data deterministic;
+  // final_npu_we remains deasserted for current L2->L1 read routes.
+  assign npu_l2_wdata = '0;
+
   // Port B arbitration: CVO bridge wins when busy
   logic        final_npu_we;
   logic [16:0] final_npu_addr;
@@ -331,6 +419,7 @@ module mem_dispatcher #() (
 
       .S_AXIS_ACP_FMAP  (S_AXIS_ACP_FMAP),
       .M_AXIS_ACP_RESULT(M_AXIS_ACP_RESULT),
+      .M_AXIS_NPU_FMAP  (M_AXIS_L1_FMAP),
 
       // ACP control
       .IN_acp_write_en  (OUT_acp_cmd.write_en),

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -191,8 +191,7 @@ module mem_dispatcher #() (
   // 128-bit word counts. Keep that arithmetic behind a registered boundary:
   //   s1: capture route/base/shape
   //   s2: compute X*Y
-  //   s3: compute low bits of X*Y*Z needed by the 128-bit word count
-  //   s4: compute ceil(X*Y*Z/8)
+  //   s3: compute ceil(X*Y*Z/8)
   //   issue: enqueue ACP/NPU descriptor
   // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
   // from the 400 MHz core cycle while preserving the external command contract.
@@ -226,14 +225,10 @@ module mem_dispatcher #() (
   logic        load_s3_to_npu;
   logic        load_s3_write_en;
   logic [16:0] load_s3_base_addr;
-  logic [19:0] load_s3_elem_count_lo;
+  logic [16:0] load_s3_word_total;
+  logic [50:0] load_s2_words_plus7;
 
-  logic        load_s4_valid;
-  logic        load_s4_to_acp;
-  logic        load_s4_to_npu;
-  logic        load_s4_write_en;
-  logic [16:0] load_s4_base_addr;
-  logic [16:0] load_s4_word_total;
+  assign load_s2_words_plus7 = (load_s2_shape_xy * load_s2_shape_z) + 51'd7;
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
@@ -263,13 +258,7 @@ module mem_dispatcher #() (
       load_s3_to_npu    <= 1'b0;
       load_s3_write_en  <= 1'b0;
       load_s3_base_addr <= '0;
-      load_s3_elem_count_lo <= '0;
-      load_s4_valid     <= 1'b0;
-      load_s4_to_acp    <= 1'b0;
-      load_s4_to_npu    <= 1'b0;
-      load_s4_write_en  <= 1'b0;
-      load_s4_base_addr <= '0;
-      load_s4_word_total <= '0;
+      load_s3_word_total <= '0;
     end else begin
       acp_rx_start <= 1'b0;
       npu_rx_start <= 1'b0;
@@ -337,30 +326,23 @@ module mem_dispatcher #() (
       load_s3_to_npu     <= load_s2_to_npu;
       load_s3_write_en   <= load_s2_write_en;
       load_s3_base_addr  <= load_s2_base_addr;
-      load_s3_elem_count_lo <= load_s2_shape_xy[19:0] * load_s2_shape_z;
+      load_s3_word_total <= load_s2_words_plus7[19:3];
 
-      load_s4_valid      <= load_s3_valid;
-      load_s4_to_acp     <= load_s3_to_acp;
-      load_s4_to_npu     <= load_s3_to_npu;
-      load_s4_write_en   <= load_s3_write_en;
-      load_s4_base_addr  <= load_s3_base_addr;
-      load_s4_word_total <= load_s3_elem_count_lo[19:3] + {16'd0, |load_s3_elem_count_lo[2:0]};
-
-      if (load_s4_valid && load_s4_to_acp) begin
+      if (load_s3_valid && load_s3_to_acp) begin
         acp_uop <= '{
-            write_en  : load_s4_write_en,
-            base_addr : load_s4_base_addr,
-            end_addr  : load_s4_base_addr + load_s4_word_total
+            write_en  : load_s3_write_en,
+            base_addr : load_s3_base_addr,
+            end_addr  : load_s3_base_addr + load_s3_word_total
         };
         acp_rx_start <= 1'b1;
         IN_acp_rdy   <= 1'b1;
       end
 
-      if (load_s4_valid && load_s4_to_npu) begin
+      if (load_s3_valid && load_s3_to_npu) begin
         npu_uop <= '{
-            write_en  : load_s4_write_en,
-            base_addr : load_s4_base_addr,
-            end_addr  : load_s4_base_addr + load_s4_word_total
+            write_en  : load_s3_write_en,
+            base_addr : load_s3_base_addr,
+            end_addr  : load_s3_base_addr + load_s3_word_total
         };
         npu_rx_start <= 1'b1;
         IN_npu_rdy   <= 1'b1;

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -427,6 +427,7 @@ module mem_dispatcher #() (
   // ===| L2 cache controller |===================================================
   // CVO bridge drives L2 port B when active; otherwise port B is driven by
   // the NPU DMA state machine in mem_GLOBAL_cache.
+  logic        cvo_l2_valid;
   logic        cvo_l2_we;
   logic [16:0] cvo_l2_addr;
   logic [127:0] cvo_l2_wdata;
@@ -469,6 +470,7 @@ module mem_dispatcher #() (
 
       // Direct port-B owner for CVO L2 read/write bursts.
       .IN_npu_direct_en   (cvo_bridge_busy),
+      .IN_npu_direct_valid(cvo_l2_valid),
       .IN_npu_direct_we   (cvo_l2_we),
       .IN_npu_direct_addr (cvo_l2_addr),
       .IN_npu_direct_wdata(cvo_l2_wdata),
@@ -490,6 +492,7 @@ module mem_dispatcher #() (
       .OUT_done           (cvo_bridge_done),
 
       // L2 port B direct access
+      .OUT_l2_valid       (cvo_l2_valid),
       .OUT_l2_we          (cvo_l2_we),
       .OUT_l2_addr        (cvo_l2_addr),
       .OUT_l2_wdata       (cvo_l2_wdata),

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -191,7 +191,7 @@ module mem_dispatcher #() (
   // 128-bit word counts. Keep that arithmetic behind a registered boundary:
   //   s1: capture route/base/shape
   //   s2: compute X*Y
-  //   s3: compute X*Y*Z
+  //   s3: compute low bits of X*Y*Z needed by the 128-bit word count
   //   s4: compute ceil(X*Y*Z/8)
   //   issue: enqueue ACP/NPU descriptor
   // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
@@ -226,7 +226,7 @@ module mem_dispatcher #() (
   logic        load_s3_to_npu;
   logic        load_s3_write_en;
   logic [16:0] load_s3_base_addr;
-  logic [50:0] load_s3_word_product;
+  logic [19:0] load_s3_elem_count_lo;
 
   logic        load_s4_valid;
   logic        load_s4_to_acp;
@@ -263,7 +263,7 @@ module mem_dispatcher #() (
       load_s3_to_npu    <= 1'b0;
       load_s3_write_en  <= 1'b0;
       load_s3_base_addr <= '0;
-      load_s3_word_product <= '0;
+      load_s3_elem_count_lo <= '0;
       load_s4_valid     <= 1'b0;
       load_s4_to_acp    <= 1'b0;
       load_s4_to_npu    <= 1'b0;
@@ -337,14 +337,14 @@ module mem_dispatcher #() (
       load_s3_to_npu     <= load_s2_to_npu;
       load_s3_write_en   <= load_s2_write_en;
       load_s3_base_addr  <= load_s2_base_addr;
-      load_s3_word_product <= load_s2_shape_xy * load_s2_shape_z;
+      load_s3_elem_count_lo <= load_s2_shape_xy[19:0] * load_s2_shape_z;
 
       load_s4_valid      <= load_s3_valid;
       load_s4_to_acp     <= load_s3_to_acp;
       load_s4_to_npu     <= load_s3_to_npu;
       load_s4_write_en   <= load_s3_write_en;
       load_s4_base_addr  <= load_s3_base_addr;
-      load_s4_word_total <= load_s3_word_product[19:3] + {16'd0, |load_s3_word_product[2:0]};
+      load_s4_word_total <= load_s3_elem_count_lo[19:3] + {16'd0, |load_s3_elem_count_lo[2:0]};
 
       if (load_s4_valid && load_s4_to_acp) begin
         acp_uop <= '{

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -191,7 +191,9 @@ module mem_dispatcher #() (
   // 128-bit word counts. Keep that arithmetic behind a registered boundary:
   //   s1: capture route/base/shape
   //   s2: compute X*Y
-  //   s3: compute ceil(X*Y*Z/8)
+  //   s3: keep the low product operands required by the 17-bit word contract
+  //   s4: compute low 20 bits of X*Y*Z
+  //   s5: compute ceil(X*Y*Z/8) and enqueue descriptor
   //   issue: enqueue ACP/NPU descriptor
   // This removes the prior shape_const_ram -> DSP -> DSP -> descriptor path
   // from the 400 MHz core cycle while preserving the external command contract.
@@ -225,10 +227,29 @@ module mem_dispatcher #() (
   logic        load_s3_to_npu;
   logic        load_s3_write_en;
   logic [16:0] load_s3_base_addr;
-  logic [16:0] load_s3_word_total;
-  logic [50:0] load_s2_words_plus7;
+  logic [19:0] load_s3_shape_xy_low;
+  logic [16:0] load_s3_shape_z;
+  logic [36:0] load_s3_elem_low_product;
 
-  assign load_s2_words_plus7 = (load_s2_shape_xy * load_s2_shape_z) + 51'd7;
+  logic        load_s4_valid;
+  logic        load_s4_to_acp;
+  logic        load_s4_to_npu;
+  logic        load_s4_write_en;
+  logic [16:0] load_s4_base_addr;
+  logic [19:0] load_s4_elem_low20;
+  logic [16:0] load_s4_word_floor;
+  logic        load_s4_word_round;
+
+  logic        load_s5_valid;
+  logic        load_s5_to_acp;
+  logic        load_s5_to_npu;
+  logic        load_s5_write_en;
+  logic [16:0] load_s5_base_addr;
+  logic [16:0] load_s5_word_total;
+
+  assign load_s3_elem_low_product = load_s3_shape_xy_low * load_s3_shape_z;
+  assign load_s4_word_floor       = load_s4_elem_low20[19:3];
+  assign load_s4_word_round       = |load_s4_elem_low20[2:0];
 
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
@@ -258,7 +279,20 @@ module mem_dispatcher #() (
       load_s3_to_npu    <= 1'b0;
       load_s3_write_en  <= 1'b0;
       load_s3_base_addr <= '0;
-      load_s3_word_total <= '0;
+      load_s3_shape_xy_low <= '0;
+      load_s3_shape_z      <= '0;
+      load_s4_valid      <= 1'b0;
+      load_s4_to_acp     <= 1'b0;
+      load_s4_to_npu     <= 1'b0;
+      load_s4_write_en   <= 1'b0;
+      load_s4_base_addr  <= '0;
+      load_s4_elem_low20 <= '0;
+      load_s5_valid      <= 1'b0;
+      load_s5_to_acp     <= 1'b0;
+      load_s5_to_npu     <= 1'b0;
+      load_s5_write_en   <= 1'b0;
+      load_s5_base_addr  <= '0;
+      load_s5_word_total <= '0;
     end else begin
       acp_rx_start <= 1'b0;
       npu_rx_start <= 1'b0;
@@ -326,23 +360,38 @@ module mem_dispatcher #() (
       load_s3_to_npu     <= load_s2_to_npu;
       load_s3_write_en   <= load_s2_write_en;
       load_s3_base_addr  <= load_s2_base_addr;
-      load_s3_word_total <= load_s2_words_plus7[19:3];
+      load_s3_shape_xy_low <= load_s2_shape_xy[19:0];
+      load_s3_shape_z      <= load_s2_shape_z;
 
-      if (load_s3_valid && load_s3_to_acp) begin
+      load_s4_valid      <= load_s3_valid;
+      load_s4_to_acp     <= load_s3_to_acp;
+      load_s4_to_npu     <= load_s3_to_npu;
+      load_s4_write_en   <= load_s3_write_en;
+      load_s4_base_addr  <= load_s3_base_addr;
+      load_s4_elem_low20 <= load_s3_elem_low_product[19:0];
+
+      load_s5_valid      <= load_s4_valid;
+      load_s5_to_acp     <= load_s4_to_acp;
+      load_s5_to_npu     <= load_s4_to_npu;
+      load_s5_write_en   <= load_s4_write_en;
+      load_s5_base_addr  <= load_s4_base_addr;
+      load_s5_word_total <= load_s4_word_floor + 17'(load_s4_word_round);
+
+      if (load_s5_valid && load_s5_to_acp) begin
         acp_uop <= '{
-            write_en  : load_s3_write_en,
-            base_addr : load_s3_base_addr,
-            end_addr  : load_s3_base_addr + load_s3_word_total
+            write_en  : load_s5_write_en,
+            base_addr : load_s5_base_addr,
+            end_addr  : load_s5_base_addr + load_s5_word_total
         };
         acp_rx_start <= 1'b1;
         IN_acp_rdy   <= 1'b1;
       end
 
-      if (load_s3_valid && load_s3_to_npu) begin
+      if (load_s5_valid && load_s5_to_npu) begin
         npu_uop <= '{
-            write_en  : load_s3_write_en,
-            base_addr : load_s3_base_addr,
-            end_addr  : load_s3_base_addr + load_s3_word_total
+            write_en  : load_s5_write_en,
+            base_addr : load_s5_base_addr,
+            end_addr  : load_s5_base_addr + load_s5_word_total
         };
         npu_rx_start <= 1'b1;
         IN_npu_rdy   <= 1'b1;

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"
 `include "GLOBAL_CONST.svh"

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -383,8 +383,6 @@ module mem_dispatcher #() (
   logic [127:0] cvo_l2_wdata;
   logic [127:0] cvo_l2_rdata;
 
-  logic        npu_l2_we;
-  logic [16:0] npu_l2_addr;
   logic [127:0] npu_l2_wdata;
   logic [127:0] npu_l2_rdata;
 
@@ -392,23 +390,6 @@ module mem_dispatcher #() (
   // Until that producer is wired, keep the inactive write data deterministic;
   // final_npu_we remains deasserted for current L2->L1 read routes.
   assign npu_l2_wdata = '0;
-
-  // Port B arbitration: CVO bridge wins when busy
-  logic        final_npu_we;
-  logic [16:0] final_npu_addr;
-  logic [127:0] final_npu_wdata;
-
-  always_comb begin
-    if (cvo_bridge_busy) begin
-      final_npu_we    = cvo_l2_we;
-      final_npu_addr  = cvo_l2_addr;
-      final_npu_wdata = cvo_l2_wdata;
-    end else begin
-      final_npu_we    = npu_l2_we;
-      final_npu_addr  = npu_l2_addr;
-      final_npu_wdata = npu_l2_wdata;
-    end
-  end
 
   // Route L2 rdata to the appropriate consumer
   assign cvo_l2_rdata = npu_l2_rdata;  // shared read bus
@@ -437,7 +418,13 @@ module mem_dispatcher #() (
       .IN_npu_rx_start  (OUT_npu_cmd_valid),
       .OUT_npu_is_busy  (npu_is_busy_wire),
 
-      .IN_npu_wdata     (final_npu_wdata),
+      // Direct port-B owner for CVO L2 read/write bursts.
+      .IN_npu_direct_en   (cvo_bridge_busy),
+      .IN_npu_direct_we   (cvo_l2_we),
+      .IN_npu_direct_addr (cvo_l2_addr),
+      .IN_npu_direct_wdata(cvo_l2_wdata),
+
+      .IN_npu_wdata     (npu_l2_wdata),
       .OUT_npu_rdata    (npu_l2_rdata)
   );
 

--- a/hw/rtl/NPU_top.sv
+++ b/hw/rtl/NPU_top.sv
@@ -71,6 +71,7 @@ module NPU_top (
   axis_if #(.DATA_WIDTH(128)) M_CORE_HP1_WEIGHT ();
   axis_if #(.DATA_WIDTH(128)) M_CORE_HP2_WEIGHT ();
   axis_if #(.DATA_WIDTH(128)) M_CORE_HP3_WEIGHT ();
+  axis_if #(.DATA_WIDTH(128)) M_CORE_FMAP_FROM_L2 ();
 
   // ===| Internal Wires — Instruction Path |=====================================
   logic                GEMV_op_x64_valid_wire;
@@ -149,6 +150,7 @@ module NPU_top (
 
       .S_AXIS_ACP_FMAP  (S_AXIS_ACP_FMAP),
       .M_AXIS_ACP_RESULT(M_AXIS_ACP_RESULT),
+      .M_AXIS_L1_FMAP   (M_CORE_FMAP_FROM_L2),
 
       .IN_LOAD_uop     (LOAD_uop_wire),
       .IN_mem_set_uop  (mem_set_uop),
@@ -195,7 +197,7 @@ module NPU_top (
       .rst_n  (rst_n_core),
       .i_clear(i_clear),
 
-      .S_AXIS_ACP_FMAP(S_AXIS_ACP_FMAP),
+      .S_AXIS_ACP_FMAP(M_CORE_FMAP_FROM_L2),
 
       .i_rd_start(sram_rd_start_wire),
 

--- a/hw/rtl/NPU_top.sv
+++ b/hw/rtl/NPU_top.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `include "GLOBAL_CONST.svh"
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"

--- a/hw/rtl/PREPROCESS/preprocess_fmap.sv
+++ b/hw/rtl/PREPROCESS/preprocess_fmap.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `include "GLOBAL_CONST.svh"
 `timescale 1ns / 1ps
 `include "GEMM_Array.svh"

--- a/hw/rtl/PREPROCESS/preprocess_fmap.sv
+++ b/hw/rtl/PREPROCESS/preprocess_fmap.sv
@@ -111,16 +111,23 @@ module preprocess_fmap #(
     end
   end
 
-  logic [`BF16_EXP_WIDTH-1:0] emax_cache_mem[0:1023][0:`ARRAY_SIZE_H-1];
+  localparam int EMAX_CACHE_WIDTH = `ARRAY_SIZE_H * `BF16_EXP_WIDTH;
+  logic [EMAX_CACHE_WIDTH-1:0] emax_active_pack;
+  logic [EMAX_CACHE_WIDTH-1:0] emax_cache_rdata;
+  logic [EMAX_CACHE_WIDTH-1:0] emax_cache_mem[0:1023];
   logic [9:0] emax_wr_addr, emax_rd_addr;
+
+  always_comb begin
+    for (int i = 0; i < `ARRAY_SIZE_H; i++) begin
+      emax_active_pack[i*`BF16_EXP_WIDTH+:`BF16_EXP_WIDTH] = active_emax[i];
+    end
+  end
 
   always_ff @(posedge clk) begin
     if (!rst_n || i_clear) begin
       emax_wr_addr <= 0;
     end else if (emax_group_valid) begin
-      for (int i = 0; i < `ARRAY_SIZE_H; i++) begin
-        emax_cache_mem[emax_wr_addr][i] <= active_emax[i];
-      end
+      emax_cache_mem[emax_wr_addr] <= emax_active_pack;
       emax_wr_addr <= emax_wr_addr + 1;
     end
   end
@@ -131,8 +138,14 @@ module preprocess_fmap #(
     end else if (i_rd_start) begin
       emax_rd_addr <= 0;
     end
+    emax_cache_rdata <= emax_cache_mem[emax_rd_addr];
+  end
+
+  always_comb begin
     for (int i = 0; i < `ARRAY_SIZE_H; i++) begin
-      o_cached_emax[i] <= emax_cache_mem[emax_rd_addr][i];
+      o_cached_emax[i] = (!rst_n || i_clear)
+        ? '0
+        : emax_cache_rdata[i*`BF16_EXP_WIDTH+:`BF16_EXP_WIDTH];
     end
   end
 

--- a/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
+++ b/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
@@ -34,16 +34,7 @@ module GEMV_generate_lut
     // exponent field is carried here; matches GEMV_top's port width.
     input logic [dtype_pkg::Bf16ExpWidth-1:0] IN_cached_emax_out[0:param.fmap_cache_out_cnt-1],
     // LUT depth = 2^weight_width (one entry per signed INT4 value, -8..+7).
-    output logic signed [param.fixed_mant_width+2:0] OUT_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1],
-    // OUT_fmap_ready feeds GEMV_accumulate.init, which the reduction_branch
-    // header documents as a one-cycle pulse opening a new GEMV batch. This
-    // module is pure-combinational with no clk/rst_n, so it cannot produce
-    // such a pulse on its own; fmap_cache.rd_valid is also a level held
-    // high across the 2048-cycle broadcast burst. Driving this port from
-    // the level-valid signal would gate the accumulator off for the whole
-    // burst. Left undriven until a clocked edge-detector lands at the
-    // consumer side.
-    output logic OUT_fmap_ready
+    output logic signed [param.fixed_mant_width+2:0] OUT_fmap_LUT[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1]
 );
   genvar idx, w;
   generate

--- a/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
+++ b/hw/rtl/VEC_CORE/GEMV_generate_lut.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 
 `include "GEMV_Vec_Matrix_MUL.svh"

--- a/hw/rtl/VEC_CORE/GEMV_top.sv
+++ b/hw/rtl/VEC_CORE/GEMV_top.sv
@@ -83,6 +83,25 @@ module GEMV_top
   logic signed [param.fixed_mant_width+2:0] fmap_LUT_wire[0:param.fmap_cache_out_cnt-1][0:(1<<param.weight_width)-1];
 
   logic fmap_ready_wire;
+  logic fmap_broadcast_valid_q;
+
+  // GEMV_generate_lut is combinational. The recurrent accumulator needs a
+  // one-cycle batch-start pulse, so generate it at the clocked GEMV boundary
+  // from the level-valid fmap broadcast.
+  always_ff @(posedge clk) begin
+    if (!rst_n) begin
+      fmap_broadcast_valid_q <= 1'b0;
+      fmap_ready_wire        <= 1'b0;
+    end else begin
+      fmap_ready_wire        <= IN_fmap_broadcast_valid & ~fmap_broadcast_valid_q;
+      fmap_broadcast_valid_q <= IN_fmap_broadcast_valid;
+    end
+  end
+
+  assign OUT_weight_ready_A = IN_activated_lane[A] & IN_weight_valid_A;
+  assign OUT_weight_ready_B = IN_activated_lane[B] & IN_weight_valid_B;
+  assign OUT_weight_ready_C = IN_activated_lane[C] & IN_weight_valid_C;
+  assign OUT_weight_ready_D = IN_activated_lane[D] & IN_weight_valid_D;
 
   GEMV_generate_lut #(
       .param(VecCoreDefaultCfg)
@@ -91,8 +110,7 @@ module GEMV_top
       .IN_fmap_broadcast_valid(IN_fmap_broadcast_valid),
       .IN_cached_emax_out(IN_cached_emax_out),
 
-      .OUT_fmap_LUT  (fmap_LUT_wire),
-      .OUT_fmap_ready(fmap_ready_wire)
+      .OUT_fmap_LUT(fmap_LUT_wire)
   );
 
 

--- a/hw/rtl/VEC_CORE/GEMV_top.sv
+++ b/hw/rtl/VEC_CORE/GEMV_top.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 
 `include "GEMV_Vec_Matrix_MUL.svh"

--- a/hw/sim/run_verification.sh
+++ b/hw/sim/run_verification.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # Unified verification runner for pccx-FPGA.
 #
 # Runs every known testbench in deterministic order and reports a one-line
@@ -34,6 +36,7 @@ declare -A TB_DEPS=(
     [tb_FROM_mat_result_packer]="MAT_CORE/FROM_mat_result_packer.sv"
     [tb_barrel_shifter_BF16]="barrel_shifter_BF16.sv"
     [tb_ctrl_npu_decoder]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv"
+    [tb_CVO_sfu_reduce_sum]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv Library/Algorithms/BF16_math.sv CVO_CORE/CVO_sfu_unit.sv"
     [tb_mem_u_operation_queue]="Constants/compilePriority_Order/E_obs_pkg/perf_counter_pkg.sv NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv MEM_control/IO/mem_u_operation_queue.sv"
     [tb_GEMM_fmap_staggered_delay]="MAT_CORE/GEMM_fmap_staggered_delay.sv"
     [tb_v002_runtime_smoke_program]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv NPU_Controller/Global_Scheduler.sv"
@@ -50,9 +53,10 @@ declare -A TB_CORE=(
     [tb_FROM_mat_result_packer]=5
     [tb_barrel_shifter_BF16]=6
     [tb_ctrl_npu_decoder]=7
-    [tb_mem_u_operation_queue]=8
-    [tb_GEMM_fmap_staggered_delay]=9
-    [tb_v002_runtime_smoke_program]=10
+    [tb_CVO_sfu_reduce_sum]=8
+    [tb_mem_u_operation_queue]=9
+    [tb_GEMM_fmap_staggered_delay]=10
+    [tb_v002_runtime_smoke_program]=11
 )
 
 TB_LIST=(
@@ -64,6 +68,7 @@ TB_LIST=(
     tb_FROM_mat_result_packer
     tb_barrel_shifter_BF16
     tb_ctrl_npu_decoder
+    tb_CVO_sfu_reduce_sum
     tb_mem_u_operation_queue
     tb_GEMM_fmap_staggered_delay
     tb_v002_runtime_smoke_program
@@ -130,6 +135,12 @@ while (($#)); do
 done
 
 mkdir -p "$WORK_ROOT"
+
+# Keep concurrent local-candidate / direct-regression invocations from sharing
+# the same xsim work directories at the same time. The per-TB work paths stay
+# stable for evidence, but only one runner mutates them at once.
+exec 8>"$WORK_ROOT/.run_verification.lock"
+flock 8
 
 # Build the pccx-lab bridge binary if stale / missing.
 if [[ ! -x "$PCCX_CLI_BIN" ]]; then

--- a/hw/tb/tb_CVO_sfu_reduce_sum.sv
+++ b/hw/tb/tb_CVO_sfu_reduce_sum.sv
@@ -129,6 +129,7 @@ module tb_CVO_sfu_reduce_sum;
     logic [15:0] expected;
     bit          reduce_seen;
     bit          gelu_seen;
+    bit          exp_seen;
 
     rst_n     = 1'b0;
     i_clear   = 1'b0;
@@ -200,8 +201,34 @@ module tb_CVO_sfu_reduce_sum;
       $display("FAIL: timeout waiting for GELU(0) output.");
     end
 
+    @(negedge clk);
+    IN_func  = CVO_EXP;
+    IN_data  = 16'd0;
+    IN_valid = 1'b1;
+    @(negedge clk);
+    IN_valid = 1'b0;
+    IN_data  = 16'd0;
+
+    exp_seen = 1'b0;
+    for (int cycle = 0; cycle < 96; cycle++) begin
+      @(posedge clk); #1;
+      if (OUT_result_valid) begin
+        exp_seen = 1'b1;
+        if (OUT_result !== 16'h3F80) begin
+          errors++;
+          $display("[%0t] EXP(0) mismatch: got=%h exp=3f80", $time, OUT_result);
+        end
+        break;
+      end
+    end
+
+    if (!exp_seen) begin
+      errors++;
+      $display("FAIL: timeout waiting for EXP(0) output.");
+    end
+
     if (errors == 0) begin
-      $display("PASS: %0d cycles, CVO SFU reduce sum and GELU smoke match golden.", N_WORDS);
+      $display("PASS: %0d cycles, CVO SFU reduce sum, GELU, and EXP smoke match golden.", N_WORDS);
     end else begin
       $display("FAIL: %0d mismatches over CVO SFU smoke.", errors);
     end

--- a/hw/tb/tb_CVO_sfu_reduce_sum.sv
+++ b/hw/tb/tb_CVO_sfu_reduce_sum.sv
@@ -127,6 +127,8 @@ module tb_CVO_sfu_reduce_sum;
 
   initial begin
     logic [15:0] expected;
+    bit          reduce_seen;
+    bit          gelu_seen;
 
     rst_n     = 1'b0;
     i_clear   = 1'b0;
@@ -148,10 +150,12 @@ module tb_CVO_sfu_reduce_sum;
     expected = 16'd0;
     for (int i = 0; i < N_WORDS; i++) expected = model_bf16_add(expected, 16'h3F80);
 
+    reduce_seen = 1'b0;
     for (int cycle = 0; cycle < 80; cycle++) begin
       @(posedge clk); #1;
       if (OUT_data_ready !== 1'b1) observed_backpressure = 1'b1;
       if (OUT_result_valid) begin
+        reduce_seen = 1'b1;
         if (OUT_result !== expected) begin
           errors++;
           $display("[%0t] reduce sum mismatch: got=%h exp=%h", $time, OUT_result, expected);
@@ -160,17 +164,47 @@ module tb_CVO_sfu_reduce_sum;
           errors++;
           $display("[%0t] reduce sum did not apply expected local backpressure", $time);
         end
-        if (errors == 0) begin
-          $display("PASS: %0d cycles, CVO SFU reduce sum matches golden.", N_WORDS);
-        end else begin
-          $display("FAIL: %0d mismatches over %0d cycles.", errors, N_WORDS);
-        end
-        $finish;
+        break;
       end
     end
 
-    errors++;
-    $display("FAIL: timeout waiting for reduce sum output.");
+    if (!reduce_seen) begin
+      errors++;
+      $display("FAIL: timeout waiting for reduce sum output.");
+      $finish;
+    end
+
+    @(negedge clk);
+    IN_func  = CVO_GELU;
+    IN_data  = 16'd0;
+    IN_valid = 1'b1;
+    @(negedge clk);
+    IN_valid = 1'b0;
+    IN_data  = 16'd0;
+
+    gelu_seen = 1'b0;
+    for (int cycle = 0; cycle < 96; cycle++) begin
+      @(posedge clk); #1;
+      if (OUT_result_valid) begin
+        gelu_seen = 1'b1;
+        if (OUT_result !== 16'd0) begin
+          errors++;
+          $display("[%0t] GELU(0) mismatch: got=%h exp=0000", $time, OUT_result);
+        end
+        break;
+      end
+    end
+
+    if (!gelu_seen) begin
+      errors++;
+      $display("FAIL: timeout waiting for GELU(0) output.");
+    end
+
+    if (errors == 0) begin
+      $display("PASS: %0d cycles, CVO SFU reduce sum and GELU smoke match golden.", N_WORDS);
+    end else begin
+      $display("FAIL: %0d mismatches over CVO SFU smoke.", errors);
+    end
     $finish;
   end
 

--- a/hw/tb/tb_CVO_sfu_reduce_sum.sv
+++ b/hw/tb/tb_CVO_sfu_reduce_sum.sv
@@ -55,7 +55,7 @@ module tb_CVO_sfu_reduce_sum;
   int errors = 0;
   bit observed_backpressure = 1'b0;
 
-  function automatic logic [15:0] model_bf16_add(input logic [15:0] a, input logic [15:0] b);
+	  function automatic logic [15:0] model_bf16_add(input logic [15:0] a, input logic [15:0] b);
     logic [7:0] ea, eb, elarge;
     logic [7:0] diff;
     logic [8:0] ma, mb;
@@ -99,7 +99,27 @@ module tb_CVO_sfu_reduce_sum;
       eout = elarge - 8'd1;
       mout = sum[7:1];
     end
-    return {sout, eout, mout};
+	    return {sout, eout, mout};
+	  endfunction
+
+  function automatic logic [15:0] model_bf16_mul(input logic [15:0] a, input logic [15:0] b);
+    logic        s;
+    logic [ 8:0] esum;
+    logic [15:0] mp;
+    logic [ 7:0] er;
+    logic [ 6:0] mr;
+    if (a[14:0] == 0 || b[14:0] == 0) return 16'd0;
+    s    = a[15] ^ b[15];
+    esum = {1'b0, a[14:7]} + {1'b0, b[14:7]};
+    mp   = {1'b1, a[6:0]} * {1'b1, b[6:0]};
+    if (mp[15]) begin
+      er = 8'(esum - 9'd127 + 9'd1);
+      mr = mp[14:8];
+    end else begin
+      er = 8'(esum - 9'd127);
+      mr = mp[13:7];
+    end
+    return {s, er, mr};
   endfunction
 
   task automatic push_word(input logic [15:0] word);
@@ -127,9 +147,15 @@ module tb_CVO_sfu_reduce_sum;
 
   initial begin
     logic [15:0] expected;
-    bit          reduce_seen;
-    bit          gelu_seen;
-    bit          exp_seen;
+	    bit          reduce_seen;
+	    bit          gelu_seen;
+	    bit          exp_seen;
+    bit          recip_seen;
+    logic [15:0] recip_input;
+    logic [15:0] recip_seed;
+    logic [15:0] recip_xr0;
+    logic [15:0] recip_corr;
+    logic [15:0] recip_expected;
 
     rst_n     = 1'b0;
     i_clear   = 1'b0;
@@ -222,13 +248,47 @@ module tb_CVO_sfu_reduce_sum;
       end
     end
 
-    if (!exp_seen) begin
-      errors++;
-      $display("FAIL: timeout waiting for EXP(0) output.");
+	    if (!exp_seen) begin
+	      errors++;
+	      $display("FAIL: timeout waiting for EXP(0) output.");
+	    end
+
+    recip_input    = 16'h4000;  // 2.0
+    recip_seed     = {1'b0,
+                      8'(8'd254 - recip_input[14:7]),
+                      7'(7'd127 - {1'b0, recip_input[6:1]})};
+    recip_xr0      = model_bf16_mul({1'b0, recip_input[14:0]}, recip_seed);
+    recip_corr     = model_bf16_add(16'h4000, {1'b1, recip_xr0[14:0]});
+    recip_expected = {recip_input[15], model_bf16_mul(recip_seed, recip_corr)[14:0]};
+
+    @(negedge clk);
+    IN_func  = CVO_RECIP;
+    IN_data  = recip_input;
+    IN_valid = 1'b1;
+    @(negedge clk);
+    IN_valid = 1'b0;
+    IN_data  = 16'd0;
+
+    recip_seen = 1'b0;
+    for (int cycle = 0; cycle < 96; cycle++) begin
+      @(posedge clk); #1;
+      if (OUT_result_valid) begin
+        recip_seen = 1'b1;
+        if (OUT_result !== recip_expected) begin
+          errors++;
+          $display("[%0t] RECIP smoke mismatch: got=%h exp=%h", $time, OUT_result, recip_expected);
+        end
+        break;
+      end
     end
 
-    if (errors == 0) begin
-      $display("PASS: %0d cycles, CVO SFU reduce sum, GELU, and EXP smoke match golden.", N_WORDS);
+    if (!recip_seen) begin
+      errors++;
+      $display("FAIL: timeout waiting for RECIP output.");
+    end
+
+	    if (errors == 0) begin
+	      $display("PASS: %0d cycles, CVO SFU reduce sum, GELU, EXP, and RECIP smoke match golden.", N_WORDS);
     end else begin
       $display("FAIL: %0d mismatches over CVO SFU smoke.", errors);
     end

--- a/hw/tb/tb_CVO_sfu_reduce_sum.sv
+++ b/hw/tb/tb_CVO_sfu_reduce_sum.sv
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+`timescale 1ns / 1ps
+
+// ===============================================================================
+// Testbench: tb_CVO_sfu_reduce_sum
+// Phase : pccx v002 — CVO SFU local timing path coverage
+//
+// Purpose
+// -------
+//   Drives REDUCE_SUM through the SFU ready/valid boundary and checks that the
+//   ready-gated accumulator pipeline preserves the scalar BF16 sum.
+// ===============================================================================
+
+`include "GLOBAL_CONST.svh"
+
+import isa_pkg::*;
+
+module tb_CVO_sfu_reduce_sum;
+
+  localparam int N_WORDS = 4;
+
+  // ===| Clock + reset |=========================================================
+  logic clk;
+  logic rst_n;
+  logic i_clear;
+  initial clk = 1'b0;
+  always #2 clk = ~clk;
+
+  // ===| DUT IO |================================================================
+  cvo_func_e   IN_func;
+  logic [15:0] IN_length;
+  cvo_flags_t  IN_flags;
+  logic [15:0] IN_data;
+  logic        IN_valid;
+  logic        OUT_data_ready;
+  logic [15:0] OUT_result;
+  logic        OUT_result_valid;
+
+  CVO_sfu_unit u_dut (
+      .clk             (clk),
+      .rst_n           (rst_n),
+      .i_clear         (i_clear),
+      .IN_func         (IN_func),
+      .IN_length       (IN_length),
+      .IN_flags        (IN_flags),
+      .IN_data         (IN_data),
+      .IN_valid        (IN_valid),
+      .OUT_data_ready  (OUT_data_ready),
+      .OUT_result      (OUT_result),
+      .OUT_result_valid(OUT_result_valid)
+  );
+
+  // ===| Scoreboard |============================================================
+  int errors = 0;
+  bit observed_backpressure = 1'b0;
+
+  function automatic logic [15:0] model_bf16_add(input logic [15:0] a, input logic [15:0] b);
+    logic [7:0] ea, eb, elarge;
+    logic [7:0] diff;
+    logic [8:0] ma, mb;
+    logic [9:0] sum;
+    logic [7:0] eout;
+    logic [6:0] mout;
+    logic       sout;
+    if (a[14:0] == 0) return b;
+    if (b[14:0] == 0) return a;
+    ea = a[14:7];
+    eb = b[14:7];
+    ma = {1'b0, 1'b1, a[6:0]};
+    mb = {1'b0, 1'b1, b[6:0]};
+    if (ea >= eb) begin
+      elarge = ea;
+      diff = ea - eb;
+      mb = 9'(mb >> diff);
+    end else begin
+      elarge = eb;
+      diff = eb - ea;
+      ma = 9'(ma >> diff);
+    end
+    if (a[15] == b[15]) begin
+      sout = a[15];
+      sum  = {1'b0, ma} + {1'b0, mb};
+    end else if (ma >= mb) begin
+      sout = a[15];
+      sum  = {1'b0, ma} - {1'b0, mb};
+    end else begin
+      sout = b[15];
+      sum  = {1'b0, mb} - {1'b0, ma};
+    end
+    if (sum == 0) return 16'd0;
+    if (sum[9]) begin
+      eout = elarge + 8'd1;
+      mout = sum[9:3];
+    end else if (sum[8]) begin
+      eout = elarge;
+      mout = sum[8:2];
+    end else begin
+      eout = elarge - 8'd1;
+      mout = sum[7:1];
+    end
+    return {sout, eout, mout};
+  endfunction
+
+  task automatic push_word(input logic [15:0] word);
+    int wait_cycles;
+    begin
+      wait_cycles = 0;
+      while (OUT_data_ready !== 1'b1) begin
+        observed_backpressure = 1'b1;
+        @(posedge clk);
+        wait_cycles++;
+        if (wait_cycles > 32) begin
+          errors++;
+          $display("[%0t] ready timeout before input %h", $time, word);
+          return;
+        end
+      end
+      @(negedge clk);
+      IN_data  = word;
+      IN_valid = 1'b1;
+      @(negedge clk);
+      IN_valid = 1'b0;
+      IN_data  = 16'd0;
+    end
+  endtask
+
+  initial begin
+    logic [15:0] expected;
+
+    rst_n     = 1'b0;
+    i_clear   = 1'b0;
+    IN_func   = CVO_REDUCE_SUM;
+    IN_length = N_WORDS[15:0];
+    IN_flags  = '0;
+    IN_data   = 16'd0;
+    IN_valid  = 1'b0;
+
+    repeat (4) @(posedge clk);
+    rst_n = 1'b1;
+    @(posedge clk);
+
+    push_word(16'h3F80);  // 1.0
+    push_word(16'h3F80);  // 1.0
+    push_word(16'h3F80);  // 1.0
+    push_word(16'h3F80);  // 1.0
+
+    expected = 16'd0;
+    for (int i = 0; i < N_WORDS; i++) expected = model_bf16_add(expected, 16'h3F80);
+
+    for (int cycle = 0; cycle < 80; cycle++) begin
+      @(posedge clk); #1;
+      if (OUT_data_ready !== 1'b1) observed_backpressure = 1'b1;
+      if (OUT_result_valid) begin
+        if (OUT_result !== expected) begin
+          errors++;
+          $display("[%0t] reduce sum mismatch: got=%h exp=%h", $time, OUT_result, expected);
+        end
+        if (!observed_backpressure) begin
+          errors++;
+          $display("[%0t] reduce sum did not apply expected local backpressure", $time);
+        end
+        if (errors == 0) begin
+          $display("PASS: %0d cycles, CVO SFU reduce sum matches golden.", N_WORDS);
+        end else begin
+          $display("FAIL: %0d mismatches over %0d cycles.", errors, N_WORDS);
+        end
+        $finish;
+      end
+    end
+
+    errors++;
+    $display("FAIL: timeout waiting for reduce sum output.");
+    $finish;
+  end
+
+  initial begin
+    #100000 $display("TIMEOUT"); $finish;
+  end
+
+endmodule

--- a/hw/tb/tb_CVO_sfu_reduce_sum.sv
+++ b/hw/tb/tb_CVO_sfu_reduce_sum.sv
@@ -151,11 +151,15 @@ module tb_CVO_sfu_reduce_sum;
 	    bit          gelu_seen;
 	    bit          exp_seen;
     bit          recip_seen;
+    bit          scale_seen;
     logic [15:0] recip_input;
     logic [15:0] recip_seed;
     logic [15:0] recip_xr0;
     logic [15:0] recip_corr;
     logic [15:0] recip_expected;
+    logic [15:0] scale_scalar;
+    logic [15:0] scale_input;
+    logic [15:0] scale_expected;
 
     rst_n     = 1'b0;
     i_clear   = 1'b0;
@@ -287,8 +291,46 @@ module tb_CVO_sfu_reduce_sum;
       $display("FAIL: timeout waiting for RECIP output.");
     end
 
+    scale_scalar   = 16'h4000;  // 2.0
+    scale_input    = 16'h3FC0;  // 1.5
+    scale_expected = model_bf16_mul(scale_input, scale_scalar);
+
+    @(negedge clk);
+    IN_func  = CVO_SCALE;
+    IN_flags = '0;
+    IN_data  = scale_scalar;
+    IN_valid = 1'b1;
+    @(negedge clk);
+    IN_valid = 1'b0;
+    IN_data  = 16'd0;
+
+    @(negedge clk);
+    IN_data  = scale_input;
+    IN_valid = 1'b1;
+    @(negedge clk);
+    IN_valid = 1'b0;
+    IN_data  = 16'd0;
+
+    scale_seen = 1'b0;
+    for (int cycle = 0; cycle < 96; cycle++) begin
+      @(posedge clk); #1;
+      if (OUT_result_valid) begin
+        scale_seen = 1'b1;
+        if (OUT_result !== scale_expected) begin
+          errors++;
+          $display("[%0t] SCALE smoke mismatch: got=%h exp=%h", $time, OUT_result, scale_expected);
+        end
+        break;
+      end
+    end
+
+    if (!scale_seen) begin
+      errors++;
+      $display("FAIL: timeout waiting for SCALE output.");
+    end
+
 	    if (errors == 0) begin
-	      $display("PASS: %0d cycles, CVO SFU reduce sum, GELU, EXP, and RECIP smoke match golden.", N_WORDS);
+	      $display("PASS: %0d cycles, CVO SFU reduce sum, GELU, EXP, RECIP, and SCALE smoke match golden.", N_WORDS);
     end else begin
       $display("FAIL: %0d mismatches over CVO SFU smoke.", errors);
     end

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -18,6 +18,10 @@
 //   shape address left behind by a previous MEMSET or LOAD. The descriptor
 //   contract is a registered timing boundary: a one-cycle LOAD pulse produces
 //   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
+//
+//   The TB also checks the CVO bridge path owns the L2 port-B address/write
+//   boundary when a CVO uop is active. That catches a wiring class where the
+//   bridge computes OUT_l2_* correctly but the URAM wrapper never sees it.
 // ===============================================================================
 
 module tb_mem_dispatcher_shape_lookup;
@@ -259,6 +263,66 @@ module tb_mem_dispatcher_shape_lookup;
     end
   endtask
 
+  task automatic issue_cvo_l2_direct_read_smoke;
+    int wait_cycles;
+    begin
+      set_load_idle();
+      set_memset_idle();
+
+      cvo_uop = '{
+          cvo_func : CVO_SCALE,
+          src_addr : 17'd32,  // element address -> L2 word 4
+          dst_addr : 17'd96,
+          length   : 16'd8,
+          flags    : '0,
+          async    : SYNC_OP
+      };
+
+      cvo_uop_valid = 1'b1;
+      @(posedge clk_core);
+      #1;
+      cvo_uop_valid = 1'b0;
+
+      @(posedge clk_core);
+      #1;
+
+      checks++;
+      if (dut.u_l2_cache.IN_npu_direct_en !== 1'b1) begin
+        errors++;
+        $display("[%0t] mismatch cvo direct: direct_en=%0b exp 1",
+                 $time, dut.u_l2_cache.IN_npu_direct_en);
+      end
+
+      checks++;
+      if (dut.u_l2_cache.u_l2_uram.IN_npu_we !== 1'b0 ||
+          dut.u_l2_cache.u_l2_uram.IN_npu_addr !== 17'd4) begin
+        errors++;
+        $display("[%0t] mismatch cvo direct read: we=%0b addr=%0d exp we=0 addr=4",
+                 $time,
+                 dut.u_l2_cache.u_l2_uram.IN_npu_we,
+                 dut.u_l2_cache.u_l2_uram.IN_npu_addr);
+      end
+
+      // Feed one result per accepted CVO input so the bridge can drain and
+      // return to IDLE; the payload is not checked in this wiring smoke.
+      wait_cycles = 0;
+      while (cvo_busy && wait_cycles < 200) begin
+        cvo_result_valid <= cvo_valid && cvo_result_ready;
+        cvo_result       <= cvo_data;
+        @(posedge clk_core);
+        wait_cycles++;
+      end
+      cvo_result_valid <= 1'b0;
+      #1;
+
+      checks++;
+      if (cvo_busy !== 1'b0) begin
+        errors++;
+        $display("[%0t] mismatch cvo direct: bridge did not return idle", $time);
+      end
+    end
+  endtask
+
   // ===| Stimulus |=============================================================
   initial begin
     rst_n_core = 1'b0;
@@ -318,6 +382,8 @@ module tb_mem_dispatcher_shape_lookup;
                    6'd9,
                    17'd400,
                    ceil_words(4, 4, 4));
+
+    issue_cvo_l2_direct_read_smoke();
 
     if (errors == 0) begin
       $display("PASS: %0d cycles, mem_dispatcher shape lookup matches golden.", checks);

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -186,7 +186,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (4) @(posedge clk_core);
+      repeat (3) @(posedge clk_core);
       #1;
 
       checks++;
@@ -233,7 +233,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (4) @(posedge clk_core);
+      repeat (3) @(posedge clk_core);
       #1;
 
       checks++;

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
 `timescale 1ns / 1ps
 
 // ===============================================================================

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -16,8 +16,8 @@
 //   The key regression surface is pointer selection: a LOAD must use its own
 //   shape_ptr_addr for the command generated on that clock, not a stale
 //   shape address left behind by a previous MEMSET or LOAD. The descriptor
-//   contract is a registered timing boundary: a one-cycle LOAD pulse produces
-//   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
+  //   contract is a registered timing boundary: a one-cycle LOAD pulse produces
+  //   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
 //
 //   The TB also checks the CVO bridge path owns the L2 port-B address/write
 //   boundary when a CVO uop is active. That catches a wiring class where the
@@ -190,7 +190,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (3) @(posedge clk_core);
+      repeat (5) @(posedge clk_core);
       #1;
 
       checks++;
@@ -237,7 +237,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (3) @(posedge clk_core);
+      repeat (5) @(posedge clk_core);
       #1;
 
       checks++;

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -83,6 +83,7 @@ module tb_mem_dispatcher_shape_lookup;
   // ===| Scoreboard |===========================================================
   int errors = 0;
   int checks = 0;
+  localparam int LoadIssueLatencyCycles = 7;
 
   function automatic logic [16:0] ceil_words(
       input int unsigned x_val,
@@ -190,7 +191,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (5) @(posedge clk_core);
+      repeat (LoadIssueLatencyCycles) @(posedge clk_core);
       #1;
 
       checks++;
@@ -237,7 +238,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (5) @(posedge clk_core);
+      repeat (LoadIssueLatencyCycles) @(posedge clk_core);
       #1;
 
       checks++;
@@ -299,6 +300,9 @@ module tb_mem_dispatcher_shape_lookup;
         $display("[%0t] mismatch cvo direct: direct_valid=%0b exp 1",
                  $time, dut.cvo_l2_valid);
       end
+
+      @(posedge clk_core);
+      #1;
 
       checks++;
       if (dut.u_l2_cache.u_l2_uram.IN_npu_we !== 1'b0 ||

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -16,8 +16,8 @@
 //   The key regression surface is pointer selection: a LOAD must use its own
 //   shape_ptr_addr for the command generated on that clock, not a stale
 //   shape address left behind by a previous MEMSET or LOAD. The descriptor
-  //   contract is a registered timing boundary: a one-cycle LOAD pulse produces
-  //   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
+//   contract is a registered timing boundary: a one-cycle LOAD pulse produces
+//   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
 //
 //   The TB also checks the CVO bridge path owns the L2 port-B address/write
 //   boundary when a CVO uop is active. That catches a wiring class where the

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -186,7 +186,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (3) @(posedge clk_core);
+      repeat (4) @(posedge clk_core);
       #1;
 
       checks++;
@@ -233,7 +233,7 @@ module tb_mem_dispatcher_shape_lookup;
       @(posedge clk_core);
       #1;
       set_load_idle();
-      repeat (3) @(posedge clk_core);
+      repeat (4) @(posedge clk_core);
       #1;
 
       checks++;

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -13,7 +13,9 @@
 //
 //   The key regression surface is pointer selection: a LOAD must use its own
 //   shape_ptr_addr for the command generated on that clock, not a stale
-//   shape address left behind by a previous MEMSET or LOAD.
+//   shape address left behind by a previous MEMSET or LOAD. The descriptor
+//   contract is a registered timing boundary: a one-cycle LOAD pulse produces
+//   one ACP/NPU command after the mem_dispatcher shape-word pipeline.
 // ===============================================================================
 
 module tb_mem_dispatcher_shape_lookup;
@@ -34,6 +36,7 @@ module tb_mem_dispatcher_shape_lookup;
   // ===| DUT IO |===============================================================
   axis_if #(.DATA_WIDTH(128)) s_axis_acp_fmap ();
   axis_if #(.DATA_WIDTH(128)) m_axis_acp_result ();
+  axis_if #(.DATA_WIDTH(128)) m_axis_l1_fmap ();
 
   memory_control_uop_t load_uop;
   memory_set_uop_t     mem_set_uop;
@@ -56,6 +59,7 @@ module tb_mem_dispatcher_shape_lookup;
       .rst_axi_n           (rst_axi_n),
       .S_AXIS_ACP_FMAP     (s_axis_acp_fmap),
       .M_AXIS_ACP_RESULT   (m_axis_acp_result),
+      .M_AXIS_L1_FMAP      (m_axis_l1_fmap),
       .IN_LOAD_uop         (load_uop),
       .IN_mem_set_uop      (mem_set_uop),
       .IN_CVO_uop          (cvo_uop),
@@ -179,6 +183,9 @@ module tb_mem_dispatcher_shape_lookup;
       };
       @(posedge clk_core);
       #1;
+      set_load_idle();
+      repeat (3) @(posedge clk_core);
+      #1;
 
       checks++;
       if (dut.acp_rx_start !== 1'b1) begin
@@ -198,7 +205,6 @@ module tb_mem_dispatcher_shape_lookup;
                  exp_write_en, exp_base, exp_end);
       end
 
-      set_load_idle();
       @(posedge clk_core);
       #1;
     end
@@ -224,6 +230,9 @@ module tb_mem_dispatcher_shape_lookup;
       };
       @(posedge clk_core);
       #1;
+      set_load_idle();
+      repeat (3) @(posedge clk_core);
+      #1;
 
       checks++;
       if (dut.npu_rx_start !== 1'b1) begin
@@ -243,7 +252,6 @@ module tb_mem_dispatcher_shape_lookup;
                  src_addr, exp_end);
       end
 
-      set_load_idle();
       @(posedge clk_core);
       #1;
     end
@@ -266,6 +274,7 @@ module tb_mem_dispatcher_shape_lookup;
     s_axis_acp_fmap.tlast  = 1'b0;
     s_axis_acp_fmap.tkeep  = '1;
     m_axis_acp_result.tready = 1'b1;
+    m_axis_l1_fmap.tready = 1'b1;
 
     repeat (4) @(posedge clk_core);
     rst_n_core = 1'b1;

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -294,6 +294,13 @@ module tb_mem_dispatcher_shape_lookup;
       end
 
       checks++;
+      if (dut.cvo_l2_valid !== 1'b1) begin
+        errors++;
+        $display("[%0t] mismatch cvo direct: direct_valid=%0b exp 1",
+                 $time, dut.cvo_l2_valid);
+      end
+
+      checks++;
       if (dut.u_l2_cache.u_l2_uram.IN_npu_we !== 1'b0 ||
           dut.u_l2_cache.u_l2_uram.IN_npu_addr !== 17'd4) begin
         errors++;

--- a/hw/vivado/README.md
+++ b/hw/vivado/README.md
@@ -10,8 +10,9 @@ Target device: **Kria KV260 SOM, `xck26-sfvc784-2LV-c` (ZU5EV)**.
 | `filelist.f`            | Ordered SystemVerilog source list, read by both `xvlog -f` and the Vivado TCL. |
 | `create_project.tcl`    | Build the Vivado project (part, sources, includes, XDC). |
 | `synth.tcl`             | Out-of-context synthesis of `NPU_top`. Reports into `build/reports/`. |
-| `impl.tcl`              | Opt / place / route / `write_bitstream`. Long job — only run once synth is clean. |
-| `build.sh`              | Wrapper: `./build.sh {project\|synth\|impl\|clean}`. |
+| `impl.tcl`              | OOC opt/place/route evidence. The bitstream mode is blocked for OOC modules. |
+| `top_level_status.tcl`  | Full KV260 top-level / BD bitstream-flow prerequisite gate. |
+| `build.sh`              | Wrapper: `./build.sh {project\|synth\|impl\|bitstream\|top-status\|top-bitstream\|clean}`. |
 | `npu_core_wrapper.sv`   | Plain-signal shim around `NPU_top`'s SV-interface ports, used by the BD / IP packager. |
 
 ## Quick start
@@ -25,8 +26,11 @@ cd hw
 # Out-of-context synthesis (minutes to tens of minutes, depending on machine)
 ./vivado/build.sh synth
 
-# Full implementation + bitstream (hour-scale)
+# Routed OOC implementation evidence (long job)
 ./vivado/build.sh impl
+
+# Full KV260 top-level / BD bitstream-flow prerequisite status (lightweight)
+./vivado/build.sh top-status
 
 # Wipe all generated state
 ./vivado/build.sh clean
@@ -40,9 +44,10 @@ cd hw
 | `xelab` on `GEMV_top`, `CVO_top`, `GEMM_systolic_top` | ✅ clean |
 | `xelab` on `NPU_top` standalone | ⚪ expected fail — interface ports need a wrapper; see `npu_core_wrapper.sv` |
 | `create_project.tcl` | ✅ runs green |
-| `synth.tcl` (out-of-context) | 🟡 attempted locally; no completed report yet. Use `PCCX_VIVADO_JOBS=1` on memory-constrained hosts |
-| `impl.tcl` (write_bitstream) | 🔴 not attempted yet — gated on completed synth evidence |
-| Block design / Zynq PS integration | 🔴 not written yet (see §Next steps) |
+| `synth.tcl` (out-of-context) | ✅ current PR #79 evidence: runs to reports with post-synth timing clean |
+| `impl.tcl` (out-of-context route) | 🟡 current PR #79 evidence: route completes, post-impl setup still violates by a small margin |
+| OOC `bitstream` mode | 🔴 blocked by Vivado HDOOC-3; OOC route evidence is not a KV260 bitstream |
+| Full top-level / Zynq PS integration | 🔴 not written yet (see §Next steps and `top-status`) |
 | Device-tree overlay | 🔴 not written yet |
 | Driver smoke test on board | 🔴 not attempted yet |
 
@@ -72,17 +77,22 @@ evidence, not a timing-closure claim.
    - unresolved `XPM_*` references needing `-L xpm` in synth
    - untied output ports on placeholder modules
    - multi-driver or ambiguous interface modport warnings
-2. **Block design** — create `vivado/system_bd.tcl` that drops:
+2. **Block design** — create `vivado/system_bd.tcl` or set
+   `PCCX_TOP_BD_TCL` to a board-design script that drops:
    - Zynq UltraScale+ MPSoC IP (KV260 preset)
    - `npu_core_wrapper` as a packaged IP
    - AXI Interconnect / Smart Connect between PS HP/HPC/HPM and the NPU
    - Clock Wizard for the 400 MHz core clock
-3. **`write_bitstream`** — only run after (1) and (2) are green; otherwise
-   you burn an hour for nothing.
-4. **Device-tree overlay** — see `sw/dtbo/` (to be created) for the
+3. **Top-level status gate** — run `./vivado/build.sh top-status` to
+   record whether the full top-level prerequisites exist. This writes
+   `build/reports/top_level_bitstream_status.txt`.
+4. **`write_bitstream`** — only run after full top-level implementation is
+   valid and post-implementation timing is clean; otherwise this is not board
+   evidence.
+5. **Device-tree overlay** — see `sw/dtbo/` (to be created) for the
    Ubuntu 22.04 FPGA Manager flow. Files: `pccx_npu.dtsi`,
    `shell.json`, `Makefile`.
-5. **KV260 deploy**:
+6. **KV260 deploy**:
    ```bash
    sudo xmutil unloadapp
    sudo cp build/pccx_v002_kv260.bit.bin \
@@ -92,7 +102,7 @@ evidence, not a timing-closure claim.
    sudo xmutil loadapp pccx_npu
    dmesg | tail -30     # look for successful overlay + no AXI timeouts
    ```
-6. **Driver smoke** — `sw/driver/` is still skeleton per the repo's
+7. **Driver smoke** — `sw/driver/` is still skeleton per the repo's
    implementation-status table; bring that up in parallel with the
    board-side work.
 

--- a/hw/vivado/build.sh
+++ b/hw/vivado/build.sh
@@ -7,6 +7,8 @@
 #   ./build.sh synth     # create_project + synth (OOC)
 #   ./build.sh impl      # routed OOC implementation + post-impl reports
 #   ./build.sh bitstream # explicit bitstream step; blocked for OOC module flow
+#   ./build.sh top-status # full top-level / BD prerequisite status
+#   ./build.sh top-bitstream # full top-level bitstream gate; blocked until BD exists
 #   ./build.sh clean     # wipe build/ + generated .jou/.log
 #
 # Target: Vivado 2023.2+ on Linux. Will attempt Vivado 2025.2 if available.
@@ -68,13 +70,29 @@ case "${1:-synth}" in
             -source vivado/impl.tcl \
             -tclargs bitstream
         ;;
+    top-status)
+        mkdir -p "$BUILD_DIR"
+        "$VIVADO_BIN" -mode batch \
+            -log    "$BUILD_DIR/vivado_top_status.log" \
+            -journal "$BUILD_DIR/vivado_top_status.jou" \
+            -source vivado/top_level_status.tcl \
+            -tclargs status
+        ;;
+    top-bitstream)
+        mkdir -p "$BUILD_DIR"
+        "$VIVADO_BIN" -mode batch \
+            -log    "$BUILD_DIR/vivado_top_bitstream.log" \
+            -journal "$BUILD_DIR/vivado_top_bitstream.jou" \
+            -source vivado/top_level_status.tcl \
+            -tclargs bitstream
+        ;;
     clean)
         rm -rf "$BUILD_DIR"
         rm -f  "$HW_DIR/vivado.jou" "$HW_DIR/vivado.log"
         ;;
     *)
         echo "unknown command: $1" >&2
-        echo "usage: $0 {project|synth|impl|bitstream|clean}" >&2
+        echo "usage: $0 {project|synth|impl|bitstream|top-status|top-bitstream|clean}" >&2
         exit 1
         ;;
 esac

--- a/hw/vivado/build.sh
+++ b/hw/vivado/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # build.sh — thin wrapper around the Vivado TCL flow.
 #
 #   ./build.sh project   # just create_project.tcl

--- a/hw/vivado/build.sh
+++ b/hw/vivado/build.sh
@@ -3,7 +3,8 @@
 #
 #   ./build.sh project   # just create_project.tcl
 #   ./build.sh synth     # create_project + synth (OOC)
-#   ./build.sh impl      # full impl + write_bitstream (long job)
+#   ./build.sh impl      # routed OOC implementation + post-impl reports
+#   ./build.sh bitstream # explicit bitstream step; blocked for OOC module flow
 #   ./build.sh clean     # wipe build/ + generated .jou/.log
 #
 # Target: Vivado 2023.2+ on Linux. Will attempt Vivado 2025.2 if available.
@@ -54,7 +55,16 @@ case "${1:-synth}" in
         "$VIVADO_BIN" -mode batch \
             -log    "$BUILD_DIR/vivado_impl.log" \
             -journal "$BUILD_DIR/vivado_impl.jou" \
-            -source vivado/impl.tcl
+            -source vivado/impl.tcl \
+            -tclargs route
+        ;;
+    bitstream)
+        mkdir -p "$BUILD_DIR"
+        "$VIVADO_BIN" -mode batch \
+            -log    "$BUILD_DIR/vivado_bitstream.log" \
+            -journal "$BUILD_DIR/vivado_bitstream.jou" \
+            -source vivado/impl.tcl \
+            -tclargs bitstream
         ;;
     clean)
         rm -rf "$BUILD_DIR"
@@ -62,7 +72,7 @@ case "${1:-synth}" in
         ;;
     *)
         echo "unknown command: $1" >&2
-        echo "usage: $0 {project|synth|impl|clean}" >&2
+        echo "usage: $0 {project|synth|impl|bitstream|clean}" >&2
         exit 1
         ;;
 esac

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -62,9 +62,11 @@ if {[get_property PROGRESS [get_runs synth_1]] ne "100%"} {
 if {$IMPL_MODE eq "bitstream"} {
     set status_file [file normalize $REPORTS/bitstream_status.txt]
     set fp [open $status_file w]
+    puts $fp "implementation_scope=OOC_ROUTE_ONLY"
     puts $fp "bitstream_status=BITSTREAM_BLOCKED_OOC"
     puts $fp "reason=Vivado DRC HDOOC-3: bitstream generation is not allowed for out-of-context module implementations."
-    puts $fp "required_next_step=add a full KV260 top-level or block-design wrapper flow, then run write_bitstream there."
+    puts $fp "full_top_level_flow=NOT_STARTED"
+    puts $fp "required_next_step=run ./vivado/build.sh top-status, then add a full KV260 top-level or block-design wrapper flow before write_bitstream."
     puts $fp "project=$PROJ_DIR/pccx_v002_kv260.xpr"
     close $fp
     puts "\[pccx\] bitstream blocked for OOC module flow. See $status_file"
@@ -117,9 +119,11 @@ if {[file exists $bit_file]} {
 } else {
     set status_file [file normalize $REPORTS/bitstream_status.txt]
     set fp [open $status_file w]
+    puts $fp "implementation_scope=OOC_ROUTE_ONLY"
     puts $fp "bitstream_status=BITSTREAM_NOT_REQUESTED"
     puts $fp "reason=impl mode stops at route_design for OOC timing evidence."
-    puts $fp "required_next_step=run ./vivado/build.sh bitstream after a full top-level/BD bitstream flow exists."
+    puts $fp "full_top_level_flow=NOT_STARTED"
+    puts $fp "required_next_step=run ./vivado/build.sh top-status, then add a full top-level/BD bitstream flow before write_bitstream."
     close $fp
     puts "\[pccx\] bitstream not requested in route mode. See $status_file"
 }

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # =============================================================================
 # impl.tcl — routed implementation evidence for the pccx v002 NPU core.
 #

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -89,8 +89,12 @@ puts "\[pccx\] impl strategy = [get_property strategy [get_runs impl_1]]"
 launch_runs impl_1 -to_step route_design -jobs $IMPL_JOBS
 wait_on_run impl_1
 
-if {[get_property PROGRESS [get_runs impl_1]] ne "100%"} {
-    puts "\[pccx\] impl_1 did not finish (progress=[get_property PROGRESS [get_runs impl_1]])."
+set impl_progress [get_property PROGRESS [get_runs impl_1]]
+set impl_status   [get_property STATUS [get_runs impl_1]]
+puts "\[pccx\] impl progress = $impl_progress"
+puts "\[pccx\] impl status = $impl_status"
+if {$impl_progress ne "100%" && [string first "route_design Complete" $impl_status] < 0} {
+    puts "\[pccx\] impl_1 did not finish."
     exit 1
 }
 

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -42,7 +42,7 @@ if {[catch {set_param general.maxThreads $IMPL_JOBS} msg]} {
 puts "\[pccx\] impl jobs/threads = $IMPL_JOBS"
 puts "\[pccx\] impl mode = $IMPL_MODE"
 
-set IMPL_STRATEGY ""
+set IMPL_STRATEGY "Vivado Implementation Defaults"
 if {[info exists ::env(PCCX_IMPL_STRATEGY)] && $::env(PCCX_IMPL_STRATEGY) ne ""} {
     set IMPL_STRATEGY $::env(PCCX_IMPL_STRATEGY)
 }
@@ -77,12 +77,10 @@ foreach r [get_runs -quiet impl_1] {
     reset_run $r
 }
 
-if {$IMPL_STRATEGY ne ""} {
-    if {[catch {set_property strategy $IMPL_STRATEGY [get_runs impl_1]} msg]} {
-        puts "\[pccx\] invalid PCCX_IMPL_STRATEGY=$IMPL_STRATEGY: $msg"
-        close_project
-        exit 2
-    }
+if {[catch {set_property strategy $IMPL_STRATEGY [get_runs impl_1]} msg]} {
+    puts "\[pccx\] invalid PCCX_IMPL_STRATEGY=$IMPL_STRATEGY: $msg"
+    close_project
+    exit 2
 }
 puts "\[pccx\] impl strategy = [get_property strategy [get_runs impl_1]]"
 
@@ -91,11 +89,15 @@ wait_on_run impl_1
 
 set impl_progress [get_property PROGRESS [get_runs impl_1]]
 set impl_status   [get_property STATUS [get_runs impl_1]]
+set routed_dcp    [file normalize $PROJ_DIR/pccx_v002_kv260.runs/impl_1/NPU_top_routed.dcp]
 puts "\[pccx\] impl progress = $impl_progress"
 puts "\[pccx\] impl status = $impl_status"
-if {$impl_progress ne "100%" && [string first "route_design Complete" $impl_status] < 0} {
+if {$impl_progress ne "100%" && [string first "route_design Complete" $impl_status] < 0 && ![file exists $routed_dcp]} {
     puts "\[pccx\] impl_1 did not finish."
     exit 1
+}
+if {[file exists $routed_dcp]} {
+    puts "\[pccx\] routed checkpoint = $routed_dcp"
 }
 
 open_run impl_1

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -42,6 +42,11 @@ if {[catch {set_param general.maxThreads $IMPL_JOBS} msg]} {
 puts "\[pccx\] impl jobs/threads = $IMPL_JOBS"
 puts "\[pccx\] impl mode = $IMPL_MODE"
 
+set IMPL_STRATEGY ""
+if {[info exists ::env(PCCX_IMPL_STRATEGY)] && $::env(PCCX_IMPL_STRATEGY) ne ""} {
+    set IMPL_STRATEGY $::env(PCCX_IMPL_STRATEGY)
+}
+
 open_project $PROJ_DIR/pccx_v002_kv260.xpr
 
 # Confirm the synth run is clean before committing to impl.
@@ -71,6 +76,15 @@ if {$IMPL_MODE eq "bitstream"} {
 foreach r [get_runs -quiet impl_1] {
     reset_run $r
 }
+
+if {$IMPL_STRATEGY ne ""} {
+    if {[catch {set_property strategy $IMPL_STRATEGY [get_runs impl_1]} msg]} {
+        puts "\[pccx\] invalid PCCX_IMPL_STRATEGY=$IMPL_STRATEGY: $msg"
+        close_project
+        exit 2
+    }
+}
+puts "\[pccx\] impl strategy = [get_property strategy [get_runs impl_1]]"
 
 launch_runs impl_1 -to_step route_design -jobs $IMPL_JOBS
 wait_on_run impl_1

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -1,5 +1,5 @@
 # =============================================================================
-# impl.tcl — implementation + bitstream for the pccx v002 NPU core.
+# impl.tcl — routed implementation evidence for the pccx v002 NPU core.
 #
 # This is NOT auto-run by any other script. It exists as a deliberate
 # gate — implementation + bitstream is an hour-scale job; launch it only
@@ -8,13 +8,37 @@
 #
 # Usage
 # -----
-#   vivado -mode batch -source vivado/impl.tcl
+#   vivado -mode batch -source vivado/impl.tcl -tclargs route
+#   vivado -mode batch -source vivado/impl.tcl -tclargs bitstream
 # =============================================================================
 
 set HW_ROOT  [file normalize [file dirname [info script]]/..]
 set PROJ_DIR [file normalize $HW_ROOT/build/pccx_v002_kv260]
 set REPORTS  $HW_ROOT/build/reports
 file mkdir $REPORTS
+
+set IMPL_MODE "route"
+if {[llength $argv] > 0 && [lindex $argv 0] ne ""} {
+    set IMPL_MODE [lindex $argv 0]
+}
+if {$IMPL_MODE ne "route" && $IMPL_MODE ne "bitstream"} {
+    puts "\[pccx\] invalid impl mode '$IMPL_MODE'; expected route or bitstream."
+    exit 2
+}
+
+set IMPL_JOBS 4
+if {[info exists ::env(PCCX_VIVADO_JOBS)] && $::env(PCCX_VIVADO_JOBS) ne ""} {
+    set IMPL_JOBS $::env(PCCX_VIVADO_JOBS)
+}
+if {![string is integer -strict $IMPL_JOBS] || $IMPL_JOBS < 1} {
+    puts "\[pccx\] invalid PCCX_VIVADO_JOBS=$IMPL_JOBS; expected positive integer."
+    exit 2
+}
+if {[catch {set_param general.maxThreads $IMPL_JOBS} msg]} {
+    puts "\[pccx\] warning: could not set general.maxThreads=$IMPL_JOBS: $msg"
+}
+puts "\[pccx\] impl jobs/threads = $IMPL_JOBS"
+puts "\[pccx\] impl mode = $IMPL_MODE"
 
 open_project $PROJ_DIR/pccx_v002_kv260.xpr
 
@@ -24,12 +48,29 @@ if {[get_property PROGRESS [get_runs synth_1]] ne "100%"} {
     exit 1
 }
 
-# Reset and kick off implementation.
+# The current v002 project intentionally synthesizes NPU_top out of context.
+# Vivado rejects bitstream generation for OOC modules (DRC HDOOC-3). Keep the
+# bitstream step explicit so implementation/timing evidence can still complete
+# cleanly while bitstream remains blocked until a full top-level/BD flow exists.
+if {$IMPL_MODE eq "bitstream"} {
+    set status_file [file normalize $REPORTS/bitstream_status.txt]
+    set fp [open $status_file w]
+    puts $fp "bitstream_status=BITSTREAM_BLOCKED_OOC"
+    puts $fp "reason=Vivado DRC HDOOC-3: bitstream generation is not allowed for out-of-context module implementations."
+    puts $fp "required_next_step=add a full KV260 top-level or block-design wrapper flow, then run write_bitstream there."
+    puts $fp "project=$PROJ_DIR/pccx_v002_kv260.xpr"
+    close $fp
+    puts "\[pccx\] bitstream blocked for OOC module flow. See $status_file"
+    close_project
+    exit 3
+}
+
+# Reset and kick off routed implementation.
 foreach r [get_runs -quiet impl_1] {
     reset_run $r
 }
 
-launch_runs impl_1 -to_step write_bitstream -jobs 4
+launch_runs impl_1 -to_step route_design -jobs $IMPL_JOBS
 wait_on_run impl_1
 
 if {[get_property PROGRESS [get_runs impl_1]] ne "100%"} {
@@ -52,7 +93,13 @@ if {[file exists $bit_file]} {
     file copy -force $bit_file $HW_ROOT/build/pccx_v002_kv260.bit
     puts "\[pccx\] bitstream copied to build/pccx_v002_kv260.bit"
 } else {
-    puts "\[pccx\] warning: expected bitstream not found at $bit_file"
+    set status_file [file normalize $REPORTS/bitstream_status.txt]
+    set fp [open $status_file w]
+    puts $fp "bitstream_status=BITSTREAM_NOT_REQUESTED"
+    puts $fp "reason=impl mode stops at route_design for OOC timing evidence."
+    puts $fp "required_next_step=run ./vivado/build.sh bitstream after a full top-level/BD bitstream flow exists."
+    close $fp
+    puts "\[pccx\] bitstream not requested in route mode. See $status_file"
 }
 
 close_project

--- a/hw/vivado/top_level_status.tcl
+++ b/hw/vivado/top_level_status.tcl
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# =============================================================================
+# top_level_status.tcl — explicit full KV260 top-level / BD bitstream gate.
+#
+# This script does not synthesize or route the OOC NPU core. It records whether
+# the repo has the ingredients needed for a full board bitstream flow and fails
+# fast when the flow is incomplete. The point is to keep OOC timing evidence
+# separate from a real KV260 top-level implementation.
+#
+# Usage:
+#   vivado -mode batch -source vivado/top_level_status.tcl -tclargs status
+#   vivado -mode batch -source vivado/top_level_status.tcl -tclargs bitstream
+# =============================================================================
+
+set HW_ROOT  [file normalize [file dirname [info script]]/..]
+set REPORTS  $HW_ROOT/build/reports
+file mkdir $REPORTS
+
+set MODE "status"
+if {[llength $argv] > 0 && [lindex $argv 0] ne ""} {
+    set MODE [lindex $argv 0]
+}
+if {$MODE ne "status" && $MODE ne "bitstream"} {
+    puts "\[pccx\] invalid top-level mode '$MODE'; expected status or bitstream."
+    exit 2
+}
+
+set TARGET_PART  xck26-sfvc784-2LV-c
+set TARGET_BOARD xilinx.com:kv260_som:part0:1.4
+set WRAPPER      [file normalize $HW_ROOT/vivado/npu_core_wrapper.sv]
+set FILELIST     [file normalize $HW_ROOT/vivado/filelist.f]
+set CONSTRAINTS  [file normalize $HW_ROOT/constraints/pccx_timing.xdc]
+set DEFAULT_BD   [file normalize $HW_ROOT/vivado/system_bd.tcl]
+set BD_SCRIPT    $DEFAULT_BD
+if {[info exists ::env(PCCX_TOP_BD_TCL)] && $::env(PCCX_TOP_BD_TCL) ne ""} {
+    set BD_SCRIPT [file normalize $::env(PCCX_TOP_BD_TCL)]
+}
+
+set STATUS_FILE [file normalize $REPORTS/top_level_bitstream_status.txt]
+set board_part_status "MISSING"
+if {[llength [get_board_parts -quiet $TARGET_BOARD]] > 0} {
+    set board_part_status "AVAILABLE"
+}
+
+set wrapper_status "MISSING"
+if {[file exists $WRAPPER]} {
+    set wrapper_status "PRESENT"
+}
+
+set filelist_status "MISSING"
+if {[file exists $FILELIST]} {
+    set filelist_status "PRESENT"
+}
+
+set constraints_status "MISSING"
+if {[file exists $CONSTRAINTS]} {
+    set constraints_status "PRESENT"
+}
+
+set bd_status "MISSING"
+if {[file exists $BD_SCRIPT]} {
+    set bd_status "PRESENT"
+}
+
+set full_top_status "FULL_TOP_IMPL_NOT_RUN"
+set bitstream_status "BITSTREAM_NOT_RUN_TOP_FLOW_INCOMPLETE"
+set blocker "missing_full_top_level_block_design"
+if {$bd_status eq "PRESENT"} {
+    set full_top_status "FULL_TOP_FLOW_SCAFFOLDED"
+    set bitstream_status "BITSTREAM_NOT_REQUESTED"
+    set blocker "full_top_level_bitstream_not_launched_by_status_mode"
+}
+
+if {$MODE eq "bitstream"} {
+    if {$bd_status ne "PRESENT"} {
+        set full_top_status "FULL_TOP_IMPL_NOT_RUN"
+        set bitstream_status "BITSTREAM_NOT_RUN_TOP_FLOW_INCOMPLETE"
+        set blocker "missing $BD_SCRIPT"
+    } else {
+        set full_top_status "FULL_TOP_FLOW_SCAFFOLDED"
+        set bitstream_status "BITSTREAM_BLOCKED_PENDING_RUN_SCRIPT"
+        set blocker "system_bd.tcl exists but automated full-top implementation is not enabled in this guard script"
+    }
+}
+
+set fp [open $STATUS_FILE w]
+puts $fp "implementation_scope=FULL_TOP_LEVEL"
+puts $fp "mode=$MODE"
+puts $fp "target_part=$TARGET_PART"
+puts $fp "target_board=$TARGET_BOARD"
+puts $fp "board_part_status=$board_part_status"
+puts $fp "wrapper_source=$WRAPPER"
+puts $fp "wrapper_status=$wrapper_status"
+puts $fp "filelist=$FILELIST"
+puts $fp "filelist_status=$filelist_status"
+puts $fp "constraints=$CONSTRAINTS"
+puts $fp "constraints_status=$constraints_status"
+puts $fp "bd_script=$BD_SCRIPT"
+puts $fp "bd_status=$bd_status"
+puts $fp "full_top_level_flow=$full_top_status"
+puts $fp "bitstream_status=$bitstream_status"
+puts $fp "blocker=$blocker"
+puts $fp "required_next_step=author hw/vivado/system_bd.tcl or set PCCX_TOP_BD_TCL to a board-design Tcl that packages npu_core_wrapper, instantiates Zynq MPSoC, binds clocks/resets, connects AXI, generates the HDL wrapper, runs full implementation, and writes bitstream only after timing is clean."
+close $fp
+
+puts "\[pccx\] top-level status written to $STATUS_FILE"
+puts "\[pccx\] full_top_level_flow = $full_top_status"
+puts "\[pccx\] bitstream_status = $bitstream_status"
+
+if {$MODE eq "bitstream"} {
+    exit 3
+}

--- a/scripts/v002/check-rtl-system-sanity.sh
+++ b/scripts/v002/check-rtl-system-sanity.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Lightweight RTL relationship checks before expensive Vivado runs.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HW_DIR="$ROOT_DIR/hw"
+FILELIST="$HW_DIR/vivado/filelist.f"
+
+failures=0
+report_fail() {
+    printf 'FAIL: %s\n' "$*"
+    failures=$((failures + 1))
+}
+
+report_pass() {
+    printf 'PASS: %s\n' "$*"
+}
+
+if [[ ! -f "$FILELIST" ]]; then
+    report_fail "missing filelist: hw/vivado/filelist.f"
+    exit 1
+fi
+
+python3 - "$ROOT_DIR" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+hw = root / "hw"
+filelist = hw / "vivado" / "filelist.f"
+failures = 0
+
+def fail(msg):
+    global failures
+    print(f"FAIL: {msg}")
+    failures += 1
+
+def ok(msg):
+    print(f"PASS: {msg}")
+
+entries = []
+for line in filelist.read_text().splitlines():
+    item = line.strip()
+    if not item or item.startswith("#"):
+        continue
+    entries.append(hw / item)
+
+missing = [p for p in entries if not p.exists()]
+if missing:
+    for path in missing:
+        fail(f"filelist entry missing: {path.relative_to(root)}")
+else:
+    ok(f"filelist entries exist ({len(entries)})")
+
+listed = {p.resolve() for p in entries}
+rtl_sv = sorted((hw / "rtl").rglob("*.sv"))
+unlisted = [p for p in rtl_sv if p.resolve() not in listed]
+if unlisted:
+    for path in unlisted:
+        fail(f"rtl sv not in filelist: {path.relative_to(root)}")
+else:
+    ok(f"all RTL .sv files are in filelist ({len(rtl_sv)})")
+
+module_defs = {}
+scan_files = rtl_sv + sorted((hw / "vivado").glob("*.sv"))
+for path in scan_files:
+    text = path.read_text(errors="ignore")
+    for match in re.finditer(r"^\s*module\s+([A-Za-z_][A-Za-z0-9_$]*)\b", text, re.MULTILINE):
+        module_defs.setdefault(match.group(1), []).append(path)
+
+dups = {name: paths for name, paths in module_defs.items() if len(paths) > 1}
+if dups:
+    for name, paths in sorted(dups.items()):
+        rels = ", ".join(str(p.relative_to(root)) for p in paths)
+        fail(f"duplicate module {name}: {rels}")
+else:
+    ok(f"no duplicate module definitions ({len(module_defs)})")
+
+mem_dispatcher = (hw / "rtl/MEM_control/top/mem_dispatcher.sv").read_text(errors="ignore")
+mem_global = (hw / "rtl/MEM_control/memory/mem_GLOBAL_cache.sv").read_text(errors="ignore")
+required_dispatcher_terms = [
+    ".IN_npu_direct_en",
+    ".IN_npu_direct_we",
+    ".IN_npu_direct_addr",
+    ".IN_npu_direct_wdata",
+]
+required_global_terms = [
+    "IN_npu_direct_en",
+    "IN_npu_direct_we",
+    "IN_npu_direct_addr",
+    "IN_npu_direct_wdata",
+    "l2_npu_addr",
+]
+missing_terms = [term for term in required_dispatcher_terms if term not in mem_dispatcher]
+missing_terms += [term for term in required_global_terms if term not in mem_global]
+if missing_terms:
+    for term in missing_terms:
+        fail(f"missing CVO/L2 direct port boundary term: {term}")
+else:
+    ok("CVO/L2 direct port-B boundary terms present")
+
+sys.exit(1 if failures else 0)
+PY
+python_status=$?
+if (( python_status != 0 )); then
+    failures=$((failures + 1))
+fi
+
+if (( failures != 0 )); then
+    printf 'RTL_SYSTEM_SANITY=FAIL\n'
+    exit 1
+fi
+
+printf 'RTL_SYSTEM_SANITY=PASS\n'

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -149,6 +149,8 @@ TIMING_REPORT="$REPORT_DIR/timing_summary_post_synth.rpt"
 UTIL_REPORT="$REPORT_DIR/utilization_post_synth.rpt"
 IMPL_TIMING_REPORT="$REPORT_DIR/timing_summary_post_impl.rpt"
 IMPL_UTIL_REPORT="$REPORT_DIR/utilization_post_impl.rpt"
+BITSTREAM_STATUS_FILE="$REPORT_DIR/bitstream_status.txt"
+TOP_LEVEL_STATUS_FILE="$REPORT_DIR/top_level_bitstream_status.txt"
 TIMING_STATUS="$(status_from_report "$TIMING_REPORT")"
 IMPL_TIMING_STATUS="$(status_from_report "$IMPL_TIMING_REPORT")"
 if [[ "$SYNTH_STATUS" == "failed" && ! -f "$TIMING_REPORT" ]]; then
@@ -172,8 +174,30 @@ capture_report_tail "$TIMING_REPORT" timing_summary_post_synth
 capture_report_tail "$UTIL_REPORT" utilization_post_synth
 capture_report_tail "$IMPL_TIMING_REPORT" timing_summary_post_impl
 capture_report_tail "$IMPL_UTIL_REPORT" utilization_post_impl
+capture_report_tail "$BITSTREAM_STATUS_FILE" bitstream_status
+capture_report_tail "$TOP_LEVEL_STATUS_FILE" top_level_bitstream_status
+
+field_from_status_file() {
+    local report="$1"
+    local field="$2"
+    if [[ ! -f "$report" ]]; then
+        printf 'unavailable'
+        return
+    fi
+    awk -F= -v key="$field" '$1 == key {print substr($0, length(key) + 2); found=1; exit} END {if (!found) print "unavailable"}' "$report"
+}
 
 VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
+BITSTREAM_STATUS="$(field_from_status_file "$BITSTREAM_STATUS_FILE" 'bitstream_status')"
+IMPLEMENTATION_SCOPE="$(field_from_status_file "$BITSTREAM_STATUS_FILE" 'implementation_scope')"
+if [[ "$IMPLEMENTATION_SCOPE" == "unavailable" ]]; then
+    case "$BITSTREAM_STATUS" in
+        BITSTREAM_NOT_REQUESTED|BITSTREAM_BLOCKED_OOC)
+            IMPLEMENTATION_SCOPE="OOC_ROUTE_ONLY"
+            ;;
+    esac
+fi
+FULL_TOP_LEVEL_FLOW="$(field_from_status_file "$TOP_LEVEL_STATUS_FILE" 'full_top_level_flow')"
 
 {
     printf 'run_id=%s\n' "$RUN_ID"
@@ -200,6 +224,11 @@ VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
     printf 'impl_timing_ths_ns=%s\n' "$(metric_from_report "$IMPL_TIMING_REPORT" 'THS(ns)')"
     printf 'utilization_report=%s\n' "$UTIL_REPORT"
     printf 'impl_utilization_report=%s\n' "$IMPL_UTIL_REPORT"
+    printf 'bitstream_status_file=%s\n' "$BITSTREAM_STATUS_FILE"
+    printf 'bitstream_status=%s\n' "$BITSTREAM_STATUS"
+    printf 'implementation_scope=%s\n' "$IMPLEMENTATION_SCOPE"
+    printf 'full_top_level_status_file=%s\n' "$TOP_LEVEL_STATUS_FILE"
+    printf 'full_top_level_flow=%s\n' "$FULL_TOP_LEVEL_FLOW"
     printf 'vivado=%s\n' "$(command -v vivado 2>/dev/null || printf MISSING)"
     printf 'vivado_version=%s\n' "$VIVADO_VERSION"
     printf 'xvlog=%s\n' "$(command -v xvlog 2>/dev/null || printf MISSING)"

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -187,7 +187,17 @@ field_from_status_file() {
     awk -F= -v key="$field" '$1 == key {print substr($0, length(key) + 2); found=1; exit} END {if (!found) print "unavailable"}' "$report"
 }
 
-VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
+vivado_version() {
+    local vivado_bin
+    vivado_bin="$(command -v vivado 2>/dev/null || true)"
+    if [[ -z "$vivado_bin" ]]; then
+        printf 'MISSING'
+        return
+    fi
+    "$vivado_bin" -version 2>/dev/null | awk 'NR == 1 {print; found=1} END {if (!found) exit 1}' || printf 'MISSING'
+}
+
+VIVADO_VERSION="$(vivado_version)"
 BITSTREAM_STATUS="$(field_from_status_file "$BITSTREAM_STATUS_FILE" 'bitstream_status')"
 IMPLEMENTATION_SCOPE="$(field_from_status_file "$BITSTREAM_STATUS_FILE" 'implementation_scope')"
 if [[ "$IMPLEMENTATION_SCOPE" == "unavailable" ]]; then

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -11,6 +11,7 @@ REPORT_DIR="$HW_DIR/build/reports"
 DRY_RUN=0
 RUN_SYNTH=0
 RUN_ID="${PCCX_RUN_ID:-}"
+ORIGINAL_ARGS=("$@")
 
 usage() {
     cat <<'USAGE'
@@ -81,6 +82,39 @@ status_from_report() {
     fi
 }
 
+metric_from_report() {
+    local report="$1"
+    local metric="$2"
+    if [[ ! -f "$report" ]]; then
+        printf 'unavailable'
+        return
+    fi
+    python3 - "$report" "$metric" <<'PY'
+import re
+import sys
+
+path, metric = sys.argv[1], sys.argv[2]
+metric_index = {
+    "WNS(ns)": 0,
+    "TNS(ns)": 1,
+    "WHS(ns)": 4,
+    "THS(ns)": 5,
+}.get(metric)
+lines = open(path, "r", encoding="utf-8", errors="replace").read().splitlines()
+for idx, line in enumerate(lines):
+    if metric_index is None or metric not in line:
+        continue
+    if not all(name in line for name in ("WNS(ns)", "TNS(ns)", "WHS(ns)", "THS(ns)")):
+        continue
+    for candidate in lines[idx + 1 : idx + 8]:
+        values = re.findall(r"[-+]?(?:\d+\.\d+|\d+)", candidate)
+        if len(values) > metric_index:
+            print(values[metric_index])
+            raise SystemExit(0)
+print("unavailable")
+PY
+}
+
 capture_report_tail() {
     local report="$1"
     local name="$2"
@@ -105,13 +139,20 @@ fi
 
 TIMING_REPORT="$REPORT_DIR/timing_summary_post_synth.rpt"
 UTIL_REPORT="$REPORT_DIR/utilization_post_synth.rpt"
+IMPL_TIMING_REPORT="$REPORT_DIR/timing_summary_post_impl.rpt"
+IMPL_UTIL_REPORT="$REPORT_DIR/utilization_post_impl.rpt"
 TIMING_STATUS="$(status_from_report "$TIMING_REPORT")"
+IMPL_TIMING_STATUS="$(status_from_report "$IMPL_TIMING_REPORT")"
 if [[ "$SYNTH_STATUS" == "failed" && ! -f "$TIMING_REPORT" ]]; then
     TIMING_STATUS="TIMING_ATTEMPTED_NO_REPORT"
 fi
 
 capture_report_tail "$TIMING_REPORT" timing_summary_post_synth
 capture_report_tail "$UTIL_REPORT" utilization_post_synth
+capture_report_tail "$IMPL_TIMING_REPORT" timing_summary_post_impl
+capture_report_tail "$IMPL_UTIL_REPORT" utilization_post_impl
+
+VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
 
 {
     printf 'run_id=%s\n' "$RUN_ID"
@@ -119,11 +160,25 @@ capture_report_tail "$UTIL_REPORT" utilization_post_synth
     printf 'git_commit=%s\n' "$COMMIT_FULL"
     printf 'dry_run=%s\n' "$DRY_RUN"
     printf 'run_synth=%s\n' "$RUN_SYNTH"
+    printf 'command_line=%q ' "$0" "${ORIGINAL_ARGS[@]}"
+    printf '\n'
     printf 'synth_status=%s\n' "$SYNTH_STATUS"
     printf 'timing_status=%s\n' "$TIMING_STATUS"
     printf 'timing_report=%s\n' "$TIMING_REPORT"
+    printf 'timing_wns_ns=%s\n' "$(metric_from_report "$TIMING_REPORT" 'WNS(ns)')"
+    printf 'timing_tns_ns=%s\n' "$(metric_from_report "$TIMING_REPORT" 'TNS(ns)')"
+    printf 'timing_whs_ns=%s\n' "$(metric_from_report "$TIMING_REPORT" 'WHS(ns)')"
+    printf 'timing_ths_ns=%s\n' "$(metric_from_report "$TIMING_REPORT" 'THS(ns)')"
+    printf 'impl_timing_status=%s\n' "$IMPL_TIMING_STATUS"
+    printf 'impl_timing_report=%s\n' "$IMPL_TIMING_REPORT"
+    printf 'impl_timing_wns_ns=%s\n' "$(metric_from_report "$IMPL_TIMING_REPORT" 'WNS(ns)')"
+    printf 'impl_timing_tns_ns=%s\n' "$(metric_from_report "$IMPL_TIMING_REPORT" 'TNS(ns)')"
+    printf 'impl_timing_whs_ns=%s\n' "$(metric_from_report "$IMPL_TIMING_REPORT" 'WHS(ns)')"
+    printf 'impl_timing_ths_ns=%s\n' "$(metric_from_report "$IMPL_TIMING_REPORT" 'THS(ns)')"
     printf 'utilization_report=%s\n' "$UTIL_REPORT"
+    printf 'impl_utilization_report=%s\n' "$IMPL_UTIL_REPORT"
     printf 'vivado=%s\n' "$(command -v vivado 2>/dev/null || printf MISSING)"
+    printf 'vivado_version=%s\n' "$VIVADO_VERSION"
     printf 'xvlog=%s\n' "$(command -v xvlog 2>/dev/null || printf MISSING)"
     printf 'part=xck26-sfvc784-2LV-c\n'
     printf 'constraints=%s\n' "$HW_DIR/constraints/pccx_timing.xdc"

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # Collect bounded v002 timing evidence without claiming closure.
 
 set -Eeuo pipefail

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -67,6 +67,11 @@ STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 COMMIT_SHORT="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || printf 'nogit')"
 COMMIT_FULL="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf 'unknown')"
 BRANCH="$(git -C "$ROOT_DIR" branch --show-current 2>/dev/null || printf 'unknown')"
+GIT_STATUS_SHORT="$(git -C "$ROOT_DIR" status --short 2>/dev/null || true)"
+WORKTREE_DIRTY=0
+if [[ -n "$GIT_STATUS_SHORT" ]]; then
+    WORKTREE_DIRTY=1
+fi
 if [[ -z "$RUN_ID" ]]; then
     RUN_ID="$STAMP-$COMMIT_SHORT"
 fi
@@ -213,6 +218,7 @@ FULL_TOP_LEVEL_FLOW="$(field_from_status_file "$TOP_LEVEL_STATUS_FILE" 'full_top
     printf 'run_id=%s\n' "$RUN_ID"
     printf 'branch=%s\n' "$BRANCH"
     printf 'git_commit=%s\n' "$COMMIT_FULL"
+    printf 'worktree_dirty=%s\n' "$WORKTREE_DIRTY"
     printf 'dry_run=%s\n' "$DRY_RUN"
     printf 'run_synth=%s\n' "$RUN_SYNTH"
     printf 'require_impl_clean=%s\n' "$REQUIRE_IMPL_CLEAN"

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -12,18 +12,20 @@ REPORT_DIR="$HW_DIR/build/reports"
 
 DRY_RUN=0
 RUN_SYNTH=0
+REQUIRE_IMPL_CLEAN=0
 RUN_ID="${PCCX_RUN_ID:-}"
 ORIGINAL_ARGS=("$@")
 
 usage() {
     cat <<'USAGE'
-usage: scripts/v002/run-timing-evidence.sh [--dry-run] [--run-synth] [--run-id <id>]
+usage: scripts/v002/run-timing-evidence.sh [--dry-run] [--run-synth] [--require-impl-clean] [--run-id <id>]
 
 Options:
-  --dry-run       collect environment/report status only
-  --run-synth     run hw/vivado/build.sh synth before collecting status
-  --run-id <id>   use a deterministic evidence directory suffix
-  -h, --help      print this help
+  --dry-run             collect environment/report status only
+  --run-synth           run hw/vivado/build.sh synth before collecting status
+  --require-impl-clean  exit nonzero unless post-impl timing is present and clean
+  --run-id <id>         use a deterministic evidence directory suffix
+  -h, --help            print this help
 USAGE
 }
 
@@ -35,6 +37,10 @@ while (($#)); do
             ;;
         --run-synth)
             RUN_SYNTH=1
+            shift
+            ;;
+        --require-impl-clean)
+            REQUIRE_IMPL_CLEAN=1
             shift
             ;;
         --run-id)
@@ -148,6 +154,19 @@ IMPL_TIMING_STATUS="$(status_from_report "$IMPL_TIMING_REPORT")"
 if [[ "$SYNTH_STATUS" == "failed" && ! -f "$TIMING_REPORT" ]]; then
     TIMING_STATUS="TIMING_ATTEMPTED_NO_REPORT"
 fi
+if [[ -f "$IMPL_TIMING_REPORT" ]]; then
+    if [[ "$IMPL_TIMING_STATUS" == "TIMING_REPORT_PRESENT_CLOSED" ]]; then
+        OVERALL_TIMING_STATUS="POST_IMPL_TIMING_CLOSED"
+    else
+        OVERALL_TIMING_STATUS="POST_IMPL_TIMING_NOT_CLOSED"
+    fi
+elif [[ "$TIMING_STATUS" == "TIMING_REPORT_PRESENT_CLOSED" ]]; then
+    OVERALL_TIMING_STATUS="POST_SYNTH_TIMING_CLOSED_IMPL_NOT_RUN"
+elif [[ "$TIMING_STATUS" == "TIMING_NOT_RUN" ]]; then
+    OVERALL_TIMING_STATUS="TIMING_NOT_RUN"
+else
+    OVERALL_TIMING_STATUS="POST_SYNTH_TIMING_NOT_CLOSED"
+fi
 
 capture_report_tail "$TIMING_REPORT" timing_summary_post_synth
 capture_report_tail "$UTIL_REPORT" utilization_post_synth
@@ -162,9 +181,11 @@ VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
     printf 'git_commit=%s\n' "$COMMIT_FULL"
     printf 'dry_run=%s\n' "$DRY_RUN"
     printf 'run_synth=%s\n' "$RUN_SYNTH"
+    printf 'require_impl_clean=%s\n' "$REQUIRE_IMPL_CLEAN"
     printf 'command_line=%q ' "$0" "${ORIGINAL_ARGS[@]}"
     printf '\n'
     printf 'synth_status=%s\n' "$SYNTH_STATUS"
+    printf 'overall_timing_status=%s\n' "$OVERALL_TIMING_STATUS"
     printf 'timing_status=%s\n' "$TIMING_STATUS"
     printf 'timing_report=%s\n' "$TIMING_REPORT"
     printf 'timing_wns_ns=%s\n' "$(metric_from_report "$TIMING_REPORT" 'WNS(ns)')"
@@ -188,13 +209,26 @@ VIVADO_VERSION="$(vivado -version 2>/dev/null | head -n 1 || printf MISSING)"
 } >"$SUMMARY"
 
 printf 'summary=%s\n' "$SUMMARY"
+printf 'overall_timing_status=%s\n' "$OVERALL_TIMING_STATUS"
 printf 'timing_status=%s\n' "$TIMING_STATUS"
+printf 'impl_timing_status=%s\n' "$IMPL_TIMING_STATUS"
 
-case "$TIMING_STATUS" in
-    TIMING_REPORT_PRESENT_CLOSED)
-        exit 0
-        ;;
-    *)
-        exit 2
-        ;;
-esac
+if (( REQUIRE_IMPL_CLEAN )); then
+    case "$IMPL_TIMING_STATUS" in
+        TIMING_REPORT_PRESENT_CLOSED)
+            exit 0
+            ;;
+        *)
+            exit 2
+            ;;
+    esac
+else
+    case "$TIMING_STATUS" in
+        TIMING_REPORT_PRESENT_CLOSED)
+            exit 0
+            ;;
+        *)
+            exit 2
+            ;;
+    esac
+fi

--- a/scripts/v002/run-top-level-evidence.sh
+++ b/scripts/v002/run-top-level-evidence.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Collect bounded full top-level / BD bitstream-flow readiness evidence.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HW_DIR="$ROOT_DIR/hw"
+REPORT_DIR="$HW_DIR/build/reports"
+
+RUN_ID="${PCCX_RUN_ID:-}"
+DRY_RUN=0
+MODE="status"
+ORIGINAL_ARGS=("$@")
+
+usage() {
+    cat <<'USAGE'
+usage: scripts/v002/run-top-level-evidence.sh [--dry-run] [--run-id <id>] [--mode status|bitstream]
+
+Collects explicit evidence for the full KV260 top-level / block-design flow.
+The status mode is lightweight and does not run implementation or write a
+bitstream. The bitstream mode is a gate: it fails fast until the full top-level
+BD flow exists.
+USAGE
+}
+
+while (($#)); do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --run-id)
+            if (($# < 2)); then
+                echo "error: --run-id requires a value" >&2
+                exit 2
+            fi
+            RUN_ID="$2"
+            shift 2
+            ;;
+        --mode)
+            if (($# < 2)); then
+                echo "error: --mode requires status or bitstream" >&2
+                exit 2
+            fi
+            MODE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$MODE" in
+    status|bitstream) ;;
+    *)
+        echo "error: --mode must be status or bitstream" >&2
+        exit 2
+        ;;
+esac
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+COMMIT_SHORT="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || printf 'nogit')"
+COMMIT_FULL="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+BRANCH="$(git -C "$ROOT_DIR" branch --show-current 2>/dev/null || printf 'unknown')"
+if [[ -z "$RUN_ID" ]]; then
+    RUN_ID="$STAMP-$COMMIT_SHORT"
+fi
+RUN_ID="${RUN_ID//\//_}"
+EVIDENCE_DIR="$HW_DIR/build/v002-top-level-evidence/$RUN_ID"
+SUMMARY="$EVIDENCE_DIR/summary.txt"
+mkdir -p "$EVIDENCE_DIR"
+
+STATUS_FILE="$REPORT_DIR/top_level_bitstream_status.txt"
+LOG_FILE="$EVIDENCE_DIR/top_level_status.log"
+TOP_STATUS="not_run"
+
+if (( DRY_RUN )); then
+    TOP_STATUS="dry_run_not_executed"
+elif bash "$HW_DIR/vivado/build.sh" top-status >"$LOG_FILE" 2>&1; then
+    TOP_STATUS="pass"
+else
+    TOP_STATUS="failed"
+fi
+
+field_from_status_file() {
+    local report="$1"
+    local field="$2"
+    if [[ ! -f "$report" ]]; then
+        printf 'unavailable'
+        return
+    fi
+    awk -F= -v key="$field" '$1 == key {print substr($0, length(key) + 2); found=1; exit} END {if (!found) print "unavailable"}' "$report"
+}
+
+if [[ -f "$STATUS_FILE" ]]; then
+    cp "$STATUS_FILE" "$EVIDENCE_DIR/top_level_bitstream_status.txt"
+fi
+
+{
+    printf 'run_id=%s\n' "$RUN_ID"
+    printf 'branch=%s\n' "$BRANCH"
+    printf 'git_commit=%s\n' "$COMMIT_FULL"
+    printf 'dry_run=%s\n' "$DRY_RUN"
+    printf 'mode=%s\n' "$MODE"
+    printf 'command_line=%q ' "$0" "${ORIGINAL_ARGS[@]}"
+    printf '\n'
+    printf 'top_level_status_command=%s\n' "$TOP_STATUS"
+    printf 'full_top_level_flow=%s\n' "$(field_from_status_file "$STATUS_FILE" 'full_top_level_flow')"
+    printf 'bitstream_status=%s\n' "$(field_from_status_file "$STATUS_FILE" 'bitstream_status')"
+    printf 'board_part_status=%s\n' "$(field_from_status_file "$STATUS_FILE" 'board_part_status')"
+    printf 'wrapper_status=%s\n' "$(field_from_status_file "$STATUS_FILE" 'wrapper_status')"
+    printf 'bd_status=%s\n' "$(field_from_status_file "$STATUS_FILE" 'bd_status')"
+    printf 'bd_script=%s\n' "$(field_from_status_file "$STATUS_FILE" 'bd_script')"
+    printf 'blocker=%s\n' "$(field_from_status_file "$STATUS_FILE" 'blocker')"
+    printf 'status_file=%s\n' "$STATUS_FILE"
+    printf 'log_file=%s\n' "$LOG_FILE"
+    printf 'KV260_board_status=NOT_RUN\n'
+    printf 'Gemma_3N_E4B_runtime_status=NO_HARDWARE_EVIDENCE\n'
+    printf 'measured_throughput_status=MEASUREMENT_NOT_AVAILABLE\n'
+} >"$SUMMARY"
+
+printf 'summary=%s\n' "$SUMMARY"
+printf 'full_top_level_flow=%s\n' "$(field_from_status_file "$STATUS_FILE" 'full_top_level_flow')"
+printf 'bitstream_status=%s\n' "$(field_from_status_file "$STATUS_FILE" 'bitstream_status')"
+
+if [[ "$MODE" == "bitstream" ]]; then
+    exit 3
+fi


### PR DESCRIPTION
## Classification

IMPL_TIMING_NOT_CLEAN

## Current evidence head

- Branch: `closure/v002-synth-impl-bitstream-candidate`
- Commit: `c36b7a865f788fa33d295cf60c11b723d4fec7e7`
- Base: `closure/v002-driver-handoff-candidate`

## Architecture state

The previous `u_mem_dispatcher` DSP-to-DSP shape/word-count top timing blocker has been reduced and reclassified. The current OOC post-impl top timing blocker is the CVO SFU reciprocal correction/product carry path:

- Startpoint: `u_CVO_top/u_CVO_sfu_unit/recip_s3_corr_reg[2]`
- Endpoint: `u_CVO_top/u_CVO_sfu_unit/recip_s4_mp_reg[15]`

Implementation routes but does not close timing. This PR does not claim timing closure, a generated bitstream, KV260 board execution, Gemma 3N E4B runtime, or measured throughput.

## Validation

- `git diff --check`: PASS
- `bash hw/sim/run_verification.sh --tb tb_mem_dispatcher_shape_lookup`: PASS, 1 passed / 0 failed
- `bash hw/sim/run_verification.sh`: PASS, 12 passed / 0 failed
- `bash scripts/v002/claim-scan.sh`: PASS, `UNSUPPORTED_CLAIM_FOUND=no`
- `bash scripts/v002/artifact-safety-check.sh`: PASS, `ARTIFACT_SAFETY=PASS`
- `PCCX_VIVADO_JOBS=1 ./hw/vivado/build.sh synth`: PASS, 0 errors / 0 critical warnings
- `PCCX_VIVADO_JOBS=1 ./hw/vivado/build.sh impl`: ROUTE_COMPLETED_FAILED_TIMING

## Timing evidence

- Post-synth OOC timing: WNS `0.052 ns`, TNS `0.000 ns`, WHS `0.085 ns`, THS `0.000 ns`
- Post-impl OOC timing: WNS `-0.046 ns`, TNS `-0.374 ns`, WHS `0.055 ns`, THS `0.000 ns`
- Old top path: `u_mem_dispatcher/load_s2_shape_xy_reg -> u_mem_dispatcher/load_s2_words_plus7` DSP-to-DSP word-count path, resolved as the top violation
- Current top path class: CVO SFU reciprocal correction/product carry path

## Full top-level / bitstream status

- Implementation scope: `OOC_ROUTE_ONLY`
- Full top-level / BD flow: `BITSTREAM_NOT_RUN_TOP_FLOW_INCOMPLETE`
- `hw/vivado/system_bd.tcl` or `PCCX_TOP_BD_TCL` remains required before a KV260 bitstream claim
- Bitstream: `BITSTREAM_NOT_GENERATED` / `BITSTREAM_NOT_REQUESTED` in OOC route mode
- KV260 board: `KV260_BOARD_NOT_RUN`
- Gemma 3N E4B hardware runtime: `NO_HARDWARE_RUNTIME_EVIDENCE`
- Measured throughput: `MEASUREMENT_NOT_AVAILABLE`

## Evidence paths

- `hw/build/v002-timing-evidence/final-default-restored-post-impl/summary.txt`
- `hw/build/reports/timing_summary_post_synth.rpt`
- `hw/build/reports/timing_summary_post_impl.rpt`
- `hw/build/reports/bitstream_status.txt`
- `hw/build/reports/top_level_bitstream_status.txt`

## Remaining blockers

- OOC post-impl setup timing is still negative by 46 ps
- Current top timing blocker is in the CVO SFU reciprocal correction/product path
- Full top-level / BD script is missing or not selected
- Full top-level implementation has not run
- Full top-level bitstream has not been generated
- KV260 board execution evidence is unavailable
- Gemma 3N E4B hardware runtime evidence is unavailable
- Measured throughput evidence is unavailable

## Next engineering action

Analyze the CVO SFU reciprocal correction/product latency contract and apply a focused timing cut only if it preserves external behavior or is covered by an explicit contract/test update.

## Review state

- Ready for review: yes, as evidence-gated timing/blocker state
- Ready for merge: no
- Ready for release: no