### PR TITLE
build(vivado): add KV260 bitstream runbook and BD scaffold

### DIFF
--- a/docs/runbooks/v002.1-bitstream-build.md
+++ b/docs/runbooks/v002.1-bitstream-build.md
@@ -1,0 +1,206 @@
+# v002.1 KV260 Bitstream Build Runbook
+
+This runbook is preparation for a user-terminal Vivado run. It is not a
+success claim, timing-closure claim, or board-deploy claim.
+This is preparation, not a success claim.
+
+Throughput wording for this lane is `20 tok/s target`; do not record it
+as measured hardware throughput until board evidence exists.
+
+## Scope
+
+- Full top-level KV260 flow using `hw/vivado/system_bd.tcl`.
+- Not the existing OOC flow in `hw/vivado/synth.tcl`.
+- Public RTL top: `NPU_top`.
+- BD module reference: `npu_core_wrapper`, which instantiates `NPU_top`.
+- BD script path: `hw/vivado/system_bd.tcl`.
+- Target part in the BD scaffold: `xczu5ev-sfvc784-1-i`.
+- Board file, when installed: `xilinx.com:kv260_som:part0:1.4`.
+- Placeholder clocks: `clk_axi` at 200 MHz, `clk_npu` at 250 MHz.
+
+`PCCX_TOP_BD_TCL` remains the explicit handoff variable for this run.
+
+## Top RTL Interface
+
+The BD cell is `npu_core_wrapper`. That wrapper is the Vivado-friendly
+plain-signal shell around `NPU_top`; it has no state of its own.
+
+`NPU_top` expects these public ports:
+
+- `clk_core`, `rst_n_core`: core clock/reset.
+- `clk_axi`, `rst_axi_n`: AXI and stream ingress clock/reset.
+- `i_clear`: synchronous active-high soft clear, tied low in the BD.
+- `S_AXIL_CTRL`: 64-bit AXI4-Lite slave. Writes reach `AXIL_CMD_IN`
+  (`0x000` instruction, `0x008` kick). Reads reach `AXIL_STAT_OUT`.
+- `S_AXI_HP0_WEIGHT`, `S_AXI_HP1_WEIGHT`: 128-bit AXIS weight streams
+  for the matrix core.
+- `S_AXI_HP2_WEIGHT`, `S_AXI_HP3_WEIGHT`: 128-bit AXIS weight streams
+  for the vector core.
+- `S_AXIS_ACP_FMAP`: 128-bit AXIS feature-map ingress.
+- `M_AXIS_ACP_RESULT`: 128-bit AXIS result egress.
+
+The scaffold connects PS HPM AXI-Lite to `S_AXIL_CTRL`, PS HP0/HP1
+memory ports to the four weight-stream DMAs, and a coherent ACP/HPC path
+to the feature-map/result DMA.
+
+## Prerequisites
+
+- Vivado/Vitis with Zynq UltraScale+ support. Record the exact version
+  from `vivado -version`; Vivado 2025.2 is the local evidence version.
+- KV260 board files installed for `xilinx.com:kv260_som:part0:1.4`.
+- `bootgen` available if the SD image expects a `.bit.bin` file.
+- A KV260 SD card or mounted target rootfs with write access.
+- Optional: set `PCCX_VIVADO_JOBS=1` on memory-constrained hosts.
+
+## User-Terminal Commands
+
+Run these in a separate terminal from the repo root. These commands start
+the full top-level flow; they are expected to take a long time.
+
+```bash
+export PCCX_REPO="${PCCX_REPO:-$(git rev-parse --show-toplevel)}"
+cd "$PCCX_REPO/hw"
+export PCCX_TOP_BD_TCL="$PWD/vivado/system_bd.tcl"
+export PCCX_VIVADO_JOBS="${PCCX_VIVADO_JOBS:-4}"
+
+./vivado/build.sh clean
+mkdir -p build/logs
+
+vivado -mode batch \
+  -log build/logs/v002_1_bd_prepare.log \
+  -journal build/logs/v002_1_bd_prepare.jou \
+  -source "$PCCX_TOP_BD_TCL" \
+  -tclargs prepare
+
+vivado -mode batch \
+  -log build/logs/v002_1_full_top_synth.log \
+  -journal build/logs/v002_1_full_top_synth.jou \
+  -source "$PCCX_TOP_BD_TCL" \
+  -tclargs synth
+
+vivado -mode batch \
+  -log build/logs/v002_1_full_top_impl.log \
+  -journal build/logs/v002_1_full_top_impl.jou \
+  -source "$PCCX_TOP_BD_TCL" \
+  -tclargs impl
+
+vivado -mode batch \
+  -log build/logs/v002_1_full_top_bitstream.log \
+  -journal build/logs/v002_1_full_top_bitstream.jou \
+  -source "$PCCX_TOP_BD_TCL" \
+  -tclargs bitstream
+```
+
+The `synth`, `impl`, and `bitstream` actions above are for the full
+top-level BD wrapper, not OOC `NPU_top` synthesis.
+
+## Timing Reality
+
+Per PR #79 evidence, post-impl OOC WNS is -0.046 ns at the CVO SFU reciprocal correction path. The full top-level run may differ. If post-impl WNS remains negative, do not deploy the bitstream as evidence of timing closure — capture the timing report and revisit the CVO SFU latency contract first.
+
+## Pre-Deploy Sanity Gate
+
+Treat deploy as blocked unless every check below is `PASS`.
+
+| Check | PASS condition | Evidence |
+| --- | --- | --- |
+| Timing | Post-impl timing summary reports constraints met and WNS is non-negative | `hw/build/reports/timing_summary_full_top_post_impl.rpt` |
+| DRC | No errors or critical warnings | `hw/build/reports/drc_full_top_post_impl.rpt` |
+| Route | Design is fully routed | `hw/build/reports/route_status_full_top_post_impl.rpt` |
+| IO planning | No unexpected external PL IO or unconstrained package pins | Vivado DRC / IO report from the full-top run |
+| Address map | NPU AXI-Lite segment and DMA control segments are present | `hw/build/reports/address_map.rpt` |
+| Bitstream | Bitstream exists and SHA256 is recorded | `hw/build/pccx_v002_kv260.bit` |
+
+## SD Packaging
+
+If the bitstream gate passes, convert and stage the image. If no overlay
+exists yet, copy only the bitstream artifact and record that `.dtbo` is
+absent.
+
+```bash
+export PCCX_REPO="${PCCX_REPO:-$(git rev-parse --show-toplevel)}"
+cd "$PCCX_REPO/hw"
+
+cat > build/pccx_v002_kv260.bif <<'BIF'
+all:
+{
+  [destination_device = pl] pccx_v002_kv260.bit
+}
+BIF
+
+(
+  cd build
+  bootgen -arch zynqmp -image pccx_v002_kv260.bif -process_bitstream bin -w
+)
+
+sha256sum build/pccx_v002_kv260.bit build/pccx_v002_kv260.bit.bin \
+  | tee build/reports/bitstream_sha256.txt
+
+export SD_MNT=/media/$USER/KV260_ROOTFS
+export FW_DIR="$SD_MNT/lib/firmware/xilinx/pccx_npu"
+sudo mkdir -p "$FW_DIR"
+sudo cp build/pccx_v002_kv260.bit.bin "$FW_DIR/"
+
+if compgen -G "../sw/dtbo/*.dtbo" > /dev/null; then
+  sudo cp ../sw/dtbo/*.dtbo "$FW_DIR/"
+fi
+if [ -f ../sw/dtbo/shell.json ]; then
+  sudo cp ../sw/dtbo/shell.json "$FW_DIR/"
+fi
+
+sync
+sudo umount "$SD_MNT"
+```
+
+Reboot the KV260 with the staged SD card. If the SD mount label differs,
+set `SD_MNT` to the actual mount path.
+
+## Board Smoke
+
+Run these on the KV260 after boot. Replace `NPU_BASE` with the NPU
+AXI-Lite base from `hw/build/reports/address_map.rpt`.
+
+```bash
+xmutil listapps
+sudo xmutil unloadapp || true
+sudo xmutil loadapp pccx_npu
+dmesg | tail -80
+
+export NPU_BASE=0xA0000000
+sudo timeout 2 devmem "$NPU_BASE" 64
+sudo timeout 2 devmem "$((NPU_BASE + 0x8))" 64 0x8000000000000000
+dmesg | tail -80
+```
+
+If the board image uses XRT, also capture:
+
+```bash
+xbutil examine
+xrt-smi examine
+```
+
+An AXI read timeout, `SError`, decode fault, or kernel AXI timeout is a
+blocked board-smoke result. Capture the log and stop before runtime work.
+
+## Failure Paths
+
+| Stage | Stop condition | Capture |
+| --- | --- | --- |
+| Prepare | BD validation fails, PS interface names differ, or board file missing | `hw/build/logs/v002_1_bd_prepare.log`, `hw/build/reports/address_map.rpt` if present |
+| Synth | `synth_design` fails or produces DRC errors | `hw/build/logs/v002_1_full_top_synth.log`, `hw/build/reports/drc_full_top_post_synth.rpt` |
+| Impl | Place/route fails or route status is incomplete | `hw/build/logs/v002_1_full_top_impl.log`, `hw/build/reports/route_status_full_top_post_impl.rpt` |
+| Timing | WNS remains negative | `hw/build/reports/timing_summary_full_top_post_impl.rpt` |
+| Bitstream | `.bit` is missing or `write_bitstream` fails | `hw/build/logs/v002_1_full_top_bitstream.log` |
+| SD | `.bit.bin`, `.dtbo`, or `shell.json` is missing when required by the image | `hw/build/reports/bitstream_sha256.txt` and the copy log |
+| Board | `xmutil loadapp`, `devmem`, or XRT checks fail | board `dmesg`, command stdout/stderr, SD image notes |
+
+Recommended board evidence directory:
+
+```bash
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-v002-1-kv260-bitstream"
+mkdir -p "docs/evidence/kv260-bitstream/$RUN_ID"
+```
+
+Store sanitized host logs, board command output, `dmesg` tail, bitstream
+SHA256, Vivado version, and the commit SHA in that directory. Do not
+commit `.bit`, `.bit.bin`, Vivado build directories, or raw board dumps.

