### PR TITLE
fix(vivado): register svh files as verilog headers in synth

### DIFF
--- a/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/summary.txt
+++ b/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/summary.txt
@@ -1,0 +1,31 @@
+Run: vivado-svh-add-files
+Branch: fix/vivado-svh-add-files
+Worktree: /tmp/kv260-svh-fix-wt
+Base: origin/main 18d4631
+
+Change:
+- hw/vivado/create_project.tcl now recursively registers hw/rtl/*.svh files
+  in sources_1 and sets each file_type to "Verilog Header".
+- No RTL files changed.
+
+Commands:
+- bash hw/vivado/build.sh synth
+- bash hw/vivado/build.sh impl
+
+SVH_FILES_REGISTERED_COUNT=12
+SYNTH_RESULT=PASS
+SYNTH_WNS_NS=-9.531
+SYNTH_TNS_NS=-3528.127
+SYNTH_TIMING_CLOSED=NO
+IMPL_RESULT=FAIL
+IMPL_WNS_NS=N/A
+BITSTREAM_GENERATED=NO
+BITSTREAM_PATH=N/A
+
+CLAIM_GUARD:
+- No timing-closure claim: post-synth setup WNS is negative.
+- No bitstream-success claim: implementation failed before opt_design.
+- No RTL changed for the implementation failure.
+
+Implementation blocker:
+ERROR: [DRC MDRV-1] Multiple Driver Nets: Net u_mem_dispatcher/u_l2_cache/u_acp_cdc/u_acp_rx_fifo/xpm_fifo_base_inst/full_n has multiple drivers: u_mem_dispatcher/u_l2_cache/u_acp_cdc/u_acp_rx_fifo/xpm_fifo_base_inst/gen_pf_ic_rc.gen_full_rst_val.ram_full_n_reg/Q, and u_fmap_pre/u_fmap_fifo/xpm_fifo_base_inst/gen_pntr_flags_cc.gen_full_rst_val.ram_full_n_reg/Q.

--- a/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/svh_files.txt
+++ b/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/svh_files.txt
@@ -1,0 +1,12 @@
+hw/rtl/Constants/compilePriority_Order/A_const_svh/GLOBAL_CONST.svh
+hw/rtl/Constants/compilePriority_Order/A_const_svh/NUMBERS.svh
+hw/rtl/Constants/compilePriority_Order/A_const_svh/kv260_device.svh
+hw/rtl/Constants/compilePriority_Order/A_const_svh/npu_arch.svh
+hw/rtl/MAT_CORE/GEMM_Array.svh
+hw/rtl/MEM_control/IO/mem_IO.svh
+hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_memctrl.svh
+hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_x32.svh
+hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_x64.svh
+hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_decode_const.svh
+hw/rtl/NPU_Controller/npu_interfaces.svh
+hw/rtl/VEC_CORE/GEMV_Vec_Matrix_MUL.svh

--- a/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/vivado_impl_failure_excerpt.txt
+++ b/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/vivado_impl_failure_excerpt.txt
@@ -1,0 +1,22 @@
+Implementation command:
+bash hw/vivado/build.sh impl
+
+Implementation failure excerpt:
+Command: opt_design
+Attempting to get a license for feature 'Implementation' and/or device 'xck26'
+INFO: [Common 17-349] Got license for feature 'Implementation' and/or device 'xck26'
+Running DRC as a precondition to command opt_design
+
+Starting DRC Task
+INFO: [DRC 23-27] Running DRC with 8 threads
+WARNING: [DRC 23-814] Not all possible (connectivity based) DRCs may have been run because this design is seen as Out of Context.
+ERROR: [DRC MDRV-1] Multiple Driver Nets: Net u_mem_dispatcher/u_l2_cache/u_acp_cdc/u_acp_rx_fifo/xpm_fifo_base_inst/full_n has multiple drivers: u_mem_dispatcher/u_l2_cache/u_acp_cdc/u_acp_rx_fifo/xpm_fifo_base_inst/gen_pf_ic_rc.gen_full_rst_val.ram_full_n_reg/Q, and u_fmap_pre/u_fmap_fifo/xpm_fifo_base_inst/gen_pntr_flags_cc.gen_full_rst_val.ram_full_n_reg/Q.
+INFO: [Project 1-461] DRC finished with 1 Errors
+INFO: [Project 1-462] Please refer to the DRC report (report_drc) for more information.
+ERROR: [Vivado_Tcl 4-78] Error(s) found during DRC. Opt_design not run.
+
+INFO: [Common 17-83] Releasing license: Implementation
+13 Infos, 10 Warnings, 5 Critical Warnings and 2 Errors encountered.
+opt_design failed
+ERROR: [Common 17-39] 'opt_design' failed due to earlier errors.
+ERROR: [Vivado 12-13638] Failed runs(s) : 'impl_1'

--- a/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/vivado_synth_report.txt
+++ b/docs/evidence/vivado-svh-add-files/20260507T024124Z-18d4631/vivado_synth_report.txt
@@ -1,0 +1,17 @@
+Vivado version:
+Vivado v2025.2 (64-bit)
+
+Header registration evidence:
+[pccx] registered 12 SystemVerilog headers
+
+Synthesis result:
+Synthesis finished with 0 errors, 2 critical warnings and 210 warnings.
+synth_design completed successfully
+[pccx] synth complete. Reports in /tmp/kv260-svh-fix-wt/hw/build/reports.
+
+Post-synth timing summary:
+    WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints     WPWS(ns)     TPWS(ns)  TPWS Failing Endpoints  TPWS Total Endpoints
+    -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------
+     -9.531    -3528.127                   4194                28616        0.079        0.000                      0                28616        0.450        0.000                       0                  8740
+
+Timing constraints are not met.

--- a/hw/vivado/create_project.tcl
+++ b/hw/vivado/create_project.tcl
@@ -59,6 +59,29 @@ add_files -fileset sources_1 $sv_files
 set_property file_type SystemVerilog [get_files -of [get_filesets sources_1]]
 set_property top $TOP_MODULE [current_fileset]
 
+# Vivado's file manager requires included SystemVerilog headers to be present
+# in the project as Verilog Header files, not only discoverable via include_dirs.
+proc collect_svh_files {root} {
+    set files {}
+    foreach entry [glob -nocomplain -directory $root *] {
+        if {[file isdirectory $entry]} {
+            set files [concat $files [collect_svh_files $entry]]
+        } elseif {[file extension $entry] eq ".svh"} {
+            lappend files [file normalize $entry]
+        }
+    }
+    return $files
+}
+
+set svh_files [lsort [collect_svh_files $HW_ROOT/rtl]]
+if {[llength $svh_files] > 0} {
+    add_files -fileset sources_1 $svh_files
+    foreach svh_file $svh_files {
+        set_property file_type "Verilog Header" [get_files $svh_file]
+    }
+    puts "\[pccx\] registered [llength $svh_files] SystemVerilog headers"
+}
+
 # ----------------------------------------------------------------------------
 # Header / include search paths
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Register all hw/rtl/*.svh files in Vivado sources_1 as Verilog Header.
- Keep hw/vivado/filelist.f as the ordered SystemVerilog source list for xvlog compatibility.
- Add tracked evidence for the synth pass and the implementation attempt.

## Evidence
- SVH files registered: 12
- bash hw/vivado/build.sh synth: PASS
- Post-synth WNS: -9.531 ns; timing constraints are not met.
- bash hw/vivado/build.sh impl: FAIL at opt_design DRC MDRV-1 multiple-driver net.
- Bitstream generated: no

Refs #82, #101