### PR TITLE
feat(npu_top): connect result packer ready/valid and STORE writeback

### DIFF
--- a/hw/rtl/MAT_CORE/FROM_mat_result_packer.sv
+++ b/hw/rtl/MAT_CORE/FROM_mat_result_packer.sv
@@ -109,23 +109,24 @@ module FROM_gemm_result_packer #(
         end
 
         CHECK_VALID: begin
+          packed_valid <= 1'b0;
           // Wait until BeatsPerWord adjacent rows have produced a valid result
           // (one 128-bit word = 8 BF16 lanes today).
           if (&capture_valid[send_idx+:BeatsPerWord]) begin
-            state <= SEND_DATA;
-          end
-        end
-
-        SEND_DATA: begin
-          if (packed_ready) begin
-            // Lane b of the BeatsPerWord-wide group lands in the
-            // [b*BF16_WIDTH +: BF16_WIDTH] slice — same byte order as
-            // the original 8-lane concat, but tracks BeatsPerWord so
-            // changes to AXI_STREAM_WIDTH or BF16_WIDTH stay in sync.
+            // Drive data before asserting valid so a downstream stall sees a
+            // stable payload until the eventual valid/ready handshake.
             for (int b = 0; b < BeatsPerWord; b++) begin
               packed_data[b*`BF16_WIDTH +: `BF16_WIDTH] <= capture_reg[send_idx+b];
             end
             packed_valid <= 1'b1;
+            state        <= SEND_DATA;
+          end
+        end
+
+        SEND_DATA: begin
+          packed_valid <= 1'b1;  // Keep high until ready
+          if (packed_ready) begin
+            packed_valid <= 1'b0;
 
             if (send_idx >= LastSendIdx) begin
               state    <= IDLE;
@@ -134,8 +135,6 @@ module FROM_gemm_result_packer #(
               send_idx <= send_idx + BeatsPerWord;
               state    <= CHECK_VALID;
             end
-          end else begin
-            packed_valid <= 1'b1;  // Keep high until ready
           end
         end
 

--- a/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
+++ b/hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv
@@ -54,6 +54,10 @@ module mem_GLOBAL_cache (
     output logic         OUT_npu_is_busy,
 
     input  logic [127:0] IN_npu_wdata,
+    input  logic         IN_npu_direct_en,
+    input  logic         IN_npu_direct_we,
+    input  logic  [16:0] IN_npu_direct_addr,
+    input  logic [127:0] IN_npu_direct_wdata,
     output logic [127:0] OUT_npu_rdata
 );
 