--- a/docs/runbooks/v002.1-bitstream-build.md
+++ b/docs/runbooks/v002.1-bitstream-build.md
@@ -43,6 +43,32 @@ The scaffold connects PS HPM AXI-Lite to `S_AXIL_CTRL`, PS HP0/HP1
 memory ports to the four weight-stream DMAs, and a coherent ACP/HPC path
 to the feature-map/result DMA.
 
+## BD AXI Port Allocation
+
+This table records the wiring created by `hw/vivado/system_bd.tcl` in
+PR #82. Treat it as the BD scaffold contract for the user-terminal Vivado
+run; the generated address report remains the source for final segment
+offsets after `assign_bd_address`.
+
+| Function | BD path | PS-side port | NPU-side port | Width / protocol | Notes |
+| --- | --- | --- | --- | --- | --- |
+| NPU control/status MMIO | `ps_0` HPM0 -> `axi_ctrl_interconnect/M00_AXI` | `M_AXI_HPM0_FPD` fallback list | `S_AXIL_CTRL` | 64-bit AXI4-Lite at the NPU wrapper | Intended NPU base `0xA0000000`; BD requests a 64 KB segment while the RTL decode uses 12-bit addresses. |
+| HP0 weight DMA control | `axi_ctrl_interconnect/M01_AXI` | HPM0 via control interconnect | `dma_hp0_weight_mm2s/S_AXI_LITE` | AXI4-Lite | DMA control address is assigned by Vivado and must be read from `address_map.rpt`. |
+| HP1 weight DMA control | `axi_ctrl_interconnect/M02_AXI` | HPM0 via control interconnect | `dma_hp1_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP2 weight DMA control | `axi_ctrl_interconnect/M03_AXI` | HPM0 via control interconnect | `dma_hp2_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP3 weight DMA control | `axi_ctrl_interconnect/M04_AXI` | HPM0 via control interconnect | `dma_hp3_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| ACP fmap/result DMA control | `axi_ctrl_interconnect/M05_AXI` | HPM0 via control interconnect | `dma_acp_fmap_result/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP0 weight memory read | `dma_hp0_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S00_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP0_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP0 stream; physical DDR reads share PS HP0/HP1. |
+| HP1 weight memory read | `dma_hp1_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S01_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP1_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP1 stream; physical DDR reads share PS HP0/HP1. |
+| HP2 weight memory read | `dma_hp2_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S02_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP2_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP2 stream; physical DDR reads share PS HP0/HP1. |
+| HP3 weight memory read | `dma_hp3_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S03_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP3_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP3 stream; physical DDR reads share PS HP0/HP1. |
+| ACP feature-map ingress | `dma_acp_fmap_result/M_AXI_MM2S` -> `axi_acp_interconnect/S00_AXI` plus `M_AXIS_MM2S` | `S_AXI_ACP_FPD`, fallback `S_AXI_HPC0_FPD` / `S_AXI_HPC1_FPD` | `S_AXIS_ACP_FMAP` | 128-bit AXI4-Stream into NPU | DDR-to-NPU direction for feature maps and L2 ingress traffic. |
+| ACP result egress | `dma_acp_fmap_result/M_AXI_S2MM` -> `axi_acp_interconnect/S01_AXI` plus `S_AXIS_S2MM` | `S_AXI_ACP_FPD`, fallback `S_AXI_HPC0_FPD` / `S_AXI_HPC1_FPD` | `M_AXIS_ACP_RESULT` | 128-bit AXI4-Stream out of NPU | NPU-to-DDR direction for result traffic. |
+
+The `system_bd.tcl` fallback interface-name lists are intentional because
+Vivado exposes different Zynq UltraScale+ PS pin names across board-file
+and IP versions. Do not treat a fallback name as a separate allocation.
+
 ## Prerequisites
 
 - Vivado/Vitis with Zynq UltraScale+ support. Record the exact version

