### PR TITLE
docs(changelog): evidence section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,26 @@ bring-up.
 - #99 `docs(readme): link v002.1 ramp artifacts`
 - #100 `docs(runbook): v002.1 bitstream deploy procedure`
 
+### Evidence
+
+- #95 `docs(evidence): v002.1 evidence inventory` organizes the
+  v002.1 evidence stack across PRs #80-#94 and lists missing gates
+  before any release claim.
+- #97 `docs(release): v002.1-rc.0 notes draft` adds draft-only release
+  notes for PRs #80-#96; no tag or GitHub Release is claimed.
+- #101 `evidence(v002.1): bitstream attempt 1 reports` records a
+  full-top BD synth attempt that failed during BD preparation before
+  `synth_design`; no timing reports, implementation, route, or
+  bitstream are claimed.
+- #104 `fix(vivado): register svh files as verilog headers in synth`
+  records SVH header registration, `bash hw/vivado/build.sh synth`
+  passing, post-synth WNS `-9.531 ns`, implementation blocked at
+  `opt_design` DRC `MDRV-1`, and no bitstream generated.
+- #105 `docs(spec): timing improvement playbook for full-top closure`
+  adds docs-only timing triage guidance based on the open evidence,
+  without claiming timing closure, bitstream availability, KV260
+  runtime, measured throughput, or release readiness.
+
 ## v0.1.0-alpha — 2026-05-01
 
 First public RTL preview of the pccx v002 NPU implementation targeting


### PR DESCRIPTION
## Summary
- Add an Evidence section to the v002.1 ramp changelog inventory from PR #102.
- List PR #95 inventory evidence, PR #97 draft release notes, and the PR #101/#104/#105 Vivado evidence / timing-triage trail.
- Keep the wording limited to recorded docs and open evidence; no timing closure, bitstream, KV260 runtime, throughput, or release-readiness claim.

## Validation
- git diff --check
- bash scripts/v002/claim-scan.sh -> UNSUPPORTED_CLAIM_FOUND=no
- bash scripts/v002/artifact-safety-check.sh -> ARTIFACT_SAFETY=PASS

## Claim guard
Docs-only changelog update. No merge, tag, release, timing-closure, bitstream, board bring-up, KV260 runtime, measured-throughput, or release-readiness claim.