### PR TITLE
docs(release): v002.1 acceptance criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Added explicit pccx v002.1 KV260 acceptance criteria covering
+  bitstream generation, board-run evidence, and a Gemma 3N E4B token
+  observation gate without treating any criterion as complete.
+
 ## v0.1.0-alpha — 2026-05-01
 
 First public RTL preview of the pccx v002 NPU implementation targeting

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ Pages, bilingual EN / KO).
   [TIMING_EVIDENCE.md](TIMING_EVIDENCE.md)
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
+- Repo-local v002.1 KV260 acceptance criteria:
+  [releases/v002.1-acceptance-criteria.md](releases/v002.1-acceptance-criteria.md)
 - Documentation root (language picker):
   <https://pccxai.github.io/pccx/en/index.html>
 - pccx source repository:

--- a/docs/RELEASE_EVIDENCE_CHECKLIST.md
+++ b/docs/RELEASE_EVIDENCE_CHECKLIST.md
@@ -7,6 +7,8 @@ items are marked **[HW]**.
 
 See also: [`RELEASING.md`](../RELEASING.md) for the tagging process,
 and [`CHANGELOG.md`](../CHANGELOG.md) for the version under preparation.
+For the explicit future pccx v002.1 KV260 release gate, see
+[`docs/releases/v002.1-acceptance-criteria.md`](releases/v002.1-acceptance-criteria.md).
 
 ---
 
@@ -138,3 +140,22 @@ A tag **MUST NOT** be created unless:
 **No production release before full implementation + evidence collection.**
 `v0.2.0` is the earliest realistic target; see EPIC
 [#43](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/issues/43).
+
+## 9. v002.1 KV260 acceptance criteria
+
+The future pccx v002.1 KV260 release gate requires all of the following
+from the same candidate commit, bitstream, board, and Gemma 3N E4B
+runtime fixture:
+
+- [ ] Bitstream generated, with Vivado version, command, post-implementation
+      timing summary, basename, and SHA256 recorded.
+- [ ] KV260 board run captured, with board identifier, programming log,
+      runtime command, sanitized environment, stdout, stderr, console, and
+      summary files retained.
+- [ ] Gemma 3N E4B token observed from the KV260 NPU runtime path, with
+      input fixture, output token excerpt, model fixture identity, commit
+      SHA, bitstream SHA256, and board run evidence tied together.
+
+Blocked, fallback, simulation-only, synthesis-only, or host-only evidence
+does not satisfy the v002.1 gate. This checklist defines the required
+criteria; it does not mark them complete.

--- a/docs/releases/v002.1-acceptance-criteria.md
+++ b/docs/releases/v002.1-acceptance-criteria.md
@@ -1,0 +1,79 @@
+# pccx v002.1 KV260 Acceptance Criteria
+
+This page defines the explicit release gate for a future pccx v002.1
+KV260 release. It is a criteria document only: it does not record board
+evidence, mark any item complete, or state that the release gate is met.
+
+The v002.1 release gate requires all three criteria below to be backed by
+public-safe evidence from the same commit, bitstream, board run, and
+Gemma 3N E4B runtime fixture.
+
+## Required Criteria
+
+### 1. Bitstream generation
+
+Release evidence must include:
+
+- Git commit SHA and branch used for the build.
+- Vivado version, target device, and exact bitstream-generation command.
+- Post-implementation timing summary with WNS, TNS, and failing endpoint
+  count for each release clock.
+- Bitstream basename and SHA256.
+- Storage location for the generated bitstream outside git, such as a
+  GitHub Release asset or internal handoff path acceptable for the
+  release owner.
+
+Simulation-only, synthesis-only, or dry-run evidence is not sufficient
+for this criterion.
+
+### 2. KV260 board run
+
+Release evidence must include:
+
+- KV260 board identifier, board revision when known, and boot path.
+- Programming log showing the v002.1 candidate bitstream was loaded, or
+  a recorded reason why loading was skipped because the same bitstream
+  hash was already resident.
+- Board-side runtime command and sanitized environment.
+- Captured stdout, stderr, console, and summary files from the run.
+- Runtime status from the NPU path, not a software fallback path.
+
+Fallback, loopback, blocked, or host-only runs may remain useful
+bring-up notes, but they do not satisfy this criterion.
+
+### 3. Gemma 3N E4B token observed
+
+Release evidence must include:
+
+- Gemma 3N E4B model fixture identity, quantization notes, and tokenizer
+  identity without committing private weights or local cache paths.
+- Prompt or token-ID input fixture.
+- At least one decoded output token captured from the KV260 NPU runtime
+  path.
+- The token log tied to the same commit, bitstream SHA256, board run, and
+  runtime command recorded above.
+- Clear separation between measured board output and any simulated,
+  estimated, or fallback output.
+
+Throughput may be recorded only when the measurement method is included.
+A token observation alone does not establish a tok/s target.
+
+## Evidence Location
+
+Use the existing Gemma 3N E4B evidence tree for public-safe run records:
+
+```text
+docs/evidence/kv260-gemma3n-e4b/<run_id>/
+```
+
+Required run records should include `summary.txt`, sanitized runtime logs,
+the bitstream SHA256, the commit SHA, the board identifier, and the output
+token excerpt. Do not commit bitstreams, model weights, private paths, or
+raw board dumps that contain secrets.
+
+## Release Note Wording
+
+Before the v002.1 release gate is satisfied, release notes should describe
+these items as acceptance criteria or remaining gates. They should not
+state or imply that KV260 Gemma 3N E4B board inference, timing closure,
+or measured throughput is complete without the evidence above.


### PR DESCRIPTION
## Summary
- add explicit pccx v002.1 KV260 acceptance criteria for bitstream generation, board-run evidence, and Gemma 3N E4B token observation
- link the criteria from the release evidence checklist and docs index
- record the docs update in the changelog

## Validation
- scripts/v002/claim-scan.sh
- git diff --check

## Notes
- Criteria are documented as future release gates only; no item is marked complete.