@@ -133,6 +137,22 @@ module mem_GLOBAL_cache (
 
   assign OUT_npu_is_busy = npu_is_busy;
 
+  logic        uram_npu_we;
+  logic [16:0] uram_npu_addr;
+  logic [127:0] uram_npu_wdata;
+
+  always_comb begin
+    if (IN_npu_direct_en) begin
+      uram_npu_we    = IN_npu_direct_we;
+      uram_npu_addr  = IN_npu_direct_addr;
+      uram_npu_wdata = IN_npu_direct_wdata;
+    end else begin
+      uram_npu_we    = npu_write_en & npu_is_busy;
+      uram_npu_addr  = npu_ptr;
+      uram_npu_wdata = IN_npu_wdata;
+    end
+  end
+
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
       npu_ptr      <= '0;
@@ -168,9 +188,9 @@ module mem_GLOBAL_cache (
       .OUT_acp_rdata(core_acp_tx_bus.tdata),
 
       // Port B — NPU compute
-      .IN_npu_we    (npu_write_en & npu_is_busy),
-      .IN_npu_addr  (npu_ptr),
-      .IN_npu_wdata (IN_npu_wdata),
+      .IN_npu_we    (uram_npu_we),
+      .IN_npu_addr  (uram_npu_addr),
+      .IN_npu_wdata (uram_npu_wdata),
       .OUT_npu_rdata(OUT_npu_rdata)
   );
 

--- a/hw/rtl/MEM_control/top/mem_dispatcher.sv
+++ b/hw/rtl/MEM_control/top/mem_dispatcher.sv
@@ -46,6 +46,8 @@ module mem_dispatcher #() (
 
     // ===| Engine uop inputs |===================================================
     input  memory_control_uop_t IN_LOAD_uop,
+    input  memory_control_uop_t IN_STORE_uop,
+    input  logic                IN_store_uop_valid,
     input  memory_set_uop_t     IN_mem_set_uop,
     input  cvo_control_uop_t    IN_CVO_uop,
     input  logic                IN_cvo_uop_valid,
@@ -59,9 +61,16 @@ module mem_dispatcher #() (
     input  logic        IN_cvo_result_valid,
     output logic        OUT_cvo_result_ready,
 
+    // ===| Packed compute results (from GEMM result packer) |======================
+    input  logic [`AXI_STREAM_WIDTH-1:0] IN_gemm_result_data,
+    input  logic                         IN_gemm_result_valid,
+    output logic                         OUT_gemm_result_ready,
+
     // ===| Status |=============================================================
     output logic OUT_fifo_full,
-    output logic OUT_cvo_busy
+    output logic OUT_cvo_busy,
+    output logic OUT_store_busy,
+    output logic OUT_store_done
 );
 
   // ===| FIFO full aggregation |=================================================
@@ -290,33 +299,102 @@ module mem_dispatcher #() (
       .IN_npu_is_busy       (npu_is_busy_wire)
   );
 
+  // ===| STORE writeback engine |================================================
+  // GEMM currently emits one 32-lane BF16 row through FROM_gemm_result_packer:
+  // 32 lanes × 16 bit / 128 bit = 4 L2 words. The packer holds valid/data
+  // while OUT_gemm_result_ready is low, so no extra FIFO is needed here.
+  localparam int GemmStoreWords = (`ARRAY_SIZE_H * `BF16_WIDTH) / `AXI_STREAM_WIDTH;
+  localparam int StoreWordCntW  = $clog2(GemmStoreWords + 1);
+
+  logic                    store_active;
+  logic [16:0]             store_base_addr;
+  logic [StoreWordCntW-1:0] store_word_count;
+  logic                    store_l2_we;
+  logic [16:0]             store_l2_addr;
+  logic [127:0]            store_l2_wdata;
+  logic                    store_port_ready;
+  logic                    store_accept;
+  logic                    store_done_pending;
+
+  assign OUT_store_busy        = store_active;
+  assign store_port_ready      = store_active & ~cvo_bridge_busy & ~npu_is_busy_wire;
+  assign OUT_gemm_result_ready = store_port_ready;
+  assign store_accept          = store_port_ready & IN_gemm_result_valid;
+
+  always_ff @(posedge clk_core) begin
+    if (!rst_n_core) begin
+      store_active       <= 1'b0;
+      store_base_addr    <= '0;
+      store_word_count   <= '0;
+      store_l2_we        <= 1'b0;
+      store_l2_addr      <= '0;
+      store_l2_wdata     <= '0;
+      store_done_pending <= 1'b0;
+      OUT_store_done     <= 1'b0;
+    end else begin
+      store_l2_we    <= 1'b0;
+      OUT_store_done <= 1'b0;
+
+      if (store_done_pending) begin
+        OUT_store_done     <= 1'b1;
+        store_done_pending <= 1'b0;
+      end
+
+      if (IN_store_uop_valid) begin
+        store_word_count   <= '0;
+        store_base_addr    <= IN_STORE_uop.dest_addr;
+        store_active       <= (IN_STORE_uop.data_dest == from_GEMM_res_to_L2);
+        store_done_pending <= 1'b0;
+      end else if (store_accept) begin
+        store_l2_we    <= 1'b1;
+        store_l2_addr  <= store_base_addr + 17'(store_word_count);
+        store_l2_wdata <= IN_gemm_result_data;
+
+        if (store_word_count == StoreWordCntW'(GemmStoreWords - 1)) begin
+          store_word_count <= '0;
+          store_active     <= 1'b0;
+          store_done_pending <= 1'b1;
+        end else begin
+          store_word_count <= store_word_count + StoreWordCntW'(1);
+        end
+      end
+    end
+  end
+
   // ===| L2 cache controller |===================================================
-  // CVO bridge drives L2 port B when active; otherwise port B is driven by
-  // the NPU DMA state machine in mem_GLOBAL_cache.
+  // CVO bridge drives L2 port B when active. GEMM STORE writes use the same
+  // direct port when the bridge and NPU DMA state machine are idle; otherwise
+  // the NPU DMA state machine in mem_GLOBAL_cache owns port B.
   logic        cvo_l2_we;
   logic [16:0] cvo_l2_addr;
   logic [127:0] cvo_l2_wdata;
   logic [127:0] cvo_l2_rdata;
 
-  logic        npu_l2_we;
-  logic [16:0] npu_l2_addr;
-  logic [127:0] npu_l2_wdata;
   logic [127:0] npu_l2_rdata;
 
-  // Port B arbitration: CVO bridge wins when busy
+  // Port B arbitration: CVO bridge wins when busy; STORE writes only fire when
+  // both CVO and the NPU command FSM are idle.
+  logic        final_npu_direct_en;
   logic        final_npu_we;
   logic [16:0] final_npu_addr;
   logic [127:0] final_npu_wdata;
 
   always_comb begin
     if (cvo_bridge_busy) begin
+      final_npu_direct_en = 1'b1;
       final_npu_we    = cvo_l2_we;
       final_npu_addr  = cvo_l2_addr;
       final_npu_wdata = cvo_l2_wdata;
+    end else if (store_l2_we) begin
+      final_npu_direct_en = 1'b1;
+      final_npu_we    = 1'b1;
+      final_npu_addr  = store_l2_addr;
+      final_npu_wdata = store_l2_wdata;
     end else begin
-      final_npu_we    = npu_l2_we;
-      final_npu_addr  = npu_l2_addr;
-      final_npu_wdata = npu_l2_wdata;
+      final_npu_direct_en = 1'b0;
+      final_npu_we    = 1'b0;
+      final_npu_addr  = '0;
+      final_npu_wdata = '0;
     end
   end
 
@@ -346,8 +424,12 @@ module mem_dispatcher #() (
       .IN_npu_rx_start  (OUT_npu_cmd_valid),
       .OUT_npu_is_busy  (npu_is_busy_wire),
 
-      .IN_npu_wdata     (final_npu_wdata),
-      .OUT_npu_rdata    (npu_l2_rdata)
+      .IN_npu_wdata       ('0),
+      .IN_npu_direct_en   (final_npu_direct_en),
+      .IN_npu_direct_we   (final_npu_we),
+      .IN_npu_direct_addr (final_npu_addr),
+      .IN_npu_direct_wdata(final_npu_wdata),
+      .OUT_npu_rdata      (npu_l2_rdata)
   );
 
   // ===| CVO Stream Bridge |=====================================================

--- a/hw/rtl/NPU_Controller/Global_Scheduler.sv
+++ b/hw/rtl/NPU_Controller/Global_Scheduler.sv
@@ -48,6 +48,7 @@ module Global_Scheduler #() (
     output GEMV_control_uop_t   OUT_GEMV_uop,
     output memory_control_uop_t OUT_LOAD_uop,
     output memory_control_uop_t OUT_STORE_uop,
+    output logic                OUT_STORE_uop_valid,
     output memory_set_uop_t     OUT_mem_set_uop,
     output cvo_control_uop_t    OUT_CVO_uop,
 
@@ -148,31 +149,39 @@ module Global_Scheduler #() (
   // Held until the engine signals completion (external handshake, not shown here).
   always_ff @(posedge clk_core) begin
     if (!rst_n_core) begin
-      OUT_STORE_uop <= '0;
-    end else if (IN_GEMM_op_x64_valid) begin
-      OUT_STORE_uop <= '{
-          data_dest      : from_GEMM_res_to_L2,
-          dest_addr      : GEMM_op_x64.dest_reg,
-          src_addr       : '0,
-          shape_ptr_addr : GEMM_op_x64.shape_ptr_addr,
-          async          : SYNC_OP
-      };
-    end else if (IN_GEMV_op_x64_valid) begin
-      OUT_STORE_uop <= '{
-          data_dest      : from_GEMV_res_to_L2,
-          dest_addr      : GEMV_op_x64.dest_reg,
-          src_addr       : '0,
-          shape_ptr_addr : GEMV_op_x64.shape_ptr_addr,
-          async          : SYNC_OP
-      };
-    end else if (IN_cvo_op_x64_valid) begin
-      OUT_STORE_uop <= '{
-          data_dest      : from_CVO_res_to_L2,
-          dest_addr      : cvo_op_x64.dst_addr,
-          src_addr       : '0,
-          shape_ptr_addr : '0,
-          async          : cvo_op_x64.async
-      };
+      OUT_STORE_uop       <= '0;
+      OUT_STORE_uop_valid <= 1'b0;
+    end else begin
+      OUT_STORE_uop_valid <= 1'b0;
+
+      if (IN_GEMM_op_x64_valid) begin
+        OUT_STORE_uop <= '{
+            data_dest      : from_GEMM_res_to_L2,
+            dest_addr      : GEMM_op_x64.dest_reg,
+            src_addr       : '0,
+            shape_ptr_addr : GEMM_op_x64.shape_ptr_addr,
+            async          : SYNC_OP
+        };
+        OUT_STORE_uop_valid <= 1'b1;
+      end else if (IN_GEMV_op_x64_valid) begin
+        OUT_STORE_uop <= '{
+            data_dest      : from_GEMV_res_to_L2,
+            dest_addr      : GEMV_op_x64.dest_reg,
+            src_addr       : '0,
+            shape_ptr_addr : GEMV_op_x64.shape_ptr_addr,
+            async          : SYNC_OP
+        };
+        OUT_STORE_uop_valid <= 1'b1;
+      end else if (IN_cvo_op_x64_valid) begin
+        OUT_STORE_uop <= '{
+            data_dest      : from_CVO_res_to_L2,
+            dest_addr      : cvo_op_x64.dst_addr,
+            src_addr       : '0,
+            shape_ptr_addr : '0,
+            async          : cvo_op_x64.async
+        };
+        OUT_STORE_uop_valid <= 1'b1;
+      end
     end
   end
 

