### PR TITLE
tb(gemm): re-enable fmap staggered-delay after int8 transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ PASS verdict rules, and the evidence checklist.
 | `tb_shape_const_ram`                | `shape_const_ram` (reset / write / read contract)        |   15 |
 | `tb_mem_dispatcher_shape_lookup`    | `mem_dispatcher` + `shape_const_ram` LOAD pointer routing |   11 |
 | `tb_GEMM_dsp_packer_sign_recovery` | `GEMM_dsp_packer` + `GEMM_sign_recovery` (W4A8 dual-MAC) | 1024 |
-| `tb_GEMM_fmap_staggered_delay`     | `GEMM_fmap_staggered_dispatch` (column stagger)          |   65 |
+| `tb_GEMM_fmap_staggered_delay`     | `GEMM_fmap_staggered_dispatch` (W4A8 column stagger)     |  780 |
 | `tb_GEMM_weight_dispatcher`        | `GEMM_weight_dispatcher` (upper / lower AND-valid)      |  128 |
 | `tb_mat_result_normalizer`         | `mat_result_normalizer` (48 b 2sC → BF16 4-stage)       |  256 |
 | `tb_FROM_mat_result_packer`        | `FROM_gemm_result_packer` (32 lanes → 4×128 b FSM)      |    4 |

--- a/hw/tb/tb_GEMM_fmap_staggered_delay.sv
+++ b/hw/tb/tb_GEMM_fmap_staggered_delay.sv
@@ -1,22 +1,37 @@
 `timescale 1ns / 1ps
+`include "GLOBAL_CONST.svh"
 
 // ===============================================================================
 // Testbench: tb_GEMM_fmap_staggered_delay
 //
 // Purpose
 // -------
-//   Smoke-validates the current GEMM_fmap_staggered_dispatch contract:
-//   column c emits its own fmap/data-valid/instruction stream c clocks after
-//   column 0. This is a focused xsim harness for the active RTL interface; it
-//   does not change arithmetic behavior or claim full systolic integration.
+//   Smoke-validates the W4A8 GEMM_fmap_staggered_dispatch contract:
+//   column c emits its own signed INT8 fmap/data-valid/instruction stream c
+//   clocks after column 0. The scale sideband is represented by the v002.1
+//   ACT_SCALE_EMAX_BFP policy chosen in PR #80: the activation bytes are
+//   already quantized INT8, while e_max travels in the GEMM_systolic_top
+//   SYSTOLIC_TOTAL_LATENCY pipe for later normalization.
+//
+// Latency table
+// -------------
+//   Signal group                  RTL/TB-visible source at sample cycle n
+//   row_data/row_valid            source cycle n - column
+//   row_inst/row_inst_valid       source cycle n - column
+//   e_max sideband                source cycle n - (SYSTOLIC_TOTAL_LATENCY - 1)
+//
+//   Column 0 is registered once internally but has zero relative stagger in the
+//   cycle-indexed golden above. Columns 1..N are checked against the same
+//   relative diagonal wave-front seen by the systolic array.
 // ===============================================================================
 
 module tb_GEMM_fmap_staggered_delay;
 
-  localparam int FmapWidth    = 13;
-  localparam int FmapOutWidth = 13;
-  localparam int ArraySize    = 5;
-  localparam int SampleCount  = ArraySize + 6;
+  localparam int FmapWidth             = 8;
+  localparam int FmapOutWidth          = 8;
+  localparam int ArraySize             = 5;
+  localparam int SystolicTotalLatency  = `SYSTOLIC_TOTAL_LATENCY;
+  localparam int SampleCount           = SystolicTotalLatency + ArraySize + 8;
 
   logic clk;
   logic rst_n;
@@ -32,6 +47,10 @@ module tb_GEMM_fmap_staggered_delay;
   logic                    row_valid     [0:ArraySize-1];
   logic [             2:0] row_inst      [0:ArraySize-1];
   logic                    row_inst_valid[0:ArraySize-1];
+
+  logic [`BF16_EXP_WIDTH-1:0] emax_in     [0:ArraySize-1];
+  logic [`BF16_EXP_WIDTH-1:0] emax_pipe   [0:ArraySize-1][0:SystolicTotalLatency-1];
+  logic [`BF16_EXP_WIDTH-1:0] delayed_emax[0:ArraySize-1];
 
   GEMM_fmap_staggered_dispatch #(
       .fmap_width    (FmapWidth),
