### PR TITLE
docs(runbook): post-impl timing closure and bitstream smoke plan

### DIFF
--- a/docs/runbooks/v002.1-post-impl-timing-and-bitstream-smoke.md
+++ b/docs/runbooks/v002.1-post-impl-timing-and-bitstream-smoke.md
@@ -1,0 +1,374 @@
+# v002.1 Post-Implementation Timing And Bitstream Smoke Runbook
+
+This runbook is a post-implementation evidence plan for issue
+[#29](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/issues/29).
+It tells the user what to run after Vivado implementation finishes, what
+to capture, and how to decide whether to proceed to board smoke. It does
+not claim implementation success, timing closure, bitstream availability,
+board deploy success, Gemma 3N E4B hardware execution, or measured
+throughput.
+
+Related evidence inputs:
+
+- [PR #82](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/82):
+  `docs/runbooks/v002.1-bitstream-build.md`, the KV260 bitstream pre-flight
+  and full-top BD runbook.
+- [PR #88](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/88):
+  `docs/runbooks/v002.1-synth-baseline.md`, the post-synthesis baseline
+  recorder and report vocabulary.
+- [PR #95](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/95):
+  `docs/evidence/v002.1-evidence-inventory.md`, the v002.1 evidence
+  inventory and claim guard.
+
+## Scope
+
+Use this runbook only after a user-terminal Vivado implementation attempt
+has finished or stopped at a documented stage. The implementation source
+can be either:
+
+- The repo-local wrapper flow:
+
+  ```bash
+  cd hw
+  ./vivado/build.sh impl
+  ```
+
+- The full-top BD flow described by PR #82, when that PR's runbook and
+  `hw/vivado/system_bd.tcl` are present in the branch under test.
+
+The report names below match the current repo-local flow unless a
+full-top BD runbook explicitly writes `_full_top_` suffixed reports. When
+both sets exist, use the reports from the exact flow that produced the
+bitstream candidate.
+
+## Required Inputs
+
+Record these before reviewing timing:
+
+```bash
+git rev-parse HEAD
+git branch --show-current
+vivado -version
+```
+
+Also record:
+
+- Vivado command used.
+- Whether the flow was repo-local `hw/vivado/build.sh impl` or PR #82
+  full-top BD flow.
+- Target part and board file, if applicable.
+- `PCCX_VIVADO_JOBS` value.
+- Any local constraints override.
+
+Do not commit generated `hw/build/` contents, checkpoints, `.bit`,
+`.bit.bin`, logs, or raw board captures unless a later curated-evidence
+policy explicitly allows the specific sanitized file.
+
+## Step 1: Confirm Implementation Stage
+
+From the repo root:
+
+```bash
+export PCCX_REPO="${PCCX_REPO:-$(git rev-parse --show-toplevel)}"
+cd "$PCCX_REPO"
+mkdir -p hw/build/post-impl-review
+
+git rev-parse HEAD | tee hw/build/post-impl-review/git_commit.txt
+git branch --show-current | tee hw/build/post-impl-review/git_branch.txt
+vivado -version | tee hw/build/post-impl-review/vivado_version.txt
+```
+
+Check the implementation log:
+
+```bash
+tail -n 240 hw/build/vivado_impl.log \
+  | tee hw/build/post-impl-review/vivado_impl_tail.txt
+```
+
+If using the PR #82 full-top BD flow, replace `hw/build/vivado_impl.log`
+with that run's full-top implementation log, for example:
+
+```text
+hw/build/logs/v002_1_full_top_impl.log
+```
+
+Stop here and record `implementation_status=BLOCKED_IMPL` if the log
+shows place, route, DRC, license, memory, or script failure before report
+generation.
+
+## Step 2: Capture Report Inventory
+
+Create a bounded inventory of the expected reports:
+
+```bash
+cd "$PCCX_REPO"
+
+for report in \
+  hw/build/reports/utilization_post_impl.rpt \
+  hw/build/reports/clock_interaction_post_impl.rpt \
+  hw/build/reports/timing_summary_post_impl.rpt \
+  hw/build/reports/drc_post_impl.rpt \
+  hw/build/reports/power_post_impl.rpt \
+  hw/build/pccx_v002_kv260.bit
+do
+  if [ -e "$report" ]; then
+    printf 'present %s\n' "$report"
+  else
+    printf 'missing %s\n' "$report"
+  fi
+done | tee hw/build/post-impl-review/report_inventory.txt
+```
+
+If the implementation report set is missing, record the failing stage and
+do not continue to bitstream or board smoke. Missing reports are not
+evidence of timing status.
+
+## Step 3: Capture Timing Summary
+
+Read the post-implementation timing summary directly:
+
+```bash
+cd "$PCCX_REPO"
+
+TIMING_RPT=hw/build/reports/timing_summary_post_impl.rpt
+
+if [ ! -f "$TIMING_RPT" ]; then
+  echo "timing_status=TIMING_NOT_RUN" \
+    | tee hw/build/post-impl-review/timing_status.env
+  exit 2
+fi
+
+grep -Ei 'Timing constraints are|WNS|TNS|WHS|THS|Failing Endpoints' \
+  "$TIMING_RPT" \
+  | tee hw/build/post-impl-review/timing_key_lines.txt
+
+tail -n 240 "$TIMING_RPT" \
+  | tee hw/build/post-impl-review/timing_summary_tail.txt
+```
+
+Manual classification:
+
+| Status | Required evidence |
+| --- | --- |
+| `TIMING_REPORT_PRESENT_CLOSED` | The post-implementation timing summary says constraints are met and WNS is non-negative for the checked constraints. |
+| `TIMING_REPORT_PRESENT_NOT_CLOSED` | A timing report exists, but constraints are not met, WNS is negative, or the result is ambiguous. |
+| `TIMING_ATTEMPTED_NO_REPORT` | Implementation was attempted but no post-implementation timing report exists. |
+| `TIMING_NOT_RUN` | Implementation was not attempted in the reviewed branch/session. |
+
+Only `TIMING_REPORT_PRESENT_CLOSED` can pass the timing gate. This
+runbook still requires DRC, route, bitstream, and board-smoke gates before
+any deploy decision.
+
+## Step 4: Capture Route, DRC, Clock, Power, And Utilization
+
+Capture bounded review tails:
+
+```bash
+cd "$PCCX_REPO"
+
+for item in \
+  utilization_post_impl \
+  clock_interaction_post_impl \
+  drc_post_impl \
+  power_post_impl
+do
+  src="hw/build/reports/${item}.rpt"
+  if [ -f "$src" ]; then
+    tail -n 220 "$src" >"hw/build/post-impl-review/${item}.tail.txt"
+  fi
+done
+```
+
+Review gates:
+
+| Gate | PASS condition | Blocked status when it fails |
+| --- | --- | --- |
+| Route | Implementation completed and the route stage did not report incomplete routing. | `BLOCKED_ROUTE` |
+| DRC | No DRC errors and no unexplained critical warnings. | `BLOCKED_DRC` |
+| Clock interaction | No unexpected unconstrained or unsafe clock-domain interactions. | `BLOCKED_CLOCKS` |
+| Utilization | Resource use is plausible for the branch and does not exceed device capacity. | `BLOCKED_UTILIZATION` |
+| Power | Power report exists or the missing report is explicitly explained. | `BLOCKED_POWER_REPORT` |
+
+If a full-top BD flow writes `route_status_full_top_post_impl.rpt` or
+`address_map.rpt`, capture those alongside the report tails and prefer
+their route/address evidence for board-deploy decisions.
+
+## Step 5: Categorize Failing Paths
+
+If timing is not passing, classify the top failing setup paths before
+editing RTL. Use the first ten to twenty failing setup paths from the
+timing summary and assign each path to one category:
+
+| Category | Typical source hint | First notes to capture |
+| --- | --- | --- |
+| PREPROCESS quantizer | `PREPROCESS`, BF16, scale, quantize, emax | Stage boundary, mantissa/shift depth, fanout source, target clock. |
+| GEMM DSP | `MAT_CORE`, `GEMM`, DSP, packer, sign recovery | DSP pipeline placement, cascade/fanout, accumulator depth, affected lane/row. |
+| GEMV reduction | `VEC_CORE`, `GEMV`, reduction, accumulate | Reduction tree level, lane mask logic, valid/control alignment, affected clock. |
+| SFU/CORDIC | `CVO_CORE`, `CVO`, `SFU`, `CORDIC`, reciprocal, exp, sqrt | Function, correction stage, latency contract, whether extra pipeline state changes architectural timing. |
+| memory/dispatcher | `MEM_control`, `NPU_Controller`, scheduler, queue, L2, AXI | Arbitration depth, address decode fanout, queue status path, clock crossing. |
+| other/unclassified | No clear match | Full startpoint, endpoint, hierarchy, and suspected owner. |
+
+Suggested capture format:
+
+```text
+path_id=setup_001
+category=SFU/CORDIC
+startpoint=<copy from report>
+endpoint=<copy from report>
+clock=<copy from report>
+slack_ns=<copy from report>
+suspected_stage=<pipeline/control stage>
+fix_note=<candidate pipeline/stage action, not yet implemented>
+claim=analysis_only
+```
+
+Do not treat a category note as a fix. A fix requires a separate RTL PR
+with simulation, synthesis, and timing evidence appropriate to the changed
+logic.
+
+## Step 6: Decide Bitstream Handling
+
+Check the bitstream artifact only after timing, DRC, and route review:
+
+```bash
+cd "$PCCX_REPO"
+
+BIT=hw/build/pccx_v002_kv260.bit
+if [ -f "$BIT" ]; then
+  sha256sum "$BIT" | tee hw/build/post-impl-review/bitstream_sha256.txt
+  ls -lh "$BIT" | tee hw/build/post-impl-review/bitstream_ls.txt
+else
+  echo "bitstream_status=BLOCKED_BITSTREAM_MISSING" \
+    | tee hw/build/post-impl-review/bitstream_status.env
+fi
+```
+
+The `.bit` file must remain out of git. Record only basename, size, SHA256,
+Vivado command, Vivado version, and commit SHA in review text.
+
+## Step 7: Deploy / No-Deploy Decision
+
+Use this decision table:
+
+| Decision | Required state |
+| --- | --- |
+| `NO_DEPLOY_IMPL_BLOCKED` | Implementation did not finish, route is incomplete, or required reports are missing. |
+| `NO_DEPLOY_TIMING_REVIEW` | Post-implementation timing report exists but does not pass the timing gate. |
+| `NO_DEPLOY_DRC_OR_CLOCKS` | Timing may pass, but DRC, route, clock interaction, or address-map review blocks deploy. |
+| `NO_DEPLOY_BITSTREAM_MISSING` | Report gates pass, but the expected bitstream is absent or SHA256 cannot be recorded. |
+| `BOARD_SMOKE_ALLOWED` | Timing, route, DRC, clock/address review, and bitstream SHA256 are all recorded and pass. |
+
+Do not move to board smoke unless the decision is `BOARD_SMOKE_ALLOWED`.
+If any gate is ambiguous, choose the corresponding `NO_DEPLOY_*` decision
+and attach the captured report lines.
+
+## Step 8: Board Smoke Checklist
+
+The board-smoke stage verifies only that the generated image can be loaded
+and that a minimal control-plane access does not fault. It is not runtime,
+model, throughput, or release evidence.
+
+Before running board commands, record:
+
+- Board identifier or revision.
+- Boot method and image name.
+- Bitstream basename and SHA256.
+- AXI-Lite base address from the Vivado address map or platform handoff.
+- Whether the flow is using `xmutil`, `fpgautil`, XRT, or another loader.
+
+Minimal command plan for a KV260 shell:
+
+```bash
+date -u
+uname -a
+xmutil listapps || true
+dmesg | tail -120
+
+# Replace with the address from the generated address map.
+export NPU_BASE=0xA0000000
+
+sudo timeout 2 devmem "$NPU_BASE" 64
+sudo timeout 2 devmem "$((NPU_BASE + 0x8))" 64 0x8000000000000000
+dmesg | tail -120
+```
+
+If using XRT or an overlay manager, also capture the loader command, its
+stdout/stderr, and the post-load `dmesg` tail. An AXI read timeout, decode
+fault, kernel AXI timeout, loader failure, or new critical kernel error is
+`BOARD_SMOKE_BLOCKED`.
+
+Board smoke statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `PASS_CONTROL_PLANE_SMOKE` | Bitstream was loaded by the selected mechanism and minimal AXI-Lite read/write commands returned without kernel faults. |
+| `BLOCKED_BOARD` | Board is unavailable or not reachable. |
+| `BLOCKED_LOAD` | Overlay/bitstream load failed. |
+| `BLOCKED_AXI` | AXI-Lite access timed out, faulted, or returned an unexplained bus error. |
+| `BLOCKED_RUNTIME` | Control-plane smoke passed, but runtime handoff is missing or not configured. |
+
+Only `PASS_CONTROL_PLANE_SMOKE` supports proceeding to a later runtime
+smoke plan such as `docs/KV260_BRINGUP.md`. It still does not support
+throughput wording or Gemma 3N E4B hardware-result wording.
+
+## Step 9: Evidence Bundle
+
+Keep generated artifacts under `hw/build/` or another ignored local
+directory. A recommended local bundle layout:
+
+```text
+hw/build/post-impl-review/
+  git_commit.txt
+  git_branch.txt
+  vivado_version.txt
+  vivado_impl_tail.txt
+  report_inventory.txt
+  timing_key_lines.txt
+  timing_summary_tail.txt
+  utilization_post_impl.tail.txt
+  clock_interaction_post_impl.tail.txt
+  drc_post_impl.tail.txt
+  power_post_impl.tail.txt
+  bitstream_sha256.txt
+  bitstream_ls.txt
+  board_smoke_stdout.txt
+  board_smoke_stderr.txt
+  board_dmesg_tail.txt
+  decision.env
+```
+
+For public PR or issue updates, summarize the key values instead of
+committing generated logs:
+
+```text
+implementation_status=<completed|blocked stage>
+timing_status=<TIMING_* status>
+wns_ns=<from report or n/a>
+tns_ns=<from report or n/a>
+drc_status=<pass|blocked>
+route_status=<pass|blocked>
+bitstream_status=<present_sha_recorded|missing|not_checked>
+board_smoke_status=<not_run|PASS_CONTROL_PLANE_SMOKE|BLOCKED_*>
+deploy_decision=<NO_DEPLOY_*|BOARD_SMOKE_ALLOWED>
+claim_guard=evidence_only_no_runtime_or_throughput_claim
+```
+
+## Claim Guard
+
+Acceptable wording:
+
+- "post-implementation timing report captured"
+- "WNS/TNS recorded from the reviewed report"
+- "bitstream SHA256 recorded"
+- "board control-plane smoke passed"
+- "deploy remains blocked by timing, DRC, route, bitstream, or board-smoke
+  evidence"
+
+Do not write:
+
+- closed-timing wording
+- bitstream ready
+- KV260 inference success wording
+- Gemma 3N E4B hardware-result wording
+- measured-throughput success wording
+- production readiness wording


### PR DESCRIPTION
## Summary
- Add `docs/runbooks/v002.1-post-impl-timing-and-bitstream-smoke.md` for issue #29.
- Document the user-terminal post-implementation evidence flow: report inventory, WNS/TNS capture, failing-path categorization, bitstream SHA capture, deploy/no-deploy decision, and KV260 control-plane smoke checklist.
- Cross-link PR #82 bitstream runbook, PR #88 synth baseline, and PR #95 evidence inventory while keeping every action evidence-gated.

## Validation
- `git diff --cached --check`
- `bash scripts/v002/claim-scan.sh` -> `UNSUPPORTED_CLAIM_FOUND=no`
- `bash scripts/v002/artifact-safety-check.sh` -> `ARTIFACT_SAFETY=PASS`

## Claim guard
This is documentation-only planning. It does not claim implementation success, timing closure, bitstream availability, board deploy success, Gemma 3N E4B hardware execution, measured throughput, or release readiness.

Refs #29, #82, #88, #95.