--- a/hw/rtl/NPU_Controller/npu_controller_top.sv
+++ b/hw/rtl/NPU_Controller/npu_controller_top.sv
@@ -30,6 +30,10 @@ module npu_controller_top #() (
     // ===| AXI4-Lite Slave : PS <-> NPU control plane |=========================
     axil_if.slave S_AXIL_CTRL,
 
+    // ===| Encoded Status |======================================================
+    input logic [`ISA_WIDTH-1:0] IN_enc_stat,
+    input logic                  IN_enc_valid,
+
     // ===| Decoded Instruction Valids |=========================================
     output logic OUT_GEMV_op_x64_valid,
     output logic OUT_GEMM_op_x64_valid,
@@ -57,8 +61,8 @@ module npu_controller_top #() (
       .OUT_RAW_instruction(raw_instruction),
       .OUT_kick           (raw_instruction_pop_valid),
 
-      .IN_enc_stat ('0),
-      .IN_enc_valid(1'b0),
+      .IN_enc_stat (IN_enc_stat),
+      .IN_enc_valid(IN_enc_valid),
 
       .IN_fetch_ready(fetch_PC_ready)
   );

--- a/hw/rtl/NPU_top.sv
+++ b/hw/rtl/NPU_top.sv
@@ -15,7 +15,7 @@ import bf16_math_pkg::*;
 // Clock        : clk_core @ 400 MHz (compute), clk_axi @ 250 MHz (HP/AXIL).
 // Reset        : rst_n_core / rst_axi_n active-low. Synchronous release.
 // Soft-clear   : i_clear (active-high, sync) — combined with reset wherever
-//                state is latched. See CLAUDE.md §3 reset convention.
+//                state is latched per the repo reset convention.
 // Throughput   : Steady-state, dual-lane W4A8 systolic = 32 × 32 × 2 MAC/clk.
 // Backpressure : HP weight FIFOs (mem_HP_buffer) provide CDC + skid; ACP fmap
 //                FIFO (preprocess_fmap) holds at boundary when broadcast stalls.
@@ -34,8 +34,8 @@ import bf16_math_pkg::*;
 //   OP_CVO   : L2 → CVO_top → L2 (mem_dispatcher ↔ CVO stream bridge)
 //
 // Status word (mmio_npu_stat[31:0], surfaced to AXIL_STAT_OUT):
-//   bit 0 : BUSY  = fifo_full | cvo_busy | cvo_disp_busy
-//   bit 1 : DONE  = CVO operation complete pulse (one cycle)
+//   bit 0 : BUSY  = fifo_full | cvo_busy | cvo_disp_busy | store_busy
+//   bit 1 : DONE  = CVO or STORE writeback complete pulse (one cycle)
 //   bit 31:2 reserved.
 // ===============================================================================
 
@@ -82,6 +82,7 @@ module NPU_top (
   instruction_op_x64_t instruction;
 
   logic                fifo_full_wire;
+  logic [31:0]         mmio_npu_stat;
 
   // ===| [1] NPU Controller |====================================================
   npu_controller_top #() u_npu_controller_top (
@@ -90,6 +91,9 @@ module NPU_top (
       .i_clear(i_clear),
 
       .S_AXIL_CTRL(S_AXIL_CTRL),
+
+      .IN_enc_stat ({32'd0, mmio_npu_stat}),
+      .IN_enc_valid(mmio_npu_stat[1]),
 
       .OUT_GEMV_op_x64_valid  (GEMV_op_x64_valid_wire),
       .OUT_GEMM_op_x64_valid  (GEMM_op_x64_valid_wire),
@@ -105,6 +109,7 @@ module NPU_top (
   GEMV_control_uop_t   GEMV_uop_wire;
   memory_control_uop_t LOAD_uop_wire;
   memory_control_uop_t STORE_uop_wire;  // latched at issue; drives result writeback
+  logic                STORE_uop_valid_wire;
   memory_set_uop_t     mem_set_uop;
   cvo_control_uop_t    CVO_uop_wire;
   logic                sram_rd_start_wire;  // one-cycle pulse: start fmap broadcast
@@ -125,6 +130,7 @@ module NPU_top (
       .OUT_GEMV_uop     (GEMV_uop_wire),
       .OUT_LOAD_uop     (LOAD_uop_wire),
       .OUT_STORE_uop    (STORE_uop_wire),
+      .OUT_STORE_uop_valid(STORE_uop_valid_wire),
       .OUT_mem_set_uop  (mem_set_uop),
       .OUT_CVO_uop      (CVO_uop_wire),
       .OUT_sram_rd_start(sram_rd_start_wire)
@@ -139,6 +145,11 @@ module NPU_top (
   logic        cvo_result_valid_wire;
   logic        cvo_result_ready_wire;
   logic        cvo_disp_busy_wire;
+  logic        store_busy_wire;
+  logic        store_done_wire;
+  logic [`AXI_STREAM_WIDTH-1:0] packed_res_data;
+  logic                         packed_res_valid;
+  logic        packed_res_ready;
 
   mem_dispatcher #() u_mem_dispatcher (
       .clk_core  (clk_core),
