### PR TITLE
docs(spec): timing improvement playbook for full-top closure

### DIFF
--- a/docs/spec/v002.1-timing-improvement-playbook.md
+++ b/docs/spec/v002.1-timing-improvement-playbook.md
@@ -1,0 +1,168 @@
+# v002.1 Timing Improvement Playbook
+
+This playbook is for reducing the current full-top timing gap reported in
+PR [#104](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/104).
+That evidence reports a Vivado synthesis pass with post-synth WNS
+`-9.531 ns`; the timing constraints are not met, implementation stops at
+`opt_design` DRC `MDRV-1`, and no bitstream is generated.
+
+Use this document to triage and propose timing fixes. Do not describe any
+path as fixed, closed, or hardware-ready until the matching Vivado report
+shows that result.
+
+Related PRs:
+
+- [#79](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/79):
+  CVO SFU reciprocal correction/product path evidence.
+- [#80](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/80):
+  parameterized v002 constants that can anchor timing/resource tuning.
+- [#95](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/95):
+  v002.1 evidence inventory and claim guard pattern.
+- [#104](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/104):
+  full-top synth evidence with the current negative slack figure.
+
+## Diagnostic Checklist
+
+Record the evidence before changing RTL or constraints:
+
+- Commit SHA, branch, Vivado version, command, and report path.
+- Whether the report is post-synthesis, out-of-context post-implementation,
+  or full top-level implementation.
+- WNS, TNS, failing endpoint count, source clock, destination clock, and
+  the exact startpoint/endpoint of the worst path.
+- Clock target: `core_clk` is 2.500 ns and `axi_clk` is 4.000 ns in
+  `hw/constraints/pccx_timing.xdc`.
+- The timing path group and whether the path is logic delay, routing delay,
+  clock skew, high fanout, or a CDC/constraint issue.
+- Whether the same class of path appears in more than one failing endpoint.
+- Any DRC blocker that prevents implementation timing evidence from being
+  collected. For PR #104, clear the `MDRV-1` blocker before treating
+  post-synth slack as the final physical result.
+
+Where to look first in this design:
+
+| Area | Typical slack sink | Files to inspect | Evidence to capture |
+| --- | --- | --- | --- |
+| W4A8 GEMM systolic path | INT4 unpack/sign recovery, DSP48E2 setup, horizontal weight shift, result drain | `hw/rtl/MAT_CORE/GEMM_dsp_unit*.sv`, `GEMM_dsp_packer.sv`, `GEMM_sign_recovery.sv`, `GEMM_systolic_array.sv`, `mat_result_normalizer.sv` | DSP input/output register use, cascade length, fanout on valid/control, drain multicycle assumptions |
+| W4A8 GEMM dispatch | Weight/fmap staging and row/column valid skew | `GEMM_weight_dispatcher.sv`, `GEMM_fmap_staggered_delay.sv`, `GEMM_systolic_top.sv` | Long valid nets, repeated enable decode, row/column skew depth |
+| CVO SFU | BF16 helper chains in reciprocal, scale, GELU, EXP, and output mux | `hw/rtl/CVO_CORE/CVO_sfu_unit.sv`, `CVO_top.sv` | Startpoint/endpoint stage names, operation mode, mux depth, latency contract |
+| Dispatcher and scheduler | Shape decode, word-count arithmetic, opcode fanout, queue control | `hw/rtl/MEM_control/top/mem_dispatcher.sv`, `mem_CVO_stream_bridge.sv`, `Global_Scheduler.sv`, `ctrl_npu_decoder.sv` | Fanout count, replicated vs shared decode, arithmetic width, queue ready/valid cone |
+| PREPROCESS and cache ingress | BF16 shift/normalize logic and fmap broadcast | `preprocess_bf16_fixed_pipeline.sv`, `preprocess_fmap.sv`, `fmap_cache.sv` | Combinational BF16 barrel-shift depth, broadcast fanout, SRAM read latency alignment |
+| Clock and constraints | False or missing CDC constraints, over-broad multicycle paths | `hw/constraints/pccx_timing.xdc` | `report_clock_interaction`, constrained path count, async crossing ownership |
+
+Treat W4A8 arithmetic modules as behavior-sensitive. Any timing change that
+modifies pack, sign-recovery, reduction, or BF16 conversion behavior needs the
+golden-vector gate described in `docs/W4A8_GOLDEN_VECTOR_GATE.md`.
+
+## Common Levers
+
+Pipeline insertion:
+
+- Insert registers at natural protocol boundaries: before SFU operation muxes,
+  between BF16 helper stages, after shape/word-count decode, and at GEMM
+  dispatch boundaries.
+- Move only one latency boundary at a time, then update valid, clear, and flush
+  alignment in the same patch.
+- For CVO paths, make the per-op latency contract explicit before adding a
+  stage. Keep `OUT_result_valid` aligned with the selected result.
+- For GEMM drain paths, verify that added stages preserve accumulator flush
+  ordering and result-packer capture cadence.
+
+Retiming:
+
+- Prefer structural RTL that lets Vivado move registers through simple
+  combinational cones.
+- Keep reset and clear logic consistent with the existing `rst_n` plus
+  synchronous clear convention so retiming is not blocked unnecessarily.
+- Use DSP48E2 input, pipeline, and P-registers intentionally. Capture whether
+  A/B/M/P registers are enabled on the failing path.
+- Avoid mixing retiming-only edits with arithmetic algorithm changes.
+
+Fanout reduction:
+
+- Find high-fanout valid, opcode, clear, mode, shape, and lane-enable nets in
+  the timing report and synthesized schematic.
+- Localize decode near each consumer instead of driving one global control cone
+  through GEMM, CVO, dispatcher, and preprocess logic.
+- Split control buses by subsystem when a shared VLIW or uop field only needs a
+  small subset of consumers.
+- Register ready/valid terms at queue or bridge boundaries before they feed
+  wide combinational backpressure.
+
+Register replication:
+
+- Replicate stable control and shape registers per lane, row group, or
+  subsystem when Vivado reports high fanout or routing-dominated delay.
+- Keep replicated registers single-source in RTL, with one update condition and
+  clear behavior, so equivalence is reviewable.
+- For GEMM, consider row-group or half-array replication for valid, instruction,
+  and weight-load controls before touching packed arithmetic.
+- For CVO, replicate mode/flags ahead of operation-specific pipelines instead
+  of sharing a late global mux selector.
+
+Clock budget redistribution:
+
+- Keep the public target constraints visible: `core_clk` at 400 MHz and
+  `axi_clk` at 250 MHz.
+- If a path is legitimately multi-cycle, document the protocol reason,
+  startpoint, endpoint, and hold-side adjustment in the same PR as the
+  constraint.
+- Do not use looser clocks or broad false paths as evidence of readiness.
+- If a temporary lower-frequency target is useful for debug, label it as a
+  debug budget only and keep it out of release claims.
+
+## Evidence-Gated Language
+
+Use wording that describes evidence and proposed work:
+
+- "PR #104 reports post-synth WNS `-9.531 ns`; timing constraints are not met."
+- "This patch proposes an added pipeline stage for the CVO reciprocal path."
+- "This change is intended to reduce fanout on dispatcher shape decode."
+- "Post-implementation timing evidence is still required."
+- "Bitstream generation remains unavailable until implementation completes."
+
+Avoid wording that asserts success without evidence:
+
+- Do not write that the timing gap is fixed.
+- Do not write that timing is closed.
+- Do not write that KV260 hardware execution is ready.
+- Do not write that Gemma 3N E4B throughput has been measured.
+- Do not write that a bitstream exists unless the generated bitstream and
+  evidence path are recorded.
+
+Every timing-improvement PR should include a claim guard block:
+
+```text
+Claim guard:
+- No timing closure claim.
+- No bitstream claim.
+- No KV260 runtime claim.
+- No measured throughput claim.
+- Evidence is limited to the reports listed in this PR.
+```
+
+## Review Checklist
+
+Before asking for review:
+
+- `git diff --check` passes.
+- `bash scripts/v002/claim-scan.sh` reports `UNSUPPORTED_CLAIM_FOUND=no`.
+- `bash scripts/v002/artifact-safety-check.sh` reports
+  `ARTIFACT_SAFETY=PASS`.
+- Any RTL timing patch runs the focused xsim testbench for the touched path.
+- Any constraint patch records the before/after path group, startpoint,
+  endpoint, setup adjustment, and hold adjustment.
+- The PR body names the exact evidence scope: post-synth, OOC
+  post-implementation, full implementation, or blocked.
+
+## Open Work Queue
+
+Use this order unless newer evidence changes the top failing path:
+
+1. Resolve implementation blockers that prevent full physical timing evidence.
+2. Re-run full-top synthesis and implementation evidence collection.
+3. Classify the worst failing paths by subsystem and delay type.
+4. Apply one timing lever per PR with focused tests and claim guard wording.
+5. Re-run the same report scope and compare WNS/TNS/failing endpoints.
+6. Move from post-synth or OOC evidence to full implementation evidence before
+   making any release-readiness statement.


### PR DESCRIPTION
## Summary
- Add `docs/spec/v002.1-timing-improvement-playbook.md`.
- Capture a diagnostic checklist for W4A8 GEMM, CVO SFU, dispatcher/scheduler, PREPROCESS, and constraints timing triage.
- List common timing levers: pipeline insertion, retiming, fanout reduction, register replication, and clock budget redistribution.
- Cross-link the evidence and tuning context from #79, #80, #95, and #104.

## Validation
- `git diff --check`: PASS
- `bash scripts/v002/claim-scan.sh`: PASS, `UNSUPPORTED_CLAIM_FOUND=no`
- `bash scripts/v002/artifact-safety-check.sh`: PASS, `ARTIFACT_SAFETY=PASS`

## Claim guard
NO_CLOSURE_CLAIM=yes

This is documentation-only timing triage guidance. It does not claim timing constraints are met, bitstream availability, KV260 runtime, Gemma 3N E4B hardware execution, measured throughput, or release readiness. PR #104 evidence remains post-synth WNS `-9.531 ns`, implementation blocked at `opt_design` DRC `MDRV-1`, and bitstream not generated.

Refs #79, #80, #95, #104.
