### PR TITLE
docs(test): test runner policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,9 @@ hw/sim/run_verification.sh --quick
 scripts/v002/run-local-candidate.sh --quick
 ```
 
-See [docs/SIMULATION.md](docs/SIMULATION.md) for generated log paths,
-PASS verdict rules, and the evidence checklist.
+See [docs/SIMULATION.md](docs/SIMULATION.md) for all runner flags,
+generated log paths, PASS verdict rules, new-testbench policy, and the
+evidence checklist.
 
 ### Current testbench matrix
 
@@ -372,15 +373,11 @@ non-PASS verdict.
 
 ### Adding a new testbench
 
-Two lines in `hw/sim/run_verification.sh`:
-
-```bash
-TB_DEPS[tb_new_module]="SUB_DIR/new_module.sv"
-TB_CORE[tb_new_module]=N   # pick an unused core-id for the emitted trace
-```
-
-Then drop `hw/tb/tb_new_module.sv` with the canonical `$display` line on
-success / failure. See
+Add the self-checking `hw/tb/tb_<name>.sv`, wire its dependencies and
+trace lane into `hw/sim/run_verification.sh`, add it to the deterministic
+suite list, and verify it with `--list` plus `--tb <name>`. See
+[docs/SIMULATION.md](docs/SIMULATION.md#adding-a-testbench) for the full
+runner policy, and
 [pccx-lab's verification-workflow doc](https://pccxai.github.io/pccx/en/lab/verification-workflow.html)
 for the end-to-end flow diagram and the Tauri IPC surface.
 

--- a/docs/SIMULATION.md
+++ b/docs/SIMULATION.md
@@ -10,7 +10,7 @@ closure evidence, or a performance claim.
 - A sibling `pccx-lab` checkout, or `PCCX_LAB_DIR` set to that checkout.
   The runner builds `from_xsim_log` when the binary is missing.
 
-## Run Command
+## Runner Commands
 
 From the repository root:
 
@@ -18,22 +18,52 @@ From the repository root:
 bash hw/sim/run_verification.sh
 ```
 
-Quick smoke and per-testbench modes:
+The same script can also be run from `hw/sim/`:
 
 ```bash
+bash run_verification.sh
+```
+
+Selection flags:
+
+| Flag | Behavior |
+| --- | --- |
+| `--full` | Run every testbench in the deterministic `TB_LIST`. This is the default when no selector is supplied. |
+| `--quick` | Run the stable local smoke subset in `QUICK_TB_LIST`. Use this for fast pre-review checks. |
+| `--tb <name>` | Run one known testbench. The name must exist in `TB_DEPS`. |
+| `--list` | Print known testbench names in full-suite order and exit. |
+| `-h`, `--help` | Print usage and exit. |
+
+Common examples:
+
+```bash
+bash hw/sim/run_verification.sh --full
 bash hw/sim/run_verification.sh --quick
 bash hw/sim/run_verification.sh --tb tb_v002_runtime_smoke_program
+bash hw/sim/run_verification.sh --list
 ```
+
+Use one selector per command in normal evidence logs. If multiple
+selectors are passed, the script processes them left to right and the
+last selector that assigns a testbench set wins.
 
 The runner executes testbenches in deterministic order. A testbench passes
 only when its `xsim.log` contains a `PASS:` verdict. A missing verdict or
 an explicit `FAIL:` verdict makes the runner exit nonzero.
+
+Environment variables:
+
+| Variable | Behavior |
+| --- | --- |
+| `PCCX_LAB_DIR` | Path to a sibling or external `pccx-lab` checkout. Defaults to `../pccx-lab` relative to this repo. |
+| `XILINX_VIVADO` | Vivado install root. When set and `glbl.v` exists under it, the runner compiles `glbl` for XPM/CDC models. |
 
 ## Active Testbenches
 
 | Testbench | Coverage focus |
 | --- | --- |
 | `tb_shape_const_ram` | `shape_const_ram` reset, write, read, hold, overwrite contract |
+| `tb_mem_dispatcher_shape_lookup` | `mem_dispatcher` shape-constant lookup and LOAD pointer routing |
 | `tb_GEMM_dsp_packer_sign_recovery` | W4A8 packer and sign recovery lane behavior |
 | `tb_mat_result_normalizer` | GEMM result normalization to BF16 path |
 | `tb_GEMM_weight_dispatcher` | GEMM weight dispatcher lane-valid handling |
@@ -49,6 +79,55 @@ an explicit `FAIL:` verdict makes the runner exit nonzero.
 `program.json` and `v002_runtime_smoke.memh` inside the testbench work
 directory before xsim starts. This is a runtime handoff smoke only; it is
 not model inference, board execution, or throughput evidence.
+
+## Adding a Testbench
+
+The runner is intentionally explicit: every testbench must declare its
+RTL dependencies, trace lane, and suite membership in
+`hw/sim/run_verification.sh`.
+
+1. Add the self-checking testbench at `hw/tb/tb_<name>.sv`.
+   The module name must match the filename without `.sv` because the
+   runner invokes `xelab <tb_name>`.
+
+2. Emit exactly one final verdict that starts with `PASS:` or `FAIL:`.
+   The runner scans `xsim.log` for the first matching verdict line.
+   Missing verdicts are treated as failures.
+
+3. Add the compile dependency map entry. Paths are relative to `hw/rtl/`
+   and should include packages, interfaces, and DUT modules in compile
+   order:
+
+   ```bash
+   [tb_new_module]="NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv SUB_DIR/new_module.sv"
+   ```
+
+4. Add a trace core ID in `TB_CORE`. Pick an unused integer. Keeping IDs
+   contiguous makes composed pccx-lab timelines easier to read:
+
+   ```bash
+   [tb_new_module]=11
+   ```
+
+5. Append the testbench name to `TB_LIST` in the order the full suite
+   should run. Add it to `QUICK_TB_LIST` only when the test is stable,
+   fast, and suitable for local smoke checks.
+
+6. If the testbench needs generated inputs, write them under
+   `hw/sim/work/<tb_name>/` from inside `run_tb()` before `xvlog`.
+   Do not write generated stimuli into `hw/tb/` or commit simulator
+   output.
+
+7. Verify the runner metadata and the new test:
+
+   ```bash
+   bash hw/sim/run_verification.sh --list
+   bash hw/sim/run_verification.sh --tb tb_new_module
+   ```
+
+8. For review evidence, include the exact command, Vivado version,
+   runner summary, and the new `hw/sim/work/<tb_name>/` path if the
+   test fails.
 
 ## Generated Evidence
 


### PR DESCRIPTION
## Summary
- document run_verification.sh selection flags and environment variables
- add new-testbench policy covering TB_DEPS, TB_CORE, TB_LIST, QUICK_TB_LIST, verdicts, generated inputs, and evidence
- update README to point contributors to the detailed simulation policy

## Tests
- bash hw/sim/run_verification.sh --list
- bash hw/sim/run_verification.sh --help
- git diff --check