### PR TITLE
feat(gemv): connect lane mask and remove activation hardcode

### DIFF
--- a/hw/rtl/NPU_top.sv
+++ b/hw/rtl/NPU_top.sv
@@ -314,8 +314,14 @@ module NPU_top (
   logic [16:0] gemv_num_recur;
   logic        gemv_activated_lane[0:VecCoreDefaultCfg.num_gemv_pipeline-1];
 
-  assign gemv_num_recur      = {11'b0, GEMV_uop_wire.size_ptr_addr};
-  assign gemv_activated_lane = '{default: 1'b0};
+  assign gemv_num_recur = {11'b0, GEMV_uop_wire.size_ptr_addr};
+
+  GEMV_lane_mask_decode #(
+      .param(VecCoreDefaultCfg)
+  ) u_GEMV_lane_mask_decode (
+      .IN_parallel_lane   (GEMV_uop_wire.parallel_lane),
+      .OUT_activated_lane (gemv_activated_lane)
+  );
 
   GEMV_top #(
       .param(VecCoreDefaultCfg)

--- a/hw/rtl/VEC_CORE/GEMV_lane_mask_decode.sv
+++ b/hw/rtl/VEC_CORE/GEMV_lane_mask_decode.sv
@@ -1,0 +1,27 @@
+`timescale 1ns / 1ps
+
+import isa_pkg::*;
+import vec_core_pkg::*;
+
+// ===| Module: GEMV_lane_mask_decode |=========================================
+// Purpose      : Translate the ISA GEMV parallel_lane field into per-lane
+//                activation bits for the Vector Core.
+// Policy       : parallel_lane == 0 selects all implemented GEMV lanes.
+// =============================================================================
+module GEMV_lane_mask_decode
+  import isa_pkg::*;
+  import vec_core_pkg::*;
+#(
+    parameter gemv_cfg_t param = VecCoreDefaultCfg
+) (
+    input  parallel_lane_t IN_parallel_lane,
+    output logic           OUT_activated_lane[0:param.num_gemv_pipeline-1]
+);
+
+  always_comb begin
+    for (int lane = 0; lane < param.num_gemv_pipeline; lane++) begin
+      OUT_activated_lane[lane] = (IN_parallel_lane == '0) ? 1'b1 : IN_parallel_lane[lane];
+    end
+  end
+
+endmodule

--- a/hw/sim/run_verification.sh
+++ b/hw/sim/run_verification.sh
@@ -36,6 +36,7 @@ declare -A TB_DEPS=(
     [tb_ctrl_npu_decoder]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv"
     [tb_mem_u_operation_queue]="Constants/compilePriority_Order/E_obs_pkg/perf_counter_pkg.sv NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv MEM_control/IO/mem_u_operation_queue.sv"
     [tb_GEMM_fmap_staggered_delay]="MAT_CORE/GEMM_fmap_staggered_delay.sv"
+    [tb_GEMV_lane_mask]="Constants/compilePriority_Order/B_device_pkg/device_pkg.sv Constants/compilePriority_Order/C_type_pkg/dtype_pkg.sv Constants/compilePriority_Order/C_type_pkg/mem_pkg.sv Constants/compilePriority_Order/D_pipeline_pkg/vec_core_pkg.sv NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv VEC_CORE/GEMV_lane_mask_decode.sv VEC_CORE/GEMV_reduction.sv"
     [tb_v002_runtime_smoke_program]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv NPU_Controller/Global_Scheduler.sv"
 )
 
@@ -52,7 +53,8 @@ declare -A TB_CORE=(
     [tb_ctrl_npu_decoder]=7
     [tb_mem_u_operation_queue]=8
     [tb_GEMM_fmap_staggered_delay]=9
-    [tb_v002_runtime_smoke_program]=10
+    [tb_GEMV_lane_mask]=10
+    [tb_v002_runtime_smoke_program]=11
 )
 
 TB_LIST=(
@@ -66,6 +68,7 @@ TB_LIST=(
     tb_ctrl_npu_decoder
     tb_mem_u_operation_queue
     tb_GEMM_fmap_staggered_delay
+    tb_GEMV_lane_mask
     tb_v002_runtime_smoke_program
 )
 

--- a/hw/tb/tb_GEMV_lane_mask.sv
+++ b/hw/tb/tb_GEMV_lane_mask.sv
@@ -1,0 +1,230 @@
+`timescale 1ns / 1ps
+
+`include "GLOBAL_CONST.svh"
+
+import isa_pkg::*;
+import vec_core_pkg::*;
+
+// =============================================================================
+// Testbench: tb_GEMV_lane_mask
+//
+// Verifies the GEMV lane-mask policy and reduction-valid gating for the masks
+// required by issue #36.
+// =============================================================================
+
+module DSP48E2 #(
+    parameter string USE_SIMD = "ONE48",
+    parameter int AREG = 0,
+    parameter int BREG = 0,
+    parameter int CREG = 0,
+    parameter int PREG = 1
+) (
+    input  logic        CLK,
+    input  logic        RSTP,
+    input  logic [3:0]  ALUMODE,
+    input  logic [4:0]  INMODE,
+    input  logic [8:0]  OPMODE,
+    input  logic        CEP,
+    input  logic [29:0] A,
+    input  logic [17:0] B,
+    input  logic [47:0] C,
+    output logic [47:0] P
+);
+
+  always_ff @(posedge CLK) begin
+    if (RSTP) begin
+      P <= '0;
+    end else if (CEP) begin
+      P <= {A, B} + C;
+    end
+  end
+
+endmodule
+
+module tb_GEMV_lane_mask;
+
+  localparam int LaneCnt = VecCoreDefaultCfg.num_gemv_pipeline;
+  localparam int WeightW = VecCoreDefaultCfg.weight_width;
+  localparam int WeightCnt = VecCoreDefaultCfg.weight_cnt;
+  localparam int FmapCnt = VecCoreDefaultCfg.fmap_cache_out_cnt;
+  localparam int LutDepth = (1 << WeightW);
+  localparam int ResultW = VecCoreDefaultCfg.fixed_mant_width + 3;
+  localparam int ReductionLatency = 5;
+
+  logic clk;
+  logic rst_n;
+  initial clk = 1'b0;
+  always #2 clk = ~clk;
+
+  int cycles = 0;
+  always @(posedge clk) begin
+    if (rst_n) cycles++;
+  end
+
+  parallel_lane_t lane_mask;
+  logic           activated_lane[0:LaneCnt-1];
+  logic           IN_valid;
+
+  logic [WeightW-1:0] weight_A[0:WeightCnt-1];
+  logic [WeightW-1:0] weight_B[0:WeightCnt-1];
+  logic [WeightW-1:0] weight_C[0:WeightCnt-1];
+  logic [WeightW-1:0] weight_D[0:WeightCnt-1];
+
+  logic signed [ResultW-1:0] fmap_lut[0:FmapCnt-1][0:LutDepth-1];
+  logic [ResultW-1:0]        reduction_result[0:LaneCnt-1];
+  logic [LaneCnt-1:0]        reduction_valid;
+
+  GEMV_lane_mask_decode #(
+      .param(VecCoreDefaultCfg)
+  ) u_mask_decode (
+      .IN_parallel_lane  (lane_mask),
+      .OUT_activated_lane(activated_lane)
+  );
+
+  GEMV_reduction #(
+      .param(VecCoreDefaultCfg)
+  ) u_reduction_A (
+      .clk                    (clk),
+      .rst_n                  (rst_n),
+      .IN_is_lane_active      (activated_lane[0]),
+      .IN_valid               (IN_valid),
+      .IN_fmap_LUT            (fmap_lut),
+      .IN_weight              (weight_A),
+      .OUT_reduction_result   (reduction_result[0]),
+      .OUT_reduction_res_valid(reduction_valid[0])
+  );
+
+  GEMV_reduction #(
+      .param(VecCoreDefaultCfg)
+  ) u_reduction_B (
+      .clk                    (clk),
+      .rst_n                  (rst_n),
+      .IN_is_lane_active      (activated_lane[1]),
+      .IN_valid               (IN_valid),
+      .IN_fmap_LUT            (fmap_lut),
+      .IN_weight              (weight_B),
+      .OUT_reduction_result   (reduction_result[1]),
+      .OUT_reduction_res_valid(reduction_valid[1])
+  );
+
+  GEMV_reduction #(
+      .param(VecCoreDefaultCfg)
+  ) u_reduction_C (
+      .clk                    (clk),
+      .rst_n                  (rst_n),
+      .IN_is_lane_active      (activated_lane[2]),
+      .IN_valid               (IN_valid),
+      .IN_fmap_LUT            (fmap_lut),
+      .IN_weight              (weight_C),
+      .OUT_reduction_result   (reduction_result[2]),
+      .OUT_reduction_res_valid(reduction_valid[2])
+  );
+
+  GEMV_reduction #(
+      .param(VecCoreDefaultCfg)
+  ) u_reduction_D (
+      .clk                    (clk),
+      .rst_n                  (rst_n),
+      .IN_is_lane_active      (activated_lane[3]),
+      .IN_valid               (IN_valid),
+      .IN_fmap_LUT            (fmap_lut),
+      .IN_weight              (weight_D),
+      .OUT_reduction_result   (reduction_result[3]),
+      .OUT_reduction_res_valid(reduction_valid[3])
+  );
+
+  int errors = 0;
+  int checks = 0;
+
+  function automatic logic [LaneCnt-1:0] pack_activated();
+    for (int lane = 0; lane < LaneCnt; lane++) begin
+      pack_activated[lane] = activated_lane[lane];
+    end
+  endfunction
+
+  task automatic expect_lanes(
+      input string tag,
+      input logic [LaneCnt-1:0] got,
+      input logic [LaneCnt-1:0] exp
+  );
+    begin
+      checks++;
+      if (got !== exp) begin
+        errors++;
+        $display("[%0t] mismatch %s: got=%0b exp=%0b", $time, tag, got, exp);
+      end
+    end
+  endtask
+
+  task automatic init_inputs();
+    begin
+      lane_mask = '0;
+      IN_valid  = 1'b0;
+
+      for (int idx = 0; idx < WeightCnt; idx++) begin
+        weight_A[idx] = 4'd8;
+        weight_B[idx] = 4'd8;
+        weight_C[idx] = 4'd8;
+        weight_D[idx] = 4'd8;
+      end
+
+      for (int fmap_idx = 0; fmap_idx < FmapCnt; fmap_idx++) begin
+        for (int weight_idx = 0; weight_idx < LutDepth; weight_idx++) begin
+          fmap_lut[fmap_idx][weight_idx] = '0;
+        end
+      end
+    end
+  endtask
+
+  task automatic run_mask_case(
+      input string tag,
+      input parallel_lane_t mask,
+      input logic [LaneCnt-1:0] exp_active
+  );
+    begin
+      lane_mask = mask;
+      #1;
+      expect_lanes($sformatf("%s.decode", tag), pack_activated(), exp_active);
+
+      IN_valid = 1'b1;
+      @(posedge clk);
+      #1;
+      IN_valid = 1'b0;
+
+      repeat (ReductionLatency - 1) @(posedge clk);
+      #1;
+      expect_lanes($sformatf("%s.reduction_valid", tag), reduction_valid, exp_active);
+
+      @(posedge clk);
+      #1;
+      expect_lanes($sformatf("%s.reduction_valid_clear", tag), reduction_valid, '0);
+    end
+  endtask
+
+  initial begin
+    rst_n = 1'b0;
+    init_inputs();
+
+    repeat (3) @(posedge clk);
+    rst_n = 1'b1;
+    @(posedge clk);
+    #1;
+
+    run_mask_case("mask_00001", 5'b00001, 4'b0001);
+    run_mask_case("mask_00011", 5'b00011, 4'b0011);
+    run_mask_case("mask_01111", 5'b01111, 4'b1111);
+    run_mask_case("mask_00000", 5'b00000, 4'b1111);
+
+    if (errors == 0) begin
+      $display("PASS: %0d cycles, GEMV lane masks honored over %0d checks.", cycles, checks);
+    end else begin
+      $display("FAIL: %0d GEMV lane-mask mismatches over %0d checks.", errors, checks);
+    end
+    $finish;
+  end
+
+  initial begin
+    #100000 $display("FAIL: GEMV lane-mask timeout"); $finish;
+  end
+
+endmodule

--- a/hw/vivado/filelist.f
+++ b/hw/vivado/filelist.f
@@ -52,6 +52,7 @@ rtl/MAT_CORE/mat_result_normalizer.sv
 # ===| VEC_CORE |==============================================================
 rtl/VEC_CORE/GEMV_accumulate.sv
 rtl/VEC_CORE/GEMV_generate_lut.sv
+rtl/VEC_CORE/GEMV_lane_mask_decode.sv
 rtl/VEC_CORE/GEMV_reduction.sv
 rtl/VEC_CORE/GEMV_reduction_branch.sv
 rtl/VEC_CORE/GEMV_top.sv


### PR DESCRIPTION
## Summary
- Replace the hardcoded all-disabled GEMV lane activation in `NPU_top.sv` with `GEMV_uop_wire.parallel_lane`.
- Add `GEMV_lane_mask_decode`; `parallel_lane == 0` selects all implemented GEMV lanes.
- Add `tb_GEMV_lane_mask` and register it in the xsim regression.

## Evidence
- Full RTL `xvlog` compile: PASS.
- `PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash run_verification.sh --tb tb_GEMV_lane_mask`: PASS: 25 cycles, GEMV lane masks honored over 12 checks.
- `PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash run_verification.sh --full`: Summary: 12 passed, 0 failed.
- `scripts/v002/claim-scan.sh`: UNSUPPORTED_CLAIM_FOUND=no.
- `shellcheck`: missing; marked shellcheck-missing and proceeded per instruction.
- CVO/SFU files touched: no.

Refs #36
Resolves #36