### PR TITLE
docs(env): synth resource requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ Pages, bilingual EN / KO).
   [SIMULATION.md](SIMULATION.md)
 - Repo-local Vivado timing evidence checklist:
   [TIMING_EVIDENCE.md](TIMING_EVIDENCE.md)
+- Repo-local Vivado synthesis resource policy:
+  [VIVADO_SYNTH_RESOURCE_POLICY.md](VIVADO_SYNTH_RESOURCE_POLICY.md)
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
 - Documentation root (language picker):

--- a/docs/RELEASE_EVIDENCE_CHECKLIST.md
+++ b/docs/RELEASE_EVIDENCE_CHECKLIST.md
@@ -115,6 +115,7 @@ include estimated or simulated numbers as hardware-measured results.
 
 - [ ] Exact `run_verification.sh` command and expected runtime noted
 - [ ] Required Vivado version and license type documented
+- [ ] Vivado synth host RAM, swap, and `PCCX_VIVADO_JOBS` setting documented
 - [ ] Required hardware (KV260 board revision) listed
 - [ ] Known non-reproducible parts identified (e.g. Vivado seed, licensed
       model weights)

--- a/docs/TIMING_EVIDENCE.md
+++ b/docs/TIMING_EVIDENCE.md
@@ -34,6 +34,12 @@ On memory-constrained hosts, reduce Vivado run parallelism:
 PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth
 ```
 
+See [VIVADO_SYNTH_RESOURCE_POLICY.md](VIVADO_SYNTH_RESOURCE_POLICY.md)
+for RAM, swap, and low-memory runner guidance. A
+`BLOCKED_RESOURCE_TERMINATED` synth attempt is missing synthesis
+evidence; do not infer timing, utilization, DRC, implementation, or
+bitstream status from it.
+
 For bounded status capture without launching Vivado:
 
 ```bash

--- a/docs/VIVADO_SYNTH_RESOURCE_POLICY.md
+++ b/docs/VIVADO_SYNTH_RESOURCE_POLICY.md
@@ -1,0 +1,111 @@
+# Vivado Synthesis Resource Policy
+
+This note records the host-resource requirements for the KV260 Vivado
+synthesis path. It is based on observed local and CI behavior, including
+a PR #108 synth attempt that returned `BLOCKED_RESOURCE_TERMINATED`
+before post-synthesis reports were produced.
+
+This page is operational guidance only. It does not claim synthesis
+success, implementation success, timing closure, or bitstream readiness.
+
+## Scope
+
+Applies to:
+
+- `cd hw && ./vivado/build.sh synth`
+- out-of-context synthesis of `NPU_top`
+- Vivado runs that are expected to produce `hw/build/reports/*_post_synth.rpt`
+
+Does not replace:
+
+- `docs/TIMING_EVIDENCE.md` for timing-evidence wording
+- full implementation / bitstream evidence
+- KV260 board smoke evidence
+
+## Observed Resource Blocker
+
+`BLOCKED_RESOURCE_TERMINATED` means the synth attempt did not finish
+because the host or runner stopped the job for resource reasons. Treat it
+as missing synthesis evidence:
+
+- no post-synthesis timing report
+- no post-synthesis DRC report
+- no post-synthesis utilization report
+- no bitstream evidence
+
+For review purposes, this status is different from an RTL, timing, or DRC
+failure. It says the selected machine was not a suitable Vivado synth
+host for this design snapshot.
+
+## Recommended Host Target
+
+Use a dedicated Linux host or self-hosted runner for full Vivado synth.
+The practical target is:
+
+| Resource | Recommendation |
+|----------|----------------|
+| RAM | 64 GiB target; 32 GiB minimum only for exploratory synth |
+| Swap | 64 GiB configured swap on SSD/NVMe |
+| CPU parallelism | start with `PCCX_VIVADO_JOBS=1`; raise only after one clean run |
+| Disk | keep at least 20 GiB free under `hw/build/` and the Vivado temp area |
+
+Avoid treating a standard low-memory hosted CI runner as authoritative
+for full Vivado synthesis. It can still run formatting, filelist, lint,
+dry-run, and script checks.
+
+## Standard Synth Command
+
+From repo root:
+
+```bash
+cd hw
+PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth
+```
+
+Record the exact command, Vivado version, host RAM, swap size, and final
+status in the PR. If the job is terminated by the runner before reports
+are written, record `BLOCKED_RESOURCE_TERMINATED` and do not infer any
+timing or utilization result.
+
+## Swap Setup Guidance
+
+On a dedicated Linux synth host, provision swap before launching Vivado.
+One typical setup is:
+
+```bash
+sudo fallocate -l 64G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+swapon --show
+free -h
+```
+
+Use site-local policy for persistent `/etc/fstab` entries. Do not enable
+swap inside shared CI jobs unless the runner owner explicitly allows it.
+
+## Low-Memory Strategy
+
+When a high-memory host is unavailable, use a staged evidence path:
+
+1. Run non-Vivado checks and dry-run capture:
+
+   ```bash
+   bash scripts/v002/run-timing-evidence.sh --dry-run
+   ```
+
+2. Run RTL/filelist sanity checks that do not require full Vivado synth.
+3. If Vivado is available, run with `PCCX_VIVADO_JOBS=1` and preserve the
+   log tail when the runner terminates or the process is stopped.
+4. Mark the result as blocked resource evidence, not as RTL, timing, or
+   implementation evidence:
+
+   ```text
+   RESULT_STATUS=BLOCKED_RESOURCE_TERMINATED
+   ```
+
+5. Defer synth evidence collection to a 64 GiB target host or self-hosted
+   runner.
+
+Do not promote `impl`, bitstream packaging, release evidence, or timing
+closure from a resource-terminated synth attempt.

--- a/hw/vivado/README.md
+++ b/hw/vivado/README.md
@@ -23,7 +23,7 @@ cd hw
 ./vivado/build.sh project
 
 # Out-of-context synthesis (minutes to tens of minutes, depending on machine)
-./vivado/build.sh synth
+PCCX_VIVADO_JOBS=1 ./vivado/build.sh synth
 
 # Full implementation + bitstream (hour-scale)
 ./vivado/build.sh impl
@@ -63,6 +63,9 @@ Minimum report set:
 See [`../../docs/TIMING_EVIDENCE.md`](../../docs/TIMING_EVIDENCE.md) for
 the review checklist and wording rules. A generated timing report is
 evidence, not a timing-closure claim.
+
+For host sizing, swap, and resource-terminated synth attempts, see
+[`../../docs/VIVADO_SYNTH_RESOURCE_POLICY.md`](../../docs/VIVADO_SYNTH_RESOURCE_POLICY.md).
 
 ## Next steps to reach a running board
 


### PR DESCRIPTION
## Summary
- Add a Vivado synthesis resource policy for PR #108 resource-terminated synth attempts.
- Document target host sizing: 64 GiB RAM target, 32 GiB exploratory minimum, 64 GiB swap, and PCCX_VIVADO_JOBS=1 default.
- Link the policy from timing evidence, Vivado README, docs index, and release evidence checklist.

## Verification
- git diff --check

## Notes
- Docs-only change.
- BLOCKED_RESOURCE_TERMINATED is documented as missing synthesis evidence; the PR body makes no synthesis, implementation, timing, or bitstream readiness claim.