### PR TITLE
docs(evidence): v002.1 evidence inventory

### DIFF
--- a/docs/evidence/v002.1-evidence-inventory.md
+++ b/docs/evidence/v002.1-evidence-inventory.md
@@ -1,0 +1,168 @@
+# v002.1 Evidence Inventory
+
+Date: 2026-05-07
+Scope: issue [#58](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/issues/58)
+
+This is an evidence inventory for the v002.1 release-preparation path. It
+does not claim release readiness, timing closure, bitstream availability,
+KV260 inference, Gemma 3N E4B hardware execution, or measured throughput.
+Each item below is either a recorded evidence input, a path where evidence
+is expected to land, or a gate that remains open until a later run records
+the corresponding artifact.
+
+See also:
+
+- Release evidence checklist: [`docs/RELEASE_EVIDENCE_CHECKLIST.md`](../RELEASE_EVIDENCE_CHECKLIST.md)
+- xsim workflow: [`docs/SIMULATION.md`](../SIMULATION.md)
+- timing evidence wording: [`docs/TIMING_EVIDENCE.md`](../TIMING_EVIDENCE.md)
+- KV260 bring-up checklist: [`docs/KV260_BRINGUP.md`](../KV260_BRINGUP.md)
+- KV260/Gemma handoff: [`docs/GEMMA3N_HANDOFF.md`](../GEMMA3N_HANDOFF.md)
+- Runnable-candidate summary: [`evidence/v002/FINAL_CANDIDATE_SUMMARY.md`](../../evidence/v002/FINAL_CANDIDATE_SUMMARY.md)
+
+## Current Evidence State
+
+Issue #58 was opened as a v0.2.0 release evidence tracker. Its 2026-05-03
+maintainer audit comment supersedes the stale original simulation state:
+
+- xsim/full local runner evidence had advanced to 11 passed / 0 failed in
+  the then-current v002 validation flow.
+- `tb_GEMM_fmap_staggered_delay` was no longer the old blocker.
+- Vivado compile/top elaboration evidence existed from the local candidate
+  flow.
+- Recent local Vivado synthesis attempts produced timing-report context,
+  but timing was not closed.
+- Timing status must be worded as `TIMING_REPORT_PRESENT_NOT_CLOSED` when a
+  report exists without closure evidence.
+- KV260 smoke/runtime remained blocked until board, model, bitstream, and
+  runtime inputs and logs exist.
+- Throughput remained `MEASUREMENT_NOT_AVAILABLE`; 20 tok/s is a target
+  only.
+
+After that audit comment, PR-body evidence in
+[#94](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/94) reports a
+full xsim regression result of 12 passed / 0 failed. This inventory records
+that PR evidence; it does not rerun xsim and does not turn simulation PASS
+results into synthesis, timing, board, or release claims.
+
+## PR Evidence Stack
+
+The following PRs are the requested v002.1 evidence stack for this
+inventory. The evidence notes are copied as PR-body summaries and should be
+rechecked against GitHub before tagging.
+
+| PR | Area | Evidence recorded | Claim guard |
+| --- | --- | --- | --- |
+| [#80](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/80) | v002.1 spec decisions | Documents `ACT_SCALE_EMAX_BFP`, `K_DRAIN_LIMIT=1024`, and DSP baseline constants. | Docs-only; no RTL or verification run claimed. |
+| [#81](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/81) | GEMM W4A8 DSP dual-MAC TB | `tb_gemm_w4a8_dsp_dual_mac` PASS: 25 cycles, 25 cases, 16 representative vectors, 6 accumulation lengths. | xsim-only; DSP48E2 inference and LUT-multiplier fallback were not rerun by this TB. |
+| [#82](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/82) | KV260 bitstream runbook and BD scaffold | Adds `docs/runbooks/v002.1-bitstream-build.md` and `hw/vivado/system_bd.tcl` as pre-flight flow inputs. | No Vivado run, no board command, no timing closure, no deploy claim. |
+| [#83](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/83) | Minimal `NPU_top` e2e TB | `tb_npu_top_e2e_minimal` moved from FAIL to PASS: 114 cycles, 16 checks. | TB harness overlays remain; PASS is xsim evidence only. |
+| [#84](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/84) | BF16-to-INT8 e_max golden TB | `tb_preprocess_bf16_to_int8_golden` PASS: 148 cycles, 71 cases; full run PASS: 12 passed / 0 failed. | TB-local INT8 projection only; no RTL INT8 output-port or hardware claim. |
+| [#85](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/85) | GEMM DSP packer/sign recovery TB | `tb_GEMM_dsp_packer_sign_recovery` PASS: 1046 cycles, 10 cases, 1046 pack checks, 1048 recovery checks. | xsim-only; no synthesis, implementation, timing, or board claim. |
+| [#86](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/86) | Engine completion status wiring | `tb_npu_top_e2e_minimal` PASS and full xsim PASS: 12 passed / 0 failed. | Completion/status wiring only; no CVO SFU changes and no hardware claim. |
+| [#87](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/87) | GEMV lane mask | Full RTL `xvlog` PASS; `tb_GEMV_lane_mask` PASS; full xsim PASS: 12 passed / 0 failed. | Lane-mask surface only; no CVO/SFU files touched. |
+| [#88](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/88) | Post-synth baseline recording | Adds `docs/runbooks/v002.1-synth-baseline.md` and `hw/vivado/scripts/record_synth_baseline.tcl`; script syntax/stub checks PASS. | Infra-only; Vivado synth was not run in that PR and no timing/resource result is claimed. |
+| [#89](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/89) | GEMV reduction and SFU/L2 mux TB | `tb_gemv_reduction_pipeline_mux` PASS: 66 cycles, 6 cases, 126 checks. | Checks xsim-visible mux/reduction behavior; no CVO SFU/CORDIC RTL change. |
+| [#90](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/90) | Result packer ready/valid and STORE writeback | Focused TBs PASS; full xsim PASS: 11 passed / 0 failed; filelist `xvlog` PASS. | STORE readback uses TB harness observation; no synthesis, timing, board, or throughput claim. |
+| [#91](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/91) | GEMM fmap stagger re-enable | `tb_GEMM_fmap_staggered_delay` PASS: 77 cycles, 780 checks; full xsim PASS: 11 passed / 0 failed. | No arithmetic RTL change; no synthesis, timing, board, or throughput claim. |
+| [#92](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/92) | Scheduler hazard/chaining TB | `tb_global_scheduler_hazard_chaining` PASS: 1252 cycles, 117 cases, 693 checks; full xsim PASS: 12 passed / 0 failed. | Current RTL status/interlock visibility limits remain; reserved-opcode behavior requires human review. |
+| [#93](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/93) | MEMCPY/dispatcher comprehensive TB | Records focused dispatcher, queue, and full xsim commands for MEMCPY/shape coverage. | PR body lists commands but no release-level board or timing result. |
+| [#94](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/94) | L2 URAM mapping/arbitration TB | `tb_mem_l2_uram_mapping_arbitration` PASS: 62 cases/checks; full xsim PASS: 12 passed / 0 failed; claim scan and artifact safety PASS. | xsim-visible URAM contract only; no post-synth primitive/resource inference claim. |
+
+## xsim Regression Status
+
+Recorded xsim evidence currently available to this inventory:
+
+| Source | Reported command | Reported result | Evidence boundary |
+| --- | --- | --- | --- |
+| Issue #58 audit comment, 2026-05-03 | current v002 validation flow | 11 passed / 0 failed | Maintainer audit note; not rerun by this doc PR. |
+| [#94](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/94) | `PCCX_LAB_DIR=/home/hwkim/Desktop/github/pccxai/pccx-lab bash hw/sim/run_verification.sh --full` | 12 passed / 0 failed | PR-body evidence after L2 URAM TB registration. |
+
+Generated xsim artifacts are expected under `hw/sim/work/<tb_name>/`,
+including `xvlog.log`, `xelab.log`, `xsim.log`,
+`from_xsim_log.log`, and `<tb_name>.pccx`. These paths are generated
+evidence locations and are ignored by git.
+
+## Timing And Bitstream Evidence Paths
+
+The timing and build paths below are evidence targets, not proof that the
+corresponding gate is closed.
+
+| Evidence class | Expected path | Current inventory status |
+| --- | --- | --- |
+| Post-synth utilization | `hw/build/reports/utilization_post_synth.rpt` | Generated build report path; not committed. |
+| Post-synth clocks | `hw/build/reports/clocks_post_synth.rpt` | Generated build report path; not committed. |
+| Post-synth clock interaction | `hw/build/reports/clock_interaction_post_synth.rpt` | Generated build report path; not committed. |
+| Post-synth timing summary | `hw/build/reports/timing_summary_post_synth.rpt` | Required for timing evidence wording; closure requires constraints-met evidence. |
+| Post-synth DRC | `hw/build/reports/drc_post_synth.rpt` | Required to review critical warnings/violations. |
+| v002.1 synth baseline JSON | `hw/build/reports/synth_baseline.json` | Added by [#88](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/88) when its runbook flow is executed. |
+| Timing helper summary | `hw/build/v002-timing-evidence/<run_id>/summary.txt` | Status vocabulary includes `TIMING_REPORT_PRESENT_NOT_CLOSED`; only `TIMING_REPORT_PRESENT_CLOSED` supports closure wording. |
+| Post-impl utilization | `hw/build/reports/utilization_post_impl.rpt` | Missing gate until implementation completes. |
+| Post-impl clock interaction | `hw/build/reports/clock_interaction_post_impl.rpt` | Missing gate until implementation completes. |
+| Post-impl timing summary | `hw/build/reports/timing_summary_post_impl.rpt` | Required before any timing-closure claim. |
+| Post-impl DRC | `hw/build/reports/drc_post_impl.rpt` | Missing gate until implementation completes. |
+| Post-impl power | `hw/build/reports/power_post_impl.rpt` | Missing gate until implementation completes. |
+| Bitstream | `hw/build/pccx_v002_kv260.bit` | Missing gate; bitstreams must not be committed. |
+| Full top/BD runbook | `docs/runbooks/v002.1-bitstream-build.md` | Cross-linked from [#82](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/82); pre-flight/runbook evidence only until executed. |
+| Synth baseline runbook | `docs/runbooks/v002.1-synth-baseline.md` | Cross-linked from [#88](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/88); infra-only until Vivado synth is run and captured. |
+
+## Board And Runtime Evidence Paths
+
+Tracked blocked evidence already exists for KV260/Gemma readiness checks:
+
+| Run directory | Recorded status | Notes |
+| --- | --- | --- |
+| `docs/evidence/kv260-gemma3n-e4b/20260502T054224Z-5c69049cf7ba/summary.txt` | `BLOCKED_BOARD` | Board SSH, model, bitstream, prompt, token, and runtime environment were missing. |
+| `docs/evidence/kv260-gemma3n-e4b/20260502T054224Z-5c69049cf7ba/blocker.txt` | `BLOCKED_BOARD` | Re-run instructions start with exporting board SSH variables. |
+| `docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/summary.txt` | `BLOCKED_BOARD` | Candidate branch run had `board_reachable=no`, `model_found=no`, `bitstream_found=no`, `bitstream_loaded=no`, throughput unknown. |
+| `docs/evidence/kv260-gemma3n-e4b/20260502T142200Z-b1b0dee-blocked-board/blocker.txt` | `BLOCKED_BOARD` | Re-run instructions require board SSH environment first. |
+| `docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md` | Template | Template for future sanitized board/runtime evidence. |
+
+Only a future `PASS_KV260_NPU` directory with logs, bitstream hash, commit
+SHA, runtime output, and measurement method should be treated as KV260 NPU
+smoke evidence.
+
+## Gates Still Missing For v002.1
+
+The following items remain gating items for a release claim:
+
+- Confirm the PR evidence stack state before tagging and ensure any open
+  evidence PRs are either merged or explicitly deferred with rationale.
+- Capture a fresh full xsim run on the candidate SHA and retain the
+  per-testbench `hw/sim/work/<tb_name>/` evidence paths locally.
+- Run the [#88](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/88)
+  synth-baseline flow and record `hw/build/reports/synth_baseline.json`
+  plus the associated post-synth report paths.
+- Resolve or document post-synth timing status without using closure
+  wording unless the report supports it.
+- Complete full implementation and capture post-implementation timing,
+  utilization, DRC, clock interaction, and power reports.
+- Generate a bitstream only after the Vivado/BD/implementation gates are
+  satisfied, then record its command, path, basename, and SHA256 outside
+  git-tracked bitstream artifacts.
+- Capture KV260 board logs with board identifier, boot/load sequence,
+  UART or JTAG output, and AXI-Lite smoke behavior.
+- Capture Gemma 3N E4B runtime logs only after board, model, bitstream,
+  and runtime inputs are configured.
+- Record measured throughput only from a real board/runtime run with a
+  documented measurement method.
+- Update release notes with explicit timing, bitstream, board, runtime,
+  and throughput status before any tag is cut.
+
+## Claim Guard
+
+Acceptable current wording:
+
+- "xsim regression evidence has reported 12 passed / 0 failed in PR #94."
+- "post-synth/post-implementation report paths are identified."
+- "KV260/Gemma evidence is currently blocked by missing board/model/bitstream/runtime inputs."
+- "20 tok/s remains a target."
+
+Do not write:
+
+- release ready
+- timing closed
+- bitstream ready
+- KV260 inference works
+- Gemma 3N E4B runs on KV260
+- 20 tok/s achieved
+- production ready


### PR DESCRIPTION
## Summary
- Add `docs/evidence/v002.1-evidence-inventory.md` for issue #58.
- Aggregate the v002.1 evidence stack across PRs #80-#94, including recorded xsim status and evidence paths.
- Cross-link the #82 bitstream runbook and #88 synth-baseline evidence path while listing the gates still missing before any release claim.

## Validation
- `git diff --check`
- `bash scripts/v002/claim-scan.sh` -> `UNSUPPORTED_CLAIM_FOUND=no`
- `bash scripts/v002/artifact-safety-check.sh` -> `ARTIFACT_SAFETY=PASS`

## Claim guard
This is documentation-only evidence organization. It does not claim timing closure, bitstream availability, KV260 inference, Gemma 3N E4B hardware execution, measured throughput, or production release status.

Refs #58.