### PR TITLE
docs(changelog): v002.1 ramp landings today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,26 @@ bring-up.
 - #99 `docs(readme): link v002.1 ramp artifacts`
 - #100 `docs(runbook): v002.1 bitstream deploy procedure`
 
+### Evidence
+
+- #95 `docs(evidence): v002.1 evidence inventory` organizes the
+  v002.1 evidence stack across PRs #80-#94 and lists missing gates
+  before any release claim.
+- #97 `docs(release): v002.1-rc.0 notes draft` adds draft-only release
+  notes for PRs #80-#96; no tag or GitHub Release is claimed.
+- #101 `evidence(v002.1): bitstream attempt 1 reports` records a
+  full-top BD synth attempt that failed during BD preparation before
+  `synth_design`; no timing reports, implementation, route, or
+  bitstream are claimed.
+- #104 `fix(vivado): register svh files as verilog headers in synth`
+  records SVH header registration, `bash hw/vivado/build.sh synth`
+  passing, post-synth WNS `-9.531 ns`, implementation blocked at
+  `opt_design` DRC `MDRV-1`, and no bitstream generated.
+- #105 `docs(spec): timing improvement playbook for full-top closure`
+  adds docs-only timing triage guidance based on the open evidence,
+  without claiming timing closure, bitstream availability, KV260
+  runtime, measured throughput, or release readiness.
+
 ## v0.1.0-alpha — 2026-05-01
 
 First public RTL preview of the pccx v002 NPU implementation targeting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## v002.1 ramp PR inventory — 2026-05-07
+
+Evidence-gated inventory of draft PRs #80-#100 queried for the v002.1
+ramp on 2026-05-07. This is not a release note and does not claim
+merge, tag, timing closure, bitstream availability, or KV260 board
+bring-up.
+
+### Spec
+
+- #80 `docs(spec): resolve v002 quantization, K-drain, and DSP baseline`
+
+### TBs
+
+- #81 `tb(gemm): verify W4A8 DSP dual-MAC and sign recovery`
+- #83 `tb(npu_top): minimal end-to-end integration tb`
+- #84 `tb(preprocess): bf16 to int8 e_max golden`
+- #85 `tb(gemm): validate dsp packer and sign recovery`
+- #89 `tb(gemv): verify reduction pipeline and sfu/l2 output mux`
+- #91 `tb(gemm): re-enable fmap staggered-delay after int8 transition`
+- #92 `tb(sched): global_scheduler hazard and chaining`
+- #93 `tb(memcpy): add mem_dispatcher comprehensive testbench`
+- #94 `tb(memory): verify uram l2 mapping and arbitration`
+
+### RTL fixes
+
+- #86 `feat(stat): connect engine completion to mmio_npu_stat`
+- #87 `feat(gemv): connect lane mask and remove activation hardcode`
+- #90 `feat(npu_top): connect result packer ready/valid and STORE writeback`
+
+### Infra
+
+- #82 `build(vivado): add KV260 bitstream runbook and BD scaffold`
+- #88 `infra(synth): add baseline recording scripts and runbook`
+
+### Docs
+
+- #95 `docs(evidence): v002.1 evidence inventory`
+- #96 `docs(runbook): post-impl timing closure and bitstream smoke plan`
+- #97 `docs(release): v002.1-rc.0 notes draft`
+- #98 `docs(contrib): add CONTRIBUTING.md`
+- #99 `docs(readme): link v002.1 ramp artifacts`
+- #100 `docs(runbook): v002.1 bitstream deploy procedure`
+
 ## v0.1.0-alpha — 2026-05-01
 
 First public RTL preview of the pccx v002 NPU implementation targeting


### PR DESCRIPTION
## Summary
- Add a 2026-05-07 Keep-a-Changelog section for the v002.1 ramp PR inventory.
- Group draft PRs #80-#100 by Spec, TBs, RTL fixes, Infra, and Docs.
- State the claim guard explicitly: no release, merge, timing-closure, bitstream, or KV260 board bring-up claim.

## Validation
- git diff --check
- normal git commit and push hooks were not bypassed