@@ -54,10 +73,29 @@ module tb_GEMM_fmap_staggered_delay;
   int checks = 0;
 
   function automatic logic [FmapOutWidth-1:0] sample_data(input int cycle, input int col);
+    int sel;
     if (cycle < 0) begin
       sample_data = '0;
     end else begin
-      sample_data = ((cycle + 1) * 16) + col;
+      sel = (cycle + (col * 3)) % 16;
+      case (sel)
+        0:  sample_data = 8'h80; // -128
+        1:  sample_data = 8'h81; // -127
+        2:  sample_data = 8'hc0; //  -64
+        3:  sample_data = 8'hef; //  -17
+        4:  sample_data = 8'hff; //   -1
+        5:  sample_data = 8'h00;
+        6:  sample_data = 8'h01;
+        7:  sample_data = 8'h07;
+        8:  sample_data = 8'h0f;
+        9:  sample_data = 8'h1f;
+        10: sample_data = 8'h3f;
+        11: sample_data = 8'h40;
+        12: sample_data = 8'h55;
+        13: sample_data = 8'h6a;
+        14: sample_data = 8'h7e;
+        default: sample_data = 8'h7f;
+      endcase
     end
   endfunction
 
@@ -65,7 +103,7 @@ module tb_GEMM_fmap_staggered_delay;
     if (cycle < 0) begin
       sample_valid = 1'b0;
     end else begin
-      sample_valid = (cycle != 2) && (cycle != 7);
+      sample_valid = (cycle % 11 != 3) && (cycle % 17 != 8);
     end
   endfunction
 
@@ -81,14 +119,46 @@ module tb_GEMM_fmap_staggered_delay;
     if (cycle < 0) begin
       sample_inst_valid = 1'b0;
     end else begin
-      sample_inst_valid = (cycle != 3) && (cycle != 8);
+      sample_inst_valid = (cycle % 13 != 4) && (cycle % 19 != 9);
     end
   endfunction