--- a/hw/vivado/system_bd.tcl
+++ b/hw/vivado/system_bd.tcl
@@ -1,0 +1,452 @@
+# =============================================================================
+# system_bd.tcl -- KV260 full-top block-design scaffold for pccx v002.1.
+#
+# This is a pre-flight build scaffold, not a timing or board-readiness claim.
+# It creates a Zynq UltraScale+ MPSoC BD around the existing plain-signal
+# npu_core_wrapper module, which instantiates the public RTL top NPU_top.
+#
+# Usage from hw/:
+#   vivado -mode batch -source vivado/system_bd.tcl -tclargs prepare
+#   vivado -mode batch -source vivado/system_bd.tcl -tclargs synth
+#   vivado -mode batch -source vivado/system_bd.tcl -tclargs impl
+#   vivado -mode batch -source vivado/system_bd.tcl -tclargs bitstream
+# =============================================================================
+
+set SCRIPT_DIR [file dirname [file normalize [info script]]]
+set HW_ROOT    [file normalize [file join $SCRIPT_DIR ..]]
+set BUILD_DIR  [file normalize [file join $HW_ROOT build]]
+set PROJ_DIR   [file normalize [file join $BUILD_DIR pccx_v002_kv260_bd]]
+set PROJ_NAME  pccx_v002_kv260_bd
+set BD_NAME    system
+set REPORTS    [file normalize [file join $BUILD_DIR reports]]
+set DCP_DIR    [file normalize [file join $BUILD_DIR checkpoints]]
+
+set TARGET_PART  xczu5ev-sfvc784-1-i
+set TARGET_BOARD xilinx.com:kv260_som:part0:1.4
+
+set TOP_RTL_MODULE     NPU_top
+set NPU_BD_MODULE_REF  npu_core_wrapper
+
+set CLK_AXI_MHZ 200.0
+set CLK_NPU_MHZ 250.0
+set AXIL_BASE   0xA0000000
+
+set ACTION prepare
+if {[llength $argv] > 0} {
+    set ACTION [lindex $argv 0]
+}
+if {$ACTION ni {clean prepare synth impl bitstream}} {
+    puts "error: unsupported action '$ACTION'"
+    puts "usage: system_bd.tcl {clean|prepare|synth|impl|bitstream}"
+    exit 2
+}
+
+proc pccx_msg {msg} {
+    puts "\[pccx\] $msg"
+}
+
+set VIVADO_JOBS 4
+if {[info exists ::env(PCCX_VIVADO_JOBS)] && $::env(PCCX_VIVADO_JOBS) ne ""} {
+    set VIVADO_JOBS $::env(PCCX_VIVADO_JOBS)
+}
+if {![string is integer -strict $VIVADO_JOBS] || $VIVADO_JOBS < 1} {
+    puts "error: PCCX_VIVADO_JOBS must be a positive integer"
+    exit 2
+}
+if {[catch {set_param general.maxThreads $VIVADO_JOBS} msg]} {
+    pccx_msg "warning: could not set general.maxThreads=$VIVADO_JOBS: $msg"
+}
+pccx_msg "Vivado jobs/threads = $VIVADO_JOBS"
+
+proc pccx_filelist {} {
+    global HW_ROOT
+    set filelist_path [file join $HW_ROOT vivado filelist.f]
+    set fp [open $filelist_path r]
+    set sv_files {}
+    while {[gets $fp line] >= 0} {
+        set line [string trim $line]
+        if {$line eq "" || [string index $line 0] eq "#"} {
+            continue
+        }
+        lappend sv_files [file normalize [file join $HW_ROOT $line]]
+    }
+    close $fp
+    return $sv_files
+}
+
+proc pccx_include_dirs {} {
+    global HW_ROOT
+    return [list \
+        [file join $HW_ROOT rtl] \
+        [file join $HW_ROOT rtl Constants compilePriority_Order A_const_svh] \
+        [file join $HW_ROOT rtl MAT_CORE] \
+        [file join $HW_ROOT rtl MEM_control IO] \
+        [file join $HW_ROOT rtl NPU_Controller] \
+        [file join $HW_ROOT rtl NPU_Controller NPU_Control_Unit] \
+        [file join $HW_ROOT rtl NPU_Controller NPU_Control_Unit ISA_PACKAGE] \
+        [file join $HW_ROOT rtl VEC_CORE] \
+    ]
+}
+
+proc pccx_set_props {obj props} {
+    foreach {key value} $props {
+        if {[catch {set_property $key $value $obj} msg]} {
+            pccx_msg "warning: could not set $key on $obj: $msg"
+        }
+    }
+}
+
+proc pccx_bd_intf {cell candidates purpose} {
+    foreach name $candidates {
+        set pins [get_bd_intf_pins -quiet "$cell/$name"]
+        if {[llength $pins] > 0} {
+            return [lindex $pins 0]
+        }
+    }
+    set available [get_bd_intf_pins -quiet -of_objects [get_bd_cells $cell]]
+    error "missing $purpose interface on $cell. Tried: $candidates. Available: $available"
+}
+
+proc pccx_bd_pin {path purpose} {
+    set pins [get_bd_pins -quiet $path]
+    if {[llength $pins] == 0} {
+        error "missing $purpose pin: $path"
+    }
+    return [lindex $pins 0]
+}
+
+proc pccx_connect_pin_if_present {src dst} {
+    set sp [get_bd_pins -quiet $src]
+    set dp [get_bd_pins -quiet $dst]
+    if {[llength $sp] > 0 && [llength $dp] > 0} {
+        connect_bd_net [lindex $sp 0] [lindex $dp 0]
+    }
+}
+
+proc pccx_create_project_shell {} {
+    global PROJ_NAME PROJ_DIR TARGET_PART TARGET_BOARD
+
+    file mkdir [file dirname $PROJ_DIR]
+    create_project -force $PROJ_NAME $PROJ_DIR -part $TARGET_PART
+    set_property target_language Verilog [current_project]
+    set_property simulator_language Mixed [current_project]
+
+    if {[llength [get_board_parts -quiet $TARGET_BOARD]] > 0} {
+        set_property board_part $TARGET_BOARD [current_project]
+        pccx_msg "board_part = $TARGET_BOARD"
+    } else {
+        pccx_msg "board_part $TARGET_BOARD not installed; continuing with part $TARGET_PART"
+    }
+}
+
+proc pccx_add_sources {} {
+    global HW_ROOT
+
+    set sv_files [pccx_filelist]
+    add_files -fileset sources_1 $sv_files
+    set_property file_type SystemVerilog [get_files -of [get_filesets sources_1]]
+    set_property include_dirs [pccx_include_dirs] [get_filesets sources_1]
+    set_property include_dirs [pccx_include_dirs] [get_filesets sim_1]
+
+    set xdc_dir [file join $HW_ROOT constraints]
+    foreach xdc [glob -nocomplain -directory $xdc_dir *.xdc] {
+        add_files -fileset constrs_1 [file normalize $xdc]
+    }
+
+    update_compile_order -fileset sources_1
+}
+
+proc pccx_dma {name mode} {
+    set dma [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_dma:7.1 $name]
+    set props [list \
+        CONFIG.c_include_sg 0 \
+        CONFIG.c_addr_width 40 \
+        CONFIG.c_m_axis_mm2s_tdata_width 128 \
+        CONFIG.c_s_axis_s2mm_tdata_width 128 \
+    ]
+    if {$mode eq "mm2s"} {
+        lappend props CONFIG.c_include_mm2s 1 CONFIG.c_include_s2mm 0
+    } elseif {$mode eq "s2mm"} {
+        lappend props CONFIG.c_include_mm2s 0 CONFIG.c_include_s2mm 1
+    } elseif {$mode eq "both"} {
+        lappend props CONFIG.c_include_mm2s 1 CONFIG.c_include_s2mm 1
+    } else {
+        error "bad DMA mode $mode"
+    }
+    pccx_set_props $dma $props
+    return $dma
+}
+
+proc pccx_connect_dma_clocking {dma clk rstn} {
+    foreach pin {s_axi_lite_aclk m_axi_mm2s_aclk m_axis_mm2s_aclk m_axi_s2mm_aclk s_axis_s2mm_aclk} {
+        pccx_connect_pin_if_present $clk "$dma/$pin"
+    }
+    pccx_connect_pin_if_present $rstn "$dma/axi_resetn"
+}
+
+proc pccx_prepare_bd {} {
+    global BD_NAME TOP_RTL_MODULE NPU_BD_MODULE_REF CLK_AXI_MHZ CLK_NPU_MHZ AXIL_BASE REPORTS
+
+    set existing [get_bd_designs -quiet $BD_NAME]
+    if {[llength $existing] > 0} {
+        current_bd_design $BD_NAME
+        return
+    }
+
+    create_bd_design $BD_NAME
+    current_bd_design $BD_NAME
+
+    set axi_hz [expr {int($CLK_AXI_MHZ * 1000000.0)}]
+    set npu_hz [expr {int($CLK_NPU_MHZ * 1000000.0)}]
+
+    set ps [create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.5 ps_0]
+    if {[catch {
+        apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e \
+            -config {apply_board_preset "1"} $ps
+    } msg]} {
+        pccx_msg "warning: board automation skipped: $msg"
+    }
+    pccx_set_props $ps [list \
+        CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ $CLK_AXI_MHZ \
+        CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ $CLK_NPU_MHZ \
+        CONFIG.PSU__USE__M_AXI_GP0 1 \
+        CONFIG.PSU__USE__S_AXI_GP0 1 \
+        CONFIG.PSU__USE__S_AXI_GP1 1 \
+        CONFIG.PSU__USE__S_AXI_GP2 1 \
+        CONFIG.PSU__USE__S_AXI_ACP 1 \
+    ]
+
+    set npu [create_bd_cell -type module -reference $NPU_BD_MODULE_REF npu_0]
+
+    set rst_axi [create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_axi]
+    set rst_npu [create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_npu]
+    pccx_set_props $rst_axi [list CONFIG.C_EXT_RESET_HIGH 0]
+    pccx_set_props $rst_npu [list CONFIG.C_EXT_RESET_HIGH 0]
+
+    set clear_const [create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 soft_clear_zero]
+    pccx_set_props $clear_const [list CONFIG.CONST_WIDTH 1 CONFIG.CONST_VAL 0]
+
+    set ctrl_ic [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_ctrl_interconnect]
+    set hp_ic   [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_hp_interconnect]
+    set acp_ic  [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_acp_interconnect]
+    pccx_set_props $ctrl_ic [list CONFIG.NUM_SI 1 CONFIG.NUM_MI 6]
+    pccx_set_props $hp_ic   [list CONFIG.NUM_SI 4 CONFIG.NUM_MI 2]
+    pccx_set_props $acp_ic  [list CONFIG.NUM_SI 2 CONFIG.NUM_MI 1]
+
+    set dma_hp0 [pccx_dma dma_hp0_weight_mm2s mm2s]
+    set dma_hp1 [pccx_dma dma_hp1_weight_mm2s mm2s]
+    set dma_hp2 [pccx_dma dma_hp2_weight_mm2s mm2s]
+    set dma_hp3 [pccx_dma dma_hp3_weight_mm2s mm2s]
+    set dma_acp [pccx_dma dma_acp_fmap_result both]
+
+    connect_bd_net [pccx_bd_pin "$ps/pl_clk0" "PS PL0 clock"] \
+                   [pccx_bd_pin "$npu/clk_axi" "NPU AXI clock"]
+    connect_bd_net [pccx_bd_pin "$ps/pl_clk0" "PS PL0 clock"] \
+                   [pccx_bd_pin "$rst_axi/slowest_sync_clk" "AXI reset clock"]
+    connect_bd_net [pccx_bd_pin "$ps/pl_clk1" "PS PL1 clock"] \
+                   [pccx_bd_pin "$npu/clk_core" "NPU core clock"]
+    connect_bd_net [pccx_bd_pin "$ps/pl_clk1" "PS PL1 clock"] \
+                   [pccx_bd_pin "$rst_npu/slowest_sync_clk" "NPU reset clock"]
+    connect_bd_net [pccx_bd_pin "$ps/pl_resetn0" "PS PL reset"] \
+                   [pccx_bd_pin "$rst_axi/ext_reset_in" "AXI external reset"]
+    connect_bd_net [pccx_bd_pin "$ps/pl_resetn0" "PS PL reset"] \
+                   [pccx_bd_pin "$rst_npu/ext_reset_in" "NPU external reset"]
+    connect_bd_net [pccx_bd_pin "$rst_axi/peripheral_aresetn" "AXI resetn"] \
+                   [pccx_bd_pin "$npu/rst_axi_n" "NPU AXI resetn"]
+    connect_bd_net [pccx_bd_pin "$rst_npu/peripheral_aresetn" "NPU resetn"] \
+                   [pccx_bd_pin "$npu/rst_n_core" "NPU core resetn"]
+    connect_bd_net [pccx_bd_pin "$clear_const/dout" "clear constant"] \
+                   [pccx_bd_pin "$npu/i_clear" "NPU clear"]
+
+    foreach cell [list $ctrl_ic $hp_ic $acp_ic] {
+        pccx_connect_pin_if_present "$ps/pl_clk0" "$cell/aclk"
+        pccx_connect_pin_if_present "$rst_axi/peripheral_aresetn" "$cell/aresetn"
+    }
+    foreach dma [list $dma_hp0 $dma_hp1 $dma_hp2 $dma_hp3 $dma_acp] {
+        pccx_connect_dma_clocking $dma "$ps/pl_clk0" "$rst_axi/peripheral_aresetn"
+    }
+
+    set ps_hpm0 [pccx_bd_intf $ps {M_AXI_HPM0_FPD M_AXI_HPM0_LPD M_AXI_GP0 M_AXI_HPM0} "PS AXI-Lite master"]
+    set ps_hp0  [pccx_bd_intf $ps {S_AXI_HP0_FPD S_AXI_HP0 S_AXI_HP0_FPD} "PS HP0 slave"]
+    set ps_hp1  [pccx_bd_intf $ps {S_AXI_HP1_FPD S_AXI_HP1 S_AXI_HP1_FPD} "PS HP1 slave"]
+    set ps_acp  [pccx_bd_intf $ps {S_AXI_ACP_FPD S_AXI_HPC0_FPD S_AXI_HPC1_FPD S_AXI_ACP} "PS coherent ACP/HPC slave"]
+
+    set npu_axil [pccx_bd_intf $npu {S_AXIL_CTRL S_AXIL s_axil S_AXI_CTRL S_AXI} "NPU AXI-Lite slave"]
+    set npu_hp0  [pccx_bd_intf $npu {S_AXI_HP0_WEIGHT S_AXIS_HP0_WEIGHT S_AXIS_HP0 s_axis_hp0} "NPU HP0 stream"]
+    set npu_hp1  [pccx_bd_intf $npu {S_AXI_HP1_WEIGHT S_AXIS_HP1_WEIGHT S_AXIS_HP1 s_axis_hp1} "NPU HP1 stream"]
+    set npu_hp2  [pccx_bd_intf $npu {S_AXI_HP2_WEIGHT S_AXIS_HP2_WEIGHT S_AXIS_HP2 s_axis_hp2} "NPU HP2 stream"]
+    set npu_hp3  [pccx_bd_intf $npu {S_AXI_HP3_WEIGHT S_AXIS_HP3_WEIGHT S_AXIS_HP3 s_axis_hp3} "NPU HP3 stream"]
+    set npu_fmap [pccx_bd_intf $npu {S_AXIS_ACP_FMAP S_AXI_ACP_FMAP s_axis_acp_fmap} "NPU ACP fmap stream"]
+    set npu_res  [pccx_bd_intf $npu {M_AXIS_ACP_RESULT M_AXI_ACP_RESULT m_axis_acp_result} "NPU ACP result stream"]
+
+    # S_AXIL_CTRL reaches AXIL_CMD_IN and AXIL_STAT_OUT inside NPU_top.
+    connect_bd_intf_net $ps_hpm0 [pccx_bd_intf $ctrl_ic {S00_AXI} "control interconnect S00"]
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M00_AXI} "control interconnect M00"] $npu_axil
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M01_AXI} "control interconnect M01"] [pccx_bd_intf $dma_hp0 {S_AXI_LITE} "HP0 DMA control"]
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M02_AXI} "control interconnect M02"] [pccx_bd_intf $dma_hp1 {S_AXI_LITE} "HP1 DMA control"]
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M03_AXI} "control interconnect M03"] [pccx_bd_intf $dma_hp2 {S_AXI_LITE} "HP2 DMA control"]
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M04_AXI} "control interconnect M04"] [pccx_bd_intf $dma_hp3 {S_AXI_LITE} "HP3 DMA control"]
+    connect_bd_intf_net [pccx_bd_intf $ctrl_ic {M05_AXI} "control interconnect M05"] [pccx_bd_intf $dma_acp {S_AXI_LITE} "ACP DMA control"]
+
+    connect_bd_intf_net [pccx_bd_intf $dma_hp0 {M_AXI_MM2S} "HP0 DMA MM2S master"] [pccx_bd_intf $hp_ic {S00_AXI} "HP interconnect S00"]
+    connect_bd_intf_net [pccx_bd_intf $dma_hp1 {M_AXI_MM2S} "HP1 DMA MM2S master"] [pccx_bd_intf $hp_ic {S01_AXI} "HP interconnect S01"]
+    connect_bd_intf_net [pccx_bd_intf $dma_hp2 {M_AXI_MM2S} "HP2 DMA MM2S master"] [pccx_bd_intf $hp_ic {S02_AXI} "HP interconnect S02"]
+    connect_bd_intf_net [pccx_bd_intf $dma_hp3 {M_AXI_MM2S} "HP3 DMA MM2S master"] [pccx_bd_intf $hp_ic {S03_AXI} "HP interconnect S03"]
+    connect_bd_intf_net [pccx_bd_intf $hp_ic {M00_AXI} "HP interconnect M00"] $ps_hp0
+    connect_bd_intf_net [pccx_bd_intf $hp_ic {M01_AXI} "HP interconnect M01"] $ps_hp1
+
+    connect_bd_intf_net [pccx_bd_intf $dma_hp0 {M_AXIS_MM2S} "HP0 DMA stream"] $npu_hp0
+    connect_bd_intf_net [pccx_bd_intf $dma_hp1 {M_AXIS_MM2S} "HP1 DMA stream"] $npu_hp1
+    connect_bd_intf_net [pccx_bd_intf $dma_hp2 {M_AXIS_MM2S} "HP2 DMA stream"] $npu_hp2
+    connect_bd_intf_net [pccx_bd_intf $dma_hp3 {M_AXIS_MM2S} "HP3 DMA stream"] $npu_hp3
+
+    connect_bd_intf_net [pccx_bd_intf $dma_acp {M_AXI_MM2S} "ACP DMA MM2S master"] [pccx_bd_intf $acp_ic {S00_AXI} "ACP interconnect S00"]
+    connect_bd_intf_net [pccx_bd_intf $dma_acp {M_AXI_S2MM} "ACP DMA S2MM master"] [pccx_bd_intf $acp_ic {S01_AXI} "ACP interconnect S01"]
+    connect_bd_intf_net [pccx_bd_intf $acp_ic {M00_AXI} "ACP interconnect M00"] $ps_acp
+    connect_bd_intf_net [pccx_bd_intf $dma_acp {M_AXIS_MM2S} "ACP fmap stream"] $npu_fmap
+    connect_bd_intf_net $npu_res [pccx_bd_intf $dma_acp {S_AXIS_S2MM} "ACP result stream"]
+
+    assign_bd_address
+    if {[catch {
+        set npu_seg [get_bd_addr_segs -quiet -of_objects $npu_axil]
+        if {[llength $npu_seg] > 0} {
+            set npu_addr [get_bd_addr_segs -quiet -of_objects [get_bd_addr_spaces $ps_hpm0] -filter "NAME =~ */[get_property NAME [lindex $npu_seg 0]]"]
+            if {[llength $npu_addr] > 0} {
+                set_property offset $AXIL_BASE [lindex $npu_addr 0]
+                set_property range 64K [lindex $npu_addr 0]
+            }
+        }
+    } msg]} {
+        pccx_msg "warning: NPU AXI-Lite base address left to Vivado: $msg"
+    }
+
+    validate_bd_design
+    save_bd_design
+    report_bd_address -file [file join $REPORTS address_map.rpt]
+
+    pccx_msg "BD $BD_NAME prepared around $NPU_BD_MODULE_REF, which instantiates $TOP_RTL_MODULE"
+    pccx_msg "clk_axi placeholder = ${CLK_AXI_MHZ} MHz (${axi_hz} Hz)"
+    pccx_msg "clk_npu placeholder = ${CLK_NPU_MHZ} MHz (${npu_hz} Hz)"
+}
+
+proc pccx_open_or_prepare {} {
+    global PROJ_DIR PROJ_NAME BD_NAME
+
+    set xpr [file join $PROJ_DIR ${PROJ_NAME}.xpr]
+    if {[file exists $xpr]} {
+        open_project $xpr
+    } else {
+        pccx_create_project_shell
+        pccx_add_sources
+    }
+    pccx_prepare_bd
+}
+
+proc pccx_import_bd_wrapper {} {
+    global BD_NAME
+
+    set bd_file [get_files -quiet */${BD_NAME}.bd]
+    if {[llength $bd_file] == 0} {
+        set bd_file [get_files -quiet ${BD_NAME}.bd]
+    }
+    if {[llength $bd_file] == 0} {
+        error "BD file for $BD_NAME not found"
+    }
+
+    generate_target all [lindex $bd_file 0]
+    set wrapper [make_wrapper -files [lindex $bd_file 0] -top]
+    if {[llength $wrapper] > 0} {
+        add_files -norecurse $wrapper
+    }
+    update_compile_order -fileset sources_1
+}
+
+proc pccx_synth {} {
+    global TARGET_PART BD_NAME DCP_DIR REPORTS
+
+    file mkdir $DCP_DIR
+    file mkdir $REPORTS
+    pccx_open_or_prepare
+    pccx_import_bd_wrapper
+
+    synth_design -top ${BD_NAME}_wrapper -part $TARGET_PART -flatten_hierarchy rebuilt
+    write_checkpoint -force [file join $DCP_DIR ${BD_NAME}_post_synth.dcp]
+
+    report_utilization -hierarchical -file [file join $REPORTS utilization_full_top_post_synth.rpt]
+    report_clocks -file [file join $REPORTS clocks_full_top_post_synth.rpt]
+    report_clock_interaction -file [file join $REPORTS clock_interaction_full_top_post_synth.rpt]
+    report_timing_summary -delay_type min_max -report_unconstrained \
+        -check_timing_verbose -max_paths 20 \
+        -file [file join $REPORTS timing_summary_full_top_post_synth.rpt]
+    report_drc -file [file join $REPORTS drc_full_top_post_synth.rpt]
+}
+
+proc pccx_impl {} {
+    global DCP_DIR REPORTS
+
+    set synth_dcp [file join $DCP_DIR system_post_synth.dcp]
+    if {![file exists $synth_dcp]} {
+        error "missing $synth_dcp; run 'synth' first"
+    }
+
+    open_checkpoint $synth_dcp
+    opt_design
+    place_design
+    route_design
+    write_checkpoint -force [file join $DCP_DIR system_routed.dcp]
+
+    report_utilization -hierarchical -file [file join $REPORTS utilization_full_top_post_impl.rpt]
+    report_clock_interaction -file [file join $REPORTS clock_interaction_full_top_post_impl.rpt]
+    report_route_status -file [file join $REPORTS route_status_full_top_post_impl.rpt]
+    report_timing_summary -delay_type min_max -report_unconstrained \
+        -check_timing_verbose -max_paths 50 \
+        -file [file join $REPORTS timing_summary_full_top_post_impl.rpt]
+    report_drc -file [file join $REPORTS drc_full_top_post_impl.rpt]
+    report_methodology -file [file join $REPORTS methodology_full_top_post_impl.rpt]
+    report_power -file [file join $REPORTS power_full_top_post_impl.rpt]
+}
+
+proc pccx_bitstream {} {
+    global DCP_DIR BUILD_DIR REPORTS
+
+    set routed_dcp [file join $DCP_DIR system_routed.dcp]
+    if {![file exists $routed_dcp]} {
+        error "missing $routed_dcp; run 'impl' first"
+    }
+
+    open_checkpoint $routed_dcp
+    write_bitstream -force [file join $BUILD_DIR pccx_v002_kv260.bit]
+    report_timing_summary -delay_type min_max -report_unconstrained \
+        -check_timing_verbose -max_paths 50 \
+        -file [file join $REPORTS timing_summary_full_top_bitstream_checkpoint.rpt]
+}
+
+file mkdir $BUILD_DIR
+file mkdir $REPORTS
+file mkdir $DCP_DIR
+
+if {$ACTION eq "clean"} {
+    if {[file exists $PROJ_DIR]} {
+        file delete -force $PROJ_DIR
+    }
+    foreach f [list \
+        [file join $DCP_DIR system_post_synth.dcp] \
+        [file join $DCP_DIR system_routed.dcp] \
+        [file join $BUILD_DIR pccx_v002_kv260.bit] \
+    ] {
+        if {[file exists $f]} {
+            file delete -force $f
+        }
+    }
+    pccx_msg "cleaned BD project/checkpoint outputs"
+} elseif {$ACTION eq "prepare"} {
+    pccx_open_or_prepare
+} elseif {$ACTION eq "synth"} {
+    pccx_synth
+} elseif {$ACTION eq "impl"} {
+    pccx_impl
+} elseif {$ACTION eq "bitstream"} {
+    pccx_bitstream
+}
+
+pccx_msg "system_bd.tcl action '$ACTION' complete"


### PR DESCRIPTION
Adds the v002.1 KV260 bitstream pre-flight materials: a new hw/vivado/system_bd.tcl scaffold around npu_core_wrapper/NPU_top, and docs/runbooks/v002.1-bitstream-build.md with the separate-terminal full top-level Vivado flow.

The user terminal flow is clean, prepare BD, synth full top, impl full top, write bitstream, then SD staging and KV260 smoke capture. This PR does not run Vivado, does not run board commands, and does not touch RTL.

Timing is not closed: per PR #79 evidence, post-impl OOC WNS is -0.046 ns at the CVO SFU reciprocal correction path, and the full top-level run must capture its own timing report before any deploy claim.

Refs #16, #42.

evidence state: pre-flight; no Vivado/board action taken in this PR