### PR TITLE
docs(release): v002.1-rc.0 notes draft

### DIFF
--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,20 @@
+# Release Notes
+
+This directory keeps in-tree release notes and draft release-note
+records for `pccxai/pccx-FPGA-NPU-LLM-kv260`.
+
+## Released
+
+| Version | Notes | Status |
+|---|---|---|
+| `v0.1.0-alpha` | [`v0.1.0-alpha.md`](v0.1.0-alpha.md) | Published prerelease |
+
+## Drafts
+
+| Version | Notes | Status |
+|---|---|---|
+| `v002.1-rc.0` | [`v002.1-rc.0-notes-DRAFT.md`](v002.1-rc.0-notes-DRAFT.md) | Draft only; pre-flight, not released |
+
+Draft notes are planning records. They do not imply a tag, GitHub
+Release, timing closure, bitstream availability, or KV260 board
+evidence unless the note explicitly links the completed evidence.

--- a/docs/releases/v002.1-rc.0-notes-DRAFT.md
+++ b/docs/releases/v002.1-rc.0-notes-DRAFT.md
@@ -1,0 +1,149 @@
+# pccx-FPGA-NPU-LLM-kv260 v002.1-rc.0 - release notes DRAFT
+
+> **DRAFT ONLY - pre-flight, NOT released.** No `v002.1-rc.0` tag
+> exists, no GitHub Release is published, and these notes are not a
+> release candidate. They become candidate release notes only after the
+> bitstream and KV260 board evidence land and are cross-linked here.
+
+- **Repo**: `pccxai/pccx-FPGA-NPU-LLM-kv260`
+- **Draft version**: `v002.1-rc.0`
+- **Tag**: not created
+- **GitHub Release**: not published
+- **Evidence state**: pre-flight documentation and xsim evidence only
+- **Hardware state**: gated on synthesis, implementation, bitstream, and
+  KV260 board smoke evidence
+- **Tracking issue**: #58
+- **Evidence inventory dependency**: #95
+- **Covered PR tranche**: #80 through #96
+
+## Closeout status
+
+| Area | Status | Notes |
+|---|---|---|
+| Release notes | DRAFT | This file is an in-tree draft only. |
+| Source tranche | CONFIRM pending | GitHub reported #80-#96 as open when drafted; do not treat this note as merge evidence. |
+| Tag | NOT DONE | `v002.1-rc.0` must not be tagged until release gates pass. |
+| GitHub Release | NOT DONE | No draft or published GitHub Release exists for this version. |
+| Synthesis evidence | GATED | Requires a recorded v002.1 synth run and report inventory. |
+| Implementation evidence | GATED | Requires post-route timing, utilization, DRC, and clock reports. |
+| Bitstream evidence | GATED | Requires generated bitstream path, SHA256, tool version, and command record. |
+| KV260 board evidence | GATED | Requires load/control-plane smoke logs from the intended bitstream. |
+| Release readiness | NO | These notes must not be used to claim release readiness. |
+
+## Highlights
+
+- Locks the v002.1 architectural defaults for activation scaling,
+  K-drain cadence, and DSP accounting vocabulary (#80).
+- Adds the pre-flight Vivado runbook and BD scaffold required before a
+  full KV260 bitstream attempt (#82).
+- Broadens xsim coverage across NPU top integration, preprocess
+  BF16-to-INT8 golden projection, GEMM W4A8 pack/sign behavior, GEMV
+  lane masks, GEMV reduction/SFU/L2 mux paths, scheduler hazards,
+  MEMCPY/shape dispatch, and L2 URAM mapping (#81, #83-#85, #87,
+  #89, #91-#94).
+- Connects completion/status and STORE writeback plumbing needed for
+  host-visible control-plane evidence (#86, #90).
+- Adds synthesis-baseline recording infrastructure and the v002.1
+  evidence inventory / post-implementation smoke plan that define the
+  remaining evidence path (#88, #95, #96).
+
+## PR coverage
+
+| PR | Title | Evidence state for this draft |
+|---|---|---|
+| #80 | `docs(spec): resolve v002 quantization, K-drain, and DSP baseline` | Docs-only architectural decision record; no RTL evidence claimed. |
+| #81 | `tb(gemm): verify W4A8 DSP dual-MAC and sign recovery` | Focused xsim TB evidence for signed W4A8 DSP behavior; synth DSP inference still gated. |
+| #82 | `build(vivado): add KV260 bitstream runbook and BD scaffold` | Pre-flight runbook/scaffold only; no Vivado or board action claimed. |
+| #83 | `tb(npu_top): minimal end-to-end integration tb` | xsim NPU_top smoke evidence with TB harness overlays; no synthesis/timing/board claim. |
+| #84 | `tb(preprocess): bf16 to int8 e_max golden` | TB-local ACT_SCALE_EMAX_BFP INT8 projection evidence; RTL INT8 output migration still separate. |
+| #85 | `tb(gemm): validate dsp packer and sign recovery` | xsim packer/sign-recovery golden checks; no arithmetic RTL source changes claimed. |
+| #86 | `feat(stat): connect engine completion to mmio_npu_stat` | RTL status wiring plus xsim status-read coverage; hardware status proof still gated. |
+| #87 | `feat(gemv): connect lane mask and remove activation hardcode` | GEMV lane-mask wiring and xsim coverage; full hardware behavior still gated. |
+| #88 | `infra(synth): add baseline recording scripts and runbook` | Synthesis recording infrastructure; Vivado synthesis result not claimed by this draft. |
+| #89 | `tb(gemv): verify reduction pipeline and sfu/l2 output mux` | xsim mux/reduction contract coverage; CVO SFU/CORDIC internals unchanged. |
+| #90 | `feat(npu_top): connect result packer ready/valid and STORE writeback` | STORE writeback/status xsim coverage; no timing, board, or throughput claim. |
+| #91 | `tb(gemm): re-enable fmap staggered-delay after int8 transition` | xsim fmap stagger/e_max alignment evidence; no arithmetic RTL change claimed. |
+| #92 | `tb(sched): global_scheduler hazard and chaining` | xsim issue/fence contract coverage; internal interlock/status behavior remains reviewable. |
+| #93 | `tb(memcpy): add mem_dispatcher comprehensive testbench` | MEMCPY/shape/L2 route xsim coverage; board DMA behavior still gated. |
+| #94 | `tb(memory): verify uram l2 mapping and arbitration` | L2 URAM xsim contract and static expected URAM count; post-synth primitive inference gated. |
+| #95 | `docs(evidence): v002.1 evidence inventory` | Evidence inventory dependency; must be merged/cross-linked before candidate notes. |
+| #96 | `docs(runbook): post-impl timing closure and bitstream smoke plan` | Post-impl/bitstream/board smoke plan; execution evidence still absent. |
+
+## Evidence summary
+
+- **Simulation / xsim**: PR bodies report focused PASS evidence for the
+  added or updated testbenches. This draft records those PR-body claims
+  as pre-flight notes only; it does not replace a tagged-SHA regression
+  run.
+- **Claim scanning / artifact safety**: Several PR bodies report
+  `scripts/v002/claim-scan.sh` and
+  `scripts/v002/artifact-safety-check.sh` PASS. Candidate notes must
+  rerun these checks on the final release commit.
+- **Synthesis**: Infrastructure exists in #88, but v002.1 synth evidence
+  for the final commit is not recorded in this file.
+- **Implementation / timing**: No post-route timing closure is recorded
+  for this draft.
+- **Bitstream**: No `v002.1-rc.0` bitstream path or SHA256 is recorded.
+- **KV260 board**: No KV260 load, control-plane smoke, or Gemma 3N E4B
+  hardware execution evidence is recorded.
+
+## Gating items
+
+- [ ] Confirm #80-#96 are merged into the intended release commit.
+- [ ] Run and record full release-SHA xsim regression evidence.
+- [ ] Run Vivado synthesis for the intended release commit.
+- [ ] Record Vivado version, part/board target, synth utilization,
+      timing, DRC, and report paths.
+- [ ] Run implementation through route.
+- [ ] Record post-route WNS/TNS, failing endpoint count, utilization,
+      DRC, clock interaction, and critical path summary.
+- [ ] Generate the bitstream from the same commit.
+- [ ] Record bitstream basename, SHA256, generation command, and report
+      directory.
+- [ ] Load the intended bitstream on KV260.
+- [ ] Capture KV260 boot/load/control-plane smoke logs.
+- [ ] Record board revision, connection method, runtime command, and
+      pass/fail status.
+- [ ] Cross-link #95 evidence inventory and #96 post-impl smoke plan
+      outputs.
+- [ ] Re-run `scripts/v002/claim-scan.sh` on the final notes.
+- [ ] Re-run `scripts/v002/artifact-safety-check.sh` on the final tree.
+
+## CONFIRM before candidate promotion
+
+- **CONFIRM release commit**: exact SHA that includes the intended
+  v002.1-rc.0 source set.
+- **CONFIRM merged PR set**: #80-#96 present on the release commit.
+- **CONFIRM tag decision**: only create `v002.1-rc.0` after all gates
+  above pass.
+- **CONFIRM release body**: GitHub Release notes match the candidate
+  version of this file.
+- **CONFIRM no artifacts in git**: no `.bit`, `.dcp`, Vivado build
+  directory, board dump, model weight, or licensed model artifact is
+  committed.
+- **CONFIRM hardware wording**: no throughput, inference, timing
+  closure, board success, or release-ready claim is present without
+  linked evidence.
+
+## Known limitations
+
+- These notes are prepared before tag creation and before any
+  `v002.1-rc.0` GitHub Release.
+- The PR tranche is tracked from PR metadata and PR-body evidence, not
+  from a release tag.
+- xsim evidence is not timing closure, bitstream evidence, board
+  evidence, Gemma 3N E4B hardware execution evidence, or measured
+  throughput evidence.
+- Hardware gates remain open until the final bitstream and KV260 board
+  evidence are captured for the release commit.
+
+## Candidate promotion rule
+
+Do not rename, publish, tag, or otherwise treat this draft as candidate
+release notes until:
+
+1. the final release commit is known,
+2. #80-#96 are confirmed in that commit,
+3. synthesis and implementation evidence is recorded,
+4. bitstream path and SHA256 are recorded, and
+5. KV260 board smoke evidence for that bitstream is linked.


### PR DESCRIPTION
Summary:
- Add DRAFT-only v002.1-rc.0 release notes covering PR tranche #80-#96.
- Add docs/releases/README.md with released vs draft notes.
- Explicitly gate candidate promotion on synth, impl, bitstream, and KV260 board evidence.

Evidence:
- git diff --cached --check -> PASS before commit.
- bash scripts/v002/claim-scan.sh -> UNSUPPORTED_CLAIM_FOUND=no.
- bash scripts/v002/artifact-safety-check.sh -> ARTIFACT_SAFETY=PASS.
- Confirmed no local tag matching v002.1-rc.0*.
- gh release view v002.1-rc.0 -> release not found.

Claim guard:
- Draft release notes only; no tag created and no GitHub Release published.
- Does not claim release readiness, timing closure, bitstream availability, KV260 board success, Gemma 3N E4B hardware execution, or measured throughput.
- Notes explicitly say promotion only after bitstream and board evidence land.

Refs #58, #95.