### PR TITLE
docs(runbook): v002.1 bitstream deploy procedure

### DIFF
--- a/docs/runbooks/v002.1-bitstream-deploy.md
+++ b/docs/runbooks/v002.1-bitstream-deploy.md
@@ -1,0 +1,252 @@
+# v002.1 KV260 Bitstream Deploy Runbook
+
+This runbook starts after PR
+[#82](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/82)
+has produced the v002.1 KV260 bitstream artifacts. It describes how to
+stage and load the FPGA overlay on a KV260 for a narrow register-level
+smoke check.
+
+It is not board-ready evidence, runtime evidence, or inference evidence.
+Do not claim KV260 readiness, Gemma 3N E4B inference, timing closure, or
+throughput from this procedure alone.
+
+## Scope
+
+- Target: KV260 running the existing board image and Xilinx overlay tools.
+- Artifacts: `.bit`, `.dtbo`, and `shell.json` from the same bitstream
+  generation handoff.
+- Default board posture: read-only inspection commands until the operator
+  explicitly enters the deploy/load section.
+- Allowed disruptive action: reboot, when selected by the operator and
+  recorded in the capture log.
+- Prohibited actions: firmware flash, package install, OS image mutation,
+  or driver/runtime claims beyond the smoke result.
+
+## Inputs
+
+Record these before touching the board:
+
+| Item | Source |
+| --- | --- |
+| Bitstream commit SHA | PR #82 bitstream generation log |
+| Bitstream SHA256 | PR #97 release notes draft |
+| Artifact inventory | PR #95 evidence inventory |
+| Vivado/Vitis version | PR #82 bitstream generation log |
+| Overlay app name | `shell.json` `name` field |
+| Board identifier | Label, serial, or provisioning notes if available |
+
+The expected evidence documents are:
+
+- PR [#97](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/97):
+  `docs/releases/v002.1-rc.0-notes-DRAFT.md`
+- PR [#95](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/95):
+  `docs/evidence/v002.1-evidence-inventory.md`
+
+Stop if the release-notes draft and inventory disagree on artifact names,
+hashes, tool version, or source commit.
+
+## 1. Verify Artifact Evidence
+
+From the host worktree that contains the generated artifacts:
+
+```bash
+sha256sum path/to/pccx_v002_1_kv260.bit
+sha256sum path/to/pccx_npu.dtbo
+sha256sum path/to/shell.json
+```
+
+Compare the output with PR #97 and PR #95. Record the exact artifact
+paths and hashes in the local capture directory before deployment:
+
+```bash
+mkdir -p ~/.codex/private-state/v002.1-deploy
+{
+  date -u
+  git rev-parse HEAD
+  sha256sum path/to/pccx_v002_1_kv260.bit
+  sha256sum path/to/pccx_npu.dtbo
+  sha256sum path/to/shell.json
+} | tee ~/.codex/private-state/v002.1-deploy/artifacts.txt
+```
+
+Do not continue with artifacts built from different commits or missing
+hash evidence.
+
+## 2. Stage Artifacts
+
+Use the provisioning route for the board. Do not flash firmware and do
+not install packages.
+
+### Option A: Mounted KV260 SD Card
+
+Mount the SD card on the host and copy the overlay files into the
+existing firmware app directory. Replace `<sd-root>` and `<app-name>`
+with the mounted root filesystem path and the `shell.json` app name.
+
+```bash
+sudo mkdir -p <sd-root>/lib/firmware/xilinx/<app-name>
+sudo cp path/to/pccx_v002_1_kv260.bit \
+        path/to/pccx_npu.dtbo \
+        path/to/shell.json \
+        <sd-root>/lib/firmware/xilinx/<app-name>/
+sync
+```
+
+Unmount the SD card cleanly before booting the KV260.
+
+### Option B: Transfer Over Board Console Or TTY
+
+Use this route only when the board provisioning already provides a
+console or TTY file-transfer path. If only a serial shell is available
+and no binary transfer helper is installed, transfer base64 text and
+decode it with tools already present on the image:
+
+```bash
+# Host side: create text payloads.
+base64 path/to/pccx_v002_1_kv260.bit > /tmp/pccx_v002_1_kv260.bit.b64
+base64 path/to/pccx_npu.dtbo > /tmp/pccx_npu.dtbo.b64
+base64 path/to/shell.json > /tmp/shell.json.b64
+```
+
+On the board, paste or otherwise transfer each `.b64` payload into a
+temporary writable directory, then decode and install the overlay files:
+
+```bash
+mkdir -p /tmp/pccx-deploy
+base64 -d /tmp/pccx_v002_1_kv260.bit.b64 > /tmp/pccx-deploy/pccx_v002_1_kv260.bit
+base64 -d /tmp/pccx_npu.dtbo.b64 > /tmp/pccx-deploy/pccx_npu.dtbo
+base64 -d /tmp/shell.json.b64 > /tmp/pccx-deploy/shell.json
+
+sudo mkdir -p /lib/firmware/xilinx/<app-name>
+sudo cp /tmp/pccx-deploy/pccx_v002_1_kv260.bit \
+        /tmp/pccx-deploy/pccx_npu.dtbo \
+        /tmp/pccx-deploy/shell.json \
+        /lib/firmware/xilinx/<app-name>/
+```
+
+If SSH or another existing transfer mechanism is already provisioned,
+it may be used instead. Record the transfer method in the capture log.
+
+## 3. Load Overlay
+
+First inspect the current app state with read-only commands:
+
+```bash
+xmutil listapps
+dmesg | tail -30
+```
+
+Choose one load path.
+
+### Hot Reload
+
+```bash
+sudo xmutil unloadapp
+sudo xmutil loadapp <app-name>
+xmutil listapps
+dmesg | tail -30
+```
+
+### Reboot
+
+Reboot is allowed for this procedure when the operator chooses a clean
+boot over hot reload. Record that reboot was used.
+
+```bash
+sudo reboot
+```
+
+After the board returns:
+
+```bash
+xmutil listapps
+sudo xmutil loadapp <app-name>
+xmutil listapps
+dmesg | tail -30
+```
+
+Stop if `xmutil loadapp` fails or `dmesg` reports overlay, device-tree,
+clock, reset, or AXI timeout errors.
+
+## 4. Register-Level Smoke
+
+This smoke checks only whether the mapped AXI status register can be read
+without a bus error. It does not validate inference, model execution, or
+performance.
+
+Prefer the address map emitted by PR #82. Do not hard-code an address
+unless it is copied from that generated map for the same bitstream.
+
+### Option A: `devmem`
+
+Use only if `devmem` is already available on the board image:
+
+```bash
+sudo devmem <axi_status_addr> 32
+```
+
+Record the value and whether the read completed without an AXI fault.
+
+### Option B: XRT Tooling
+
+Use only if XRT tools are already available on the board image:
+
+```bash
+xrt-smi examine
+```
+
+If a project-local XRT register-read helper exists for the same bitstream
+handoff, run that helper and record the exact command. Do not install XRT
+or any package as part of this runbook.
+
+## 5. Failure Capture
+
+If staging, loading, or smoke fails, capture logs under:
+
+```bash
+~/.codex/private-state/v002.1-deploy/
+```
+
+Suggested capture commands:
+
+```bash
+mkdir -p ~/.codex/private-state/v002.1-deploy
+{
+  date -u
+  uname -a
+  xmutil listapps
+  dmesg | tail -200
+} | tee ~/.codex/private-state/v002.1-deploy/board-load-failure.log
+```
+
+Also save:
+
+- artifact hashes and paths
+- `shell.json`
+- transfer method
+- whether hot reload or reboot was used
+- exact `xmutil` output
+- exact `devmem` or XRT smoke command and output
+
+Public notes may summarize the blocker, but keep private hostnames,
+serial console transcripts, local paths, and board identifiers out of
+committed files unless explicitly approved.
+
+## Claim Guard
+
+Acceptable wording after this runbook:
+
+- "Overlay staging attempted on KV260."
+- "Overlay load reached `xmutil loadapp <app-name>`."
+- "AXI status register read completed" only when the register smoke
+  actually returns without bus errors.
+
+Do not write:
+
+- "KV260 board ready."
+- "Gemma 3N E4B inference works."
+- "NPU runtime passes."
+- "Timing or throughput is proven."
+- "Firmware was flashed."
+
+No package install or firmware flash is part of this procedure.


### PR DESCRIPTION
## Summary
- Add v002.1 KV260 bitstream deploy runbook for post-PR #82 artifact handoff.
- Document evidence verification against PR #97 release notes draft and PR #95 inventory.
- Cover SD/TTY staging, xmutil hot reload or reboot, status-register smoke, and private failure capture.

## Guardrails
- Doc-only.
- No board-ready, inference, runtime-pass, timing, or throughput claim.
- No firmware flash.
- No package install.

Refs #82, #95, #97.