+
+  function automatic logic [`BF16_EXP_WIDTH-1:0] sample_emax(input int cycle, input int col);
+    if (cycle < 0) begin
+      sample_emax = '0;
+    end else begin
+      sample_emax = 8'd118 + ((cycle + (col * 5)) % 10);
+    end
+  endfunction
+
+  always_ff @(posedge clk) begin
+    if (!rst_n) begin
+      for (int col = 0; col < ArraySize; col++) begin
+        for (int d = 0; d < SystolicTotalLatency; d++) begin
+          emax_pipe[col][d] <= '0;
+        end
+      end
+    end else begin
+      for (int col = 0; col < ArraySize; col++) begin
+        emax_pipe[col][0] <= emax_in[col];
+        for (int d = 1; d < SystolicTotalLatency; d++) begin
+          emax_pipe[col][d] <= emax_pipe[col][d-1];
+        end
+      end
+    end
+  end
+
+  always_comb begin
+    for (int col = 0; col < ArraySize; col++) begin
+      delayed_emax[col] = emax_pipe[col][SystolicTotalLatency-1];
+    end
+  end
 
   task automatic drive_sample(input int cycle);
     begin
       for (int col = 0; col < ArraySize; col++) begin
         fmap_in[col] = sample_data(cycle, col);
+        emax_in[col] = sample_emax(cycle, col);
       end
       fmap_valid        = sample_valid(cycle);
       global_inst       = sample_inst(cycle);
@@ -104,8 +174,9 @@ module tb_GEMM_fmap_staggered_delay;
 
       if (row_data[col] !== sample_data(src_cycle, col)) begin
         errors++;
-        $display("[%0t] data mismatch cycle=%0d col=%0d got=%0d exp=%0d",
-                 $time, cycle, col, row_data[col], sample_data(src_cycle, col));
+        $display("[%0t] data mismatch cycle=%0d col=%0d got_raw=0x%02h got_s=%0d exp_raw=0x%02h exp_s=%0d",
+                 $time, cycle, col, row_data[col], $signed(row_data[col]),
+                 sample_data(src_cycle, col), $signed(sample_data(src_cycle, col)));
       end
 
       if (row_valid[col] !== sample_valid(src_cycle)) begin
@@ -128,6 +199,21 @@ module tb_GEMM_fmap_staggered_delay;
     end
   endtask
 
+  task automatic expect_emax(input int cycle, input int col);
+    int src_cycle;
+    begin
+      src_cycle = cycle - (SystolicTotalLatency - 1);
+      checks++;
+
+      if (delayed_emax[col] !== sample_emax(src_cycle, col)) begin
+        errors++;
+        $display("[%0t] emax mismatch cycle=%0d col=%0d got=%0d exp=%0d latency=%0d",
+                 $time, cycle, col, delayed_emax[col],
+                 sample_emax(src_cycle, col), SystolicTotalLatency);
+      end
+    end
+  endtask
+
   task automatic expect_reset_zero(input string tag);
     begin
       for (int col = 0; col < ArraySize; col++) begin
@@ -135,11 +221,12 @@ module tb_GEMM_fmap_staggered_delay;
         if (row_data[col] !== '0 ||
             row_valid[col] !== 1'b0 ||
             row_inst[col] !== 3'b000 ||
-            row_inst_valid[col] !== 1'b0) begin
+            row_inst_valid[col] !== 1'b0 ||
+            delayed_emax[col] !== '0) begin
           errors++;
-          $display("[%0t] reset mismatch %s col=%0d data=%0d valid=%0b inst=%0b inst_valid=%0b",
+          $display("[%0t] reset mismatch %s col=%0d data=%0d valid=%0b inst=%0b inst_valid=%0b emax=%0d",
                    $time, tag, col, row_data[col], row_valid[col],
-                   row_inst[col], row_inst_valid[col]);
+                   row_inst[col], row_inst_valid[col], delayed_emax[col]);
         end
       end
     end
@@ -152,6 +239,7 @@ module tb_GEMM_fmap_staggered_delay;
     global_inst_valid = 1'b0;
     for (int col = 0; col < ArraySize; col++) begin
       fmap_in[col] = '0;
+      emax_in[col] = '0;
     end
 
     repeat (3) @(posedge clk);
@@ -166,6 +254,7 @@ module tb_GEMM_fmap_staggered_delay;
       #1;
       for (int col = 0; col < ArraySize; col++) begin
         expect_col(cycle, col);
+        expect_emax(cycle, col);
       end
     end
 
@@ -175,7 +264,8 @@ module tb_GEMM_fmap_staggered_delay;
     expect_reset_zero("second");
 
     if (errors == 0) begin
-      $display("PASS: %0d checks, fmap staggered delay matches golden.", checks);
+      $display("PASS: %0d cycles, TB_PASSED columns=%0d checks=%0d golden=sv_functions act_scale_policy=ACT_SCALE_EMAX_BFP systolic_total_latency=%0d.",
+               SampleCount, ArraySize, checks, SystolicTotalLatency);
     end else begin
       $display("FAIL: %0d mismatches over %0d checks.", errors, checks);
     end


### PR DESCRIPTION
Summary:
- Re-enables `tb_GEMM_fmap_staggered_delay` coverage for the INT8 transition by switching the focused fmap stagger harness to signed W4A8 activation bytes.
- Adds a TB-local latency table and deterministic SV golden functions for data, valid, inst, inst_valid, and ACT_SCALE_EMAX_BFP e_max sideband alignment.
- Updates the README testbench matrix count for the new PASS verdict.

Golden: SystemVerilog functions in `hw/tb/tb_GEMM_fmap_staggered_delay.sv`.

Validation:
- `bash -n hw/sim/run_verification.sh scripts/v002/run-local-candidate.sh scripts/v002/claim-scan.sh scripts/v002/artifact-safety-check.sh` -> PASS.
- `git diff --check` -> PASS.
- `git diff --cached --check` -> PASS.
- `shellcheck` -> MISSING locally; marked shellcheck-missing and proceeded per task instruction.
- `PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --tb tb_GEMM_fmap_staggered_delay` -> PASS: 77 cycles, TB_PASSED columns=5 checks=780 golden=sv_functions act_scale_policy=ACT_SCALE_EMAX_BFP systolic_total_latency=64.
- `PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --full` -> PASS: 11 passed, 0 failed.
- `scripts/v002/claim-scan.sh` -> PASS: `UNSUPPORTED_CLAIM_FOUND=no`.
- `scripts/v002/artifact-safety-check.sh` -> PASS: `ARTIFACT_SAFETY=PASS`.
- Commit and push hooks ran; pre-push guard reported only allowlisted README timing-closure wording.

Claim guard:
- No CVO_CORE / CVO SFU files touched.
- No arithmetic RTL changed.
- No synthesis, implementation, timing, board, or throughput claim is made.

Refs #28, #80.
Resolves #28.