@@ -150,9 +161,11 @@ module NPU_top (
       .S_AXIS_ACP_FMAP  (S_AXIS_ACP_FMAP),
       .M_AXIS_ACP_RESULT(M_AXIS_ACP_RESULT),
 
-      .IN_LOAD_uop     (LOAD_uop_wire),
-      .IN_mem_set_uop  (mem_set_uop),
-      .IN_CVO_uop      (CVO_uop_wire),
+      .IN_LOAD_uop       (LOAD_uop_wire),
+      .IN_STORE_uop      (STORE_uop_wire),
+      .IN_store_uop_valid(STORE_uop_valid_wire),
+      .IN_mem_set_uop    (mem_set_uop),
+      .IN_CVO_uop        (CVO_uop_wire),
       .IN_cvo_uop_valid(cvo_op_x64_valid_wire),
 
       .OUT_cvo_data     (cvo_disp_data_wire),
@@ -163,8 +176,14 @@ module NPU_top (
       .IN_cvo_result_valid (cvo_result_valid_wire),
       .OUT_cvo_result_ready(cvo_result_ready_wire),
 
-      .OUT_fifo_full(fifo_full_wire),
-      .OUT_cvo_busy (cvo_disp_busy_wire)
+      .IN_gemm_result_data (packed_res_data),
+      .IN_gemm_result_valid(packed_res_valid),
+      .OUT_gemm_result_ready(packed_res_ready),
+
+      .OUT_fifo_full (fifo_full_wire),
+      .OUT_cvo_busy  (cvo_disp_busy_wire),
+      .OUT_store_busy(store_busy_wire),
+      .OUT_store_done(store_done_wire)
   );
 
   // ===| [4] HP Weight Buffer (CDC FIFO: AXI → Core clock) |====================
@@ -274,9 +293,6 @@ module NPU_top (
   endgenerate
 
   // ===| [8] Result Packer |=====================================================
-  logic [`AXI_STREAM_WIDTH-1:0] packed_res_data;
-  logic                         packed_res_valid;
-
   FROM_gemm_result_packer #() u_packer (
       .clk          (clk_core),
       .rst_n        (rst_n_core),
@@ -284,7 +300,7 @@ module NPU_top (
       .row_res_valid(norm_res_seq_valid),
       .packed_data  (packed_res_data),
       .packed_valid (packed_res_valid),
-      .packed_ready (1'b1),                // downstream accepts unconditionally for now
+      .packed_ready (packed_res_ready),
       .o_busy       ()
   );
 
@@ -392,11 +408,10 @@ module NPU_top (
 
   // ===| Status |================================================================
   // Aggregated NPU busy/done flags — intended for ctrl_npu_frontend IN_enc_stat.
-  // Bit 0 : BUSY  (memory FIFO full | CVO engine active | CVO DMA bridge active)
-  // Bit 1 : DONE  (CVO operation complete pulse)
-  logic [31:0] mmio_npu_stat;
-  assign mmio_npu_stat[0]    = fifo_full_wire | cvo_busy_wire | cvo_disp_busy_wire;
-  assign mmio_npu_stat[1]    = cvo_done_wire;
+  // Bit 0 : BUSY  (memory FIFO full | CVO engine active | CVO DMA bridge active | STORE active)
+  // Bit 1 : DONE  (CVO operation or STORE writeback complete pulse)
+  assign mmio_npu_stat[0]    = fifo_full_wire | cvo_busy_wire | cvo_disp_busy_wire | store_busy_wire;
+  assign mmio_npu_stat[1]    = cvo_done_wire | store_done_wire;
   assign mmio_npu_stat[31:2] = 30'd0;
 
 endmodule

--- a/hw/tb/tb_FROM_mat_result_packer.sv
+++ b/hw/tb/tb_FROM_mat_result_packer.sv
@@ -13,9 +13,8 @@
 //
 //     packed_data @ beat k = {row_res[k*8+7], ..., row_res[k*8]}
 //
-//   packed_ready is held high so the FSM advances every beat without
-//   back-pressure — the goal is functional correctness of the packing
-//   order, not the ready/valid protocol itself.
+//   packed_ready follows a deterministic pseudo-random stall pattern so the
+//   TB checks both packing order and ready/valid hold behavior.
 // ===============================================================================
 
 `include "GLOBAL_CONST.svh"
@@ -57,6 +56,9 @@ module tb_FROM_mat_result_packer;
   logic [127:0] expected_beats [0:N_BEATS-1];
   int           beats_seen = 0;
   int           errors     = 0;
+  int           stall_cycles = 0;
+  int           ready_step = 0;
+  logic         drive_ready;
 
   // Reference packing — must match the DUT's bit-ordering.
   initial begin : build_expected
@@ -76,6 +78,7 @@ module tb_FROM_mat_result_packer;
   initial begin
     rst_n        = 1'b0;
     packed_ready = 1'b0;
+    drive_ready  = 1'b0;
     for (int k = 0; k < ARRAY_SIZE; k++) begin
       row_res[k]       = '0;
       row_res_valid[k] = 1'b0;
@@ -93,7 +96,7 @@ module tb_FROM_mat_result_packer;
     @(posedge clk);
     // Results latched — drop the valids so the FSM reads out the buffer.
     for (int k = 0; k < ARRAY_SIZE; k++) row_res_valid[k] = 1'b0;
-    packed_ready = 1'b1;
+    drive_ready = 1'b1;
 
     // Collect N_BEATS beats with a generous drain window.
     i = 0;
@@ -102,38 +105,59 @@ module tb_FROM_mat_result_packer;
       i++;
     end
 
+    drive_ready = 1'b0;
+    packed_ready = 1'b0;
+
     if (beats_seen != N_BEATS) begin
       $display("FAIL: %0d mismatches over %0d cycles.",
                (N_BEATS - beats_seen) + errors, i);
+    end else if (stall_cycles == 0) begin
+      $display("FAIL: ready/valid stall path was not exercised.");
     end else if (errors == 0) begin
-      $display("PASS: %0d cycles, both channels match golden.", N_BEATS);
+      $display("PASS: %0d beats, packer ready-stall order matches golden.", N_BEATS);
     end else begin
       $display("FAIL: %0d mismatches over %0d cycles.", errors, N_BEATS);
     end
     $finish;
   end
 
-  // Capture every new beat. The DUT keeps packed_valid asserted across the
-  // CHECK_VALID -> SEND_DATA transitions, so a single logical beat persists
-  // on the bus for two clock cycles. We therefore count a beat only when
-  // packed_data actually changes (plus one initial edge).
-  logic [`AXI_STREAM_WIDTH-1:0] prev_packed_data = '0;
-  logic                         seen_first_beat  = 1'b0;
+  always @(negedge clk) begin
+    if (!rst_n || !drive_ready) begin
+      packed_ready = 1'b0;
+      ready_step   = 0;
+    end else begin
+      // Repeatable stall pattern with both single- and multi-cycle bubbles.
+      packed_ready = ((ready_step % 5) != 1) && ((ready_step % 7) != 3);
+      ready_step++;
+    end
+  end
+
+  // Capture every valid/ready beat and ensure data stays stable while stalled.
+  logic [`AXI_STREAM_WIDTH-1:0] stalled_data = '0;
+  logic                         was_stalled  = 1'b0;
 
   always_ff @(posedge clk) begin
     if (rst_n && packed_valid && packed_ready) begin
-      if (!seen_first_beat || packed_data !== prev_packed_data) begin
-        if (beats_seen < N_BEATS) begin
-          if (packed_data !== expected_beats[beats_seen]) begin
-            errors++;
-            $display("[%0t] beat %0d mismatch:\n got=%h\n exp=%h",
-                     $time, beats_seen, packed_data, expected_beats[beats_seen]);
-          end
-          beats_seen++;
+      if (beats_seen < N_BEATS) begin
+        if (packed_data !== expected_beats[beats_seen]) begin
+          errors++;
+          $display("[%0t] beat %0d mismatch:\n got=%h\n exp=%h",
+                   $time, beats_seen, packed_data, expected_beats[beats_seen]);
         end
-        prev_packed_data <= packed_data;
-        seen_first_beat  <= 1'b1;
+        beats_seen++;
       end
+      was_stalled <= 1'b0;
+    end else if (rst_n && packed_valid && !packed_ready) begin
+      stall_cycles++;
+      if (was_stalled && packed_data !== stalled_data) begin
+        errors++;
+        $display("[%0t] stalled data changed: got=%h prev=%h",
+                 $time, packed_data, stalled_data);
+      end
+      stalled_data <= packed_data;
+      was_stalled  <= 1'b1;
+    end else if (rst_n && !packed_valid) begin
+      was_stalled <= 1'b0;
     end
   end
 

--- a/hw/tb/tb_mem_dispatcher_shape_lookup.sv
+++ b/hw/tb/tb_mem_dispatcher_shape_lookup.sv
@@ -36,6 +36,8 @@ module tb_mem_dispatcher_shape_lookup;
   axis_if #(.DATA_WIDTH(128)) m_axis_acp_result ();
 
   memory_control_uop_t load_uop;
+  memory_control_uop_t store_uop;
+  logic                store_uop_valid;
   memory_set_uop_t     mem_set_uop;
   cvo_control_uop_t    cvo_uop;
   logic                cvo_uop_valid;
@@ -46,8 +48,17 @@ module tb_mem_dispatcher_shape_lookup;
   logic [15:0] cvo_result;
   logic        cvo_result_valid;
   logic        cvo_result_ready;
+  logic [127:0] gemm_result_data;
+  logic        gemm_result_valid;
+  logic        gemm_result_ready;
   logic        fifo_full;
   logic        cvo_busy;
+  logic        store_busy;
+  logic        store_done;
+  logic        tb_force_direct_en;
+  logic        tb_force_direct_we;
+  logic [16:0] tb_force_direct_addr;
+  logic [127:0] tb_force_direct_wdata;
 
   mem_dispatcher dut (
       .clk_core            (clk_core),
@@ -57,6 +68,8 @@ module tb_mem_dispatcher_shape_lookup;
       .S_AXIS_ACP_FMAP     (s_axis_acp_fmap),
       .M_AXIS_ACP_RESULT   (m_axis_acp_result),
       .IN_LOAD_uop         (load_uop),
+      .IN_STORE_uop        (store_uop),
+      .IN_store_uop_valid  (store_uop_valid),
       .IN_mem_set_uop      (mem_set_uop),
       .IN_CVO_uop          (cvo_uop),
       .IN_cvo_uop_valid    (cvo_uop_valid),
@@ -66,13 +79,21 @@ module tb_mem_dispatcher_shape_lookup;
       .IN_cvo_result       (cvo_result),
       .IN_cvo_result_valid (cvo_result_valid),
       .OUT_cvo_result_ready(cvo_result_ready),
+      .IN_gemm_result_data (gemm_result_data),
+      .IN_gemm_result_valid(gemm_result_valid),
+      .OUT_gemm_result_ready(gemm_result_ready),
       .OUT_fifo_full       (fifo_full),
-      .OUT_cvo_busy        (cvo_busy)
+      .OUT_cvo_busy        (cvo_busy),
+      .OUT_store_busy      (store_busy),
+      .OUT_store_done      (store_done)
   );
 
   // ===| Scoreboard |===========================================================
+  localparam int StoreBeats = 4;
+
   int errors = 0;
   int checks = 0;
+  logic [127:0] store_expected [0:StoreBeats-1];
 
   function automatic logic [16:0] ceil_words(
       input int unsigned x_val,
@@ -107,6 +128,19 @@ module tb_mem_dispatcher_shape_lookup;
           b_value    : 16'd0,
           c_value    : 16'd0
       };
+    end
+  endtask
+
+  task automatic set_store_idle;
+    begin
+      store_uop = '{
+          data_dest      : from_L2_to_CVO,
+          dest_addr      : '0,
+          src_addr       : '0,
+          shape_ptr_addr : '0,
+          async          : SYNC_OP
+      };
+      store_uop_valid = 1'b0;
     end
   endtask
 
@@ -249,18 +283,213 @@ module tb_mem_dispatcher_shape_lookup;
     end
   endtask
 
+  task automatic issue_gemm_store_writeback(
+      input dest_addr_t dest_addr,
+      input ptr_addr_t shape_ptr
+  );
+    bit done_seen;
+    int wait_cycles;
+    begin
+      set_load_idle();
+      set_memset_idle();
+      store_uop = '{
+          data_dest      : from_GEMM_res_to_L2,
+          dest_addr      : dest_addr,
+          src_addr       : '0,
+          shape_ptr_addr : shape_ptr,
+          async          : SYNC_OP
+      };
+      store_uop_valid = 1'b1;
+      @(posedge clk_core);
+      #1;
+      store_uop_valid = 1'b0;
+
+      checks++;
+      if (store_busy !== 1'b1) begin
+        errors++;
+        $display("[%0t] mismatch STORE: store_busy=%0b exp 1", $time, store_busy);
+      end
+      checks++;
+      if (dut.GemmStoreWords !== StoreBeats) begin
+        errors++;
+        $display("[%0t] mismatch STORE word count: got=%0d exp=%0d",
+                 $time, dut.GemmStoreWords, StoreBeats);
+      end
+
+      done_seen = 1'b0;
+      for (int beat = 0; beat < StoreBeats; beat++) begin
+        bit accepted;
+        accepted = 1'b0;
+        wait_cycles = 0;
+        gemm_result_data  = store_expected[beat];
+        gemm_result_valid = 1'b1;
+
+        while (gemm_result_ready !== 1'b1 && wait_cycles < 200) begin
+          @(posedge clk_core);
+          #1;
+          wait_cycles++;
+        end
+        if (gemm_result_ready === 1'b1) begin
+          @(posedge clk_core);
+          #1;
+          accepted = 1'b1;
+          if (store_done === 1'b1) done_seen = 1'b1;
+        end
+
+        checks++;
+        if (!accepted) begin
+          errors++;
+          $display("[%0t] timeout STORE beat %0d ready", $time, beat);
+          $display("[%0t] STORE debug: active=%0b count=%0d words=%0d port_ready=%0b cvo_busy=%0b npu_busy=%0b done_pending=%0b l2_we=%0b",
+                   $time,
+                   dut.store_active,
+                   dut.store_word_count,
+                   dut.GemmStoreWords,
+                   dut.store_port_ready,
+                   dut.cvo_bridge_busy,
+                   dut.npu_is_busy_wire,
+                   dut.store_done_pending,
+                   dut.store_l2_we);
+        end else begin
+          checks++;
+          if (dut.final_npu_direct_en !== 1'b1 ||
+              dut.final_npu_we        !== 1'b1 ||
+              dut.final_npu_addr      !== dest_addr + 17'(beat) ||
+              dut.final_npu_wdata     !== store_expected[beat] ||
+              dut.u_l2_cache.uram_npu_we    !== 1'b1 ||
+              dut.u_l2_cache.uram_npu_addr  !== dest_addr + 17'(beat) ||
+              dut.u_l2_cache.uram_npu_wdata !== store_expected[beat]) begin
+            errors++;
+            $display("[%0t] mismatch STORE L2 beat %0d: en=%0b we=%0b addr=%0d data=%032h uram_we=%0b uram_addr=%0d uram_data=%032h exp_addr=%0d exp_data=%032h",
+                     $time, beat,
+                     dut.final_npu_direct_en,
+                     dut.final_npu_we,
+                     dut.final_npu_addr,
+                     dut.final_npu_wdata,
+                     dut.u_l2_cache.uram_npu_we,
+                     dut.u_l2_cache.uram_npu_addr,
+                     dut.u_l2_cache.uram_npu_wdata,
+                     dest_addr + 17'(beat),
+                     store_expected[beat]);
+          end
+        end
+      end
+
+      gemm_result_valid = 1'b0;
+      gemm_result_data  = '0;
+
+      wait_cycles = 0;
+      while (!done_seen && wait_cycles < 20) begin
+        @(posedge clk_core);
+        #1;
+        if (store_done === 1'b1) done_seen = 1'b1;
+        wait_cycles++;
+      end
+
+      checks++;
+      if (!done_seen) begin
+        errors++;
+        $display("[%0t] timeout STORE done pulse", $time);
+      end
+
+      checks++;
+      if (store_busy !== 1'b0) begin
+        errors++;
+        $display("[%0t] mismatch STORE: store_busy=%0b exp 0 after done", $time, store_busy);
+      end
+
+      for (int beat = 0; beat < StoreBeats; beat++) begin
+        tb_force_direct_en    = 1'b1;
+        tb_force_direct_we    = 1'b0;
+        tb_force_direct_addr  = dest_addr + 17'(beat);
+        tb_force_direct_wdata = '0;
+        force dut.u_l2_cache.IN_npu_direct_en    = tb_force_direct_en;
+        force dut.u_l2_cache.IN_npu_direct_we    = tb_force_direct_we;
+        force dut.u_l2_cache.IN_npu_direct_addr  = tb_force_direct_addr;
+        force dut.u_l2_cache.IN_npu_direct_wdata = tb_force_direct_wdata;
+        repeat (5) @(posedge clk_core);
+        #1;
+
+        checks++;
+        if (dut.npu_l2_rdata !== store_expected[beat]) begin
+          errors++;
+          $display("[%0t] mismatch L2 direct read beat %0d: got=%032h exp=%032h",
+                   $time, beat, dut.npu_l2_rdata, store_expected[beat]);
+        end
+
+        release dut.u_l2_cache.IN_npu_direct_en;
+        release dut.u_l2_cache.IN_npu_direct_we;
+        release dut.u_l2_cache.IN_npu_direct_addr;
+        release dut.u_l2_cache.IN_npu_direct_wdata;
+        tb_force_direct_en    = 1'b0;
+        tb_force_direct_we    = 1'b0;
+        tb_force_direct_addr  = '0;
+        tb_force_direct_wdata = '0;
+      end
+
+    end
+  endtask
+
+  task automatic issue_l2_to_host_readback(
+      input src_addr_t src_addr,
+      input ptr_addr_t shape_ptr
+  );
+    logic [16:0] exp_end;
+    begin
+      exp_end = src_addr + 17'(StoreBeats);
+      set_memset_idle();
+      set_store_idle();
+      load_uop = '{
+          data_dest      : from_L2_to_host,
+          dest_addr      : '0,
+          src_addr       : src_addr,
+          shape_ptr_addr : shape_ptr,
+          async          : SYNC_OP
+      };
+      @(posedge clk_core);
+      #1;
+
+      checks++;
+      if (dut.acp_rx_start !== 1'b1 ||
+          dut.acp_uop.write_en !== 1'b0 ||
+          dut.acp_uop.base_addr !== src_addr ||
+          dut.acp_uop.end_addr  !== exp_end) begin
+        errors++;
+        $display("[%0t] mismatch STORE L2->host descriptor: start=%0b we=%0b base=%0d end=%0d exp start=1 we=0 base=%0d end=%0d",
+                 $time,
+                 dut.acp_rx_start,
+                 dut.acp_uop.write_en,
+                 dut.acp_uop.base_addr,
+                 dut.acp_uop.end_addr,
+                 src_addr,
+                 exp_end);
+      end
+
+      set_load_idle();
+      @(posedge clk_core);
+      #1;
+    end
+  endtask
+
   // ===| Stimulus |=============================================================
   initial begin
     rst_n_core = 1'b0;
     rst_axi_n  = 1'b0;
 
     set_load_idle();
+    set_store_idle();
     set_memset_idle();
     cvo_uop             = '0;
     cvo_uop_valid       = 1'b0;
     cvo_data_ready      = 1'b1;
     cvo_result          = '0;
     cvo_result_valid    = 1'b0;
+    gemm_result_data    = '0;
+    gemm_result_valid   = 1'b0;
+    tb_force_direct_en    = 1'b0;
+    tb_force_direct_we    = 1'b0;
+    tb_force_direct_addr  = '0;
+    tb_force_direct_wdata = '0;
     s_axis_acp_fmap.tdata  = '0;
     s_axis_acp_fmap.tvalid = 1'b0;
     s_axis_acp_fmap.tlast  = 1'b0;
@@ -273,8 +502,17 @@ module tb_mem_dispatcher_shape_lookup;
     repeat (3) @(posedge clk_core);
     #1;
 
+    store_expected[0] = 128'h0007_0006_0005_0004_0003_0002_0001_0000;
+    store_expected[1] = 128'h1007_1006_1005_1004_1003_1002_1001_1000;
+    store_expected[2] = 128'h2007_2006_2005_2004_2003_2002_2001_2000;
+    store_expected[3] = 128'h3007_3006_3005_3004_3003_3002_3001_3000;
+
     program_fmap_shape(6'd3, 16'd3, 16'd5, 16'd5);  // 75 elems -> 10 words
     program_fmap_shape(6'd9, 16'd4, 16'd4, 16'd4);  // 64 elems -> 8 words
+    program_fmap_shape(6'd12, 16'd1, 16'd1, 16'd32); // 32 elems -> 4 words
+
+    issue_gemm_store_writeback(17'd512, 6'd12);
+    issue_l2_to_host_readback(17'd512, 6'd12);
 
     issue_acp_load("host_to_L2 uses ptr3",
                    from_host_to_L2,
@@ -309,7 +547,7 @@ module tb_mem_dispatcher_shape_lookup;
                    ceil_words(4, 4, 4));
 
     if (errors == 0) begin
-      $display("PASS: %0d cycles, mem_dispatcher shape lookup matches golden.", checks);
+      $display("PASS: %0d cycles, mem_dispatcher shape/store writeback matches golden.", checks);
     end else begin
       $display("FAIL: %0d mismatches over %0d checks.", errors, checks);
     end

--- a/hw/tb/tb_v002_runtime_smoke_program.sv
+++ b/hw/tb/tb_v002_runtime_smoke_program.sv
@@ -58,6 +58,7 @@ module tb_v002_runtime_smoke_program;
   GEMV_control_uop_t   OUT_GEMV_uop;
   memory_control_uop_t OUT_LOAD_uop;
   memory_control_uop_t OUT_STORE_uop;
+  logic                OUT_STORE_uop_valid;
   memory_set_uop_t     OUT_mem_set_uop;
   cvo_control_uop_t    OUT_CVO_uop;
   logic                OUT_sram_rd_start;
@@ -75,6 +76,7 @@ module tb_v002_runtime_smoke_program;
       .OUT_GEMV_uop           (OUT_GEMV_uop),
       .OUT_LOAD_uop           (OUT_LOAD_uop),
       .OUT_STORE_uop          (OUT_STORE_uop),
+      .OUT_STORE_uop_valid    (OUT_STORE_uop_valid),
       .OUT_mem_set_uop        (OUT_mem_set_uop),
       .OUT_CVO_uop            (OUT_CVO_uop),
       .OUT_sram_rd_start      (OUT_sram_rd_start)
@@ -182,9 +184,11 @@ module tb_v002_runtime_smoke_program;
       input int index,
       input data_route_e exp_route,
       input dest_addr_t exp_dest,
-      input ptr_addr_t exp_shape_ptr
+      input ptr_addr_t exp_shape_ptr,
+      input logic exp_valid
   );
     begin
+      expect_bit($sformatf("scheduler[%0d].store_valid", index), OUT_STORE_uop_valid, exp_valid);
       checks++;
       if (OUT_STORE_uop.data_dest      !== exp_route ||
           OUT_STORE_uop.dest_addr      !== exp_dest ||
@@ -204,19 +208,22 @@ module tb_v002_runtime_smoke_program;
       case (index)
         0: begin
           expect_memset(index, data_to_fmap_shape, 6'd3, 16'd1, 16'd1, 16'd9);
+          expect_bit("scheduler[0].store_valid", OUT_STORE_uop_valid, 1'b0);
           expect_bit("scheduler[0].sram_start", OUT_sram_rd_start, 1'b0);
         end
         1: begin
           expect_memset(index, data_to_fmap_shape, 6'd9, 16'd4, 16'd4, 16'd4);
+          expect_bit("scheduler[1].store_valid", OUT_STORE_uop_valid, 1'b0);
           expect_bit("scheduler[1].sram_start", OUT_sram_rd_start, 1'b0);
         end
         2: begin
           expect_load(index, from_host_to_L2, 17'd100, 17'd0, 6'd3, SYNC_OP);
+          expect_bit("scheduler[2].store_valid", OUT_STORE_uop_valid, 1'b0);
           expect_bit("scheduler[2].sram_start", OUT_sram_rd_start, 1'b0);
         end
         3: begin
           expect_load(index, from_L2_to_L1_GEMM, 17'd0, 17'd300, 6'd3, SYNC_OP);
-          expect_store(index, from_GEMM_res_to_L2, 17'd512, 6'd3);
+          expect_store(index, from_GEMM_res_to_L2, 17'd512, 6'd3, 1'b1);
           expect_bit("scheduler[3].gemm.w_scale", OUT_GEMM_uop.flags.w_scale, 1'b1);
           expect_equal64("scheduler[3].gemm.size_lane",
                          {53'd0, OUT_GEMM_uop.size_ptr_addr, OUT_GEMM_uop.parallel_lane},
@@ -225,7 +232,7 @@ module tb_v002_runtime_smoke_program;
         end
         4: begin
           expect_load(index, from_L2_to_L1_GEMV, 17'd0, 17'd400, 6'd9, SYNC_OP);
-          expect_store(index, from_GEMV_res_to_L2, 17'd768, 6'd9);
+          expect_store(index, from_GEMV_res_to_L2, 17'd768, 6'd9, 1'b1);
           expect_bit("scheduler[4].gemv.accm", OUT_GEMV_uop.flags.accm, 1'b1);
           expect_equal64("scheduler[4].gemv.size_lane",
                          {53'd0, OUT_GEMV_uop.size_ptr_addr, OUT_GEMV_uop.parallel_lane},
@@ -234,7 +241,7 @@ module tb_v002_runtime_smoke_program;
         end
         5: begin
           expect_load(index, from_L2_to_CVO, 17'd0, 17'd768, 6'd0, SYNC_OP);
-          expect_store(index, from_CVO_res_to_L2, 17'd896, 6'd0);
+          expect_store(index, from_CVO_res_to_L2, 17'd896, 6'd0, 1'b1);
           checks++;
           if (OUT_CVO_uop.cvo_func !== CVO_REDUCE_SUM ||
               OUT_CVO_uop.src_addr !== 17'd768 ||
@@ -251,6 +258,7 @@ module tb_v002_runtime_smoke_program;
         end
         6: begin
           expect_load(index, from_L2_to_host, 17'd0, 17'd896, 6'd3, SYNC_OP);
+          expect_bit("scheduler[6].store_valid", OUT_STORE_uop_valid, 1'b0);
           expect_bit("scheduler[6].sram_start", OUT_sram_rd_start, 1'b0);
         end
         default: begin


### PR DESCRIPTION
Summary:
- Fixes FROM_gemm_result_packer so packed data is driven before valid and held stable through ready stalls.
- Adds STORE uop valid plumbing from Global_Scheduler through NPU_top into mem_dispatcher.
- Adds a GEMM STORE writeback path that backpressures the packer, writes 4 packed 128-bit beats into L2, and raises a STORE done pulse into mmio_npu_stat / AXIL_STAT_OUT.
- Extends packer, dispatcher, and runtime smoke TB coverage for ready stalls, STORE writeback, L2 direct readback, L2-to-host descriptor generation, and STORE uop valid pulses.

Evidence:
- bash -n hw/sim/run_verification.sh scripts/v002/run-local-candidate.sh scripts/v002/claim-scan.sh scripts/v002/artifact-safety-check.sh -> PASS.
- git diff --check -> PASS.
- shellcheck -> NOT_AVAILABLE locally (command not found); marked and proceeded.
- PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --tb tb_FROM_mat_result_packer -> PASS: 4 beats, packer ready-stall order matches golden.
- PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --tb tb_mem_dispatcher_shape_lookup -> PASS: 29 cycles, mem_dispatcher shape/store writeback matches golden.
- PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --tb tb_v002_runtime_smoke_program -> PASS: 7 generated runtime instructions decoded and scheduled.
- PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --full -> PASS: 11 passed, 0 failed.
- Vivado filelist xvlog compile -> PASS.
- scripts/v002/claim-scan.sh -> PASS: UNSUPPORTED_CLAIM_FOUND=no.
- scripts/v002/artifact-safety-check.sh -> PASS: ARTIFACT_SAFETY=PASS.
- Commit and push hooks ran with PCCXAI_GUARD_FORCE=1 -> PASS.

Claim guard:
- No CVO_CORE / CVO SFU files touched.
- No synthesis, implementation, timing, board, or throughput claim is made.
- STORE L2 direct readback uses a TB harness force to observe the shared L2 port; this is xsim evidence only.

Refs #17, #37.
Resolves #39.