### PR TITLE
docs(spec): axi port allocation

### DIFF
--- a/docs/runbooks/v002.1-bitstream-build.md
+++ b/docs/runbooks/v002.1-bitstream-build.md
@@ -43,6 +43,32 @@ The scaffold connects PS HPM AXI-Lite to `S_AXIL_CTRL`, PS HP0/HP1
 memory ports to the four weight-stream DMAs, and a coherent ACP/HPC path
 to the feature-map/result DMA.
 
+## BD AXI Port Allocation
+
+This table records the wiring created by `hw/vivado/system_bd.tcl` in
+PR #82. Treat it as the BD scaffold contract for the user-terminal Vivado
+run; the generated address report remains the source for final segment
+offsets after `assign_bd_address`.
+
+| Function | BD path | PS-side port | NPU-side port | Width / protocol | Notes |
+| --- | --- | --- | --- | --- | --- |
+| NPU control/status MMIO | `ps_0` HPM0 -> `axi_ctrl_interconnect/M00_AXI` | `M_AXI_HPM0_FPD` fallback list | `S_AXIL_CTRL` | 64-bit AXI4-Lite at the NPU wrapper | Intended NPU base `0xA0000000`; BD requests a 64 KB segment while the RTL decode uses 12-bit addresses. |
+| HP0 weight DMA control | `axi_ctrl_interconnect/M01_AXI` | HPM0 via control interconnect | `dma_hp0_weight_mm2s/S_AXI_LITE` | AXI4-Lite | DMA control address is assigned by Vivado and must be read from `address_map.rpt`. |
+| HP1 weight DMA control | `axi_ctrl_interconnect/M02_AXI` | HPM0 via control interconnect | `dma_hp1_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP2 weight DMA control | `axi_ctrl_interconnect/M03_AXI` | HPM0 via control interconnect | `dma_hp2_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP3 weight DMA control | `axi_ctrl_interconnect/M04_AXI` | HPM0 via control interconnect | `dma_hp3_weight_mm2s/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| ACP fmap/result DMA control | `axi_ctrl_interconnect/M05_AXI` | HPM0 via control interconnect | `dma_acp_fmap_result/S_AXI_LITE` | AXI4-Lite | Same address-map rule as HP0. |
+| HP0 weight memory read | `dma_hp0_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S00_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP0_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP0 stream; physical DDR reads share PS HP0/HP1. |
+| HP1 weight memory read | `dma_hp1_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S01_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP1_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP1 stream; physical DDR reads share PS HP0/HP1. |
+| HP2 weight memory read | `dma_hp2_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S02_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP2_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP2 stream; physical DDR reads share PS HP0/HP1. |
+| HP3 weight memory read | `dma_hp3_weight_mm2s/M_AXI_MM2S` -> `axi_hp_interconnect/S03_AXI` | `S_AXI_HP0_FPD` or `S_AXI_HP1_FPD` through `axi_hp_interconnect` | `S_AXI_HP3_WEIGHT` via `M_AXIS_MM2S` | 128-bit AXI4-Stream into NPU | Logical NPU HP3 stream; physical DDR reads share PS HP0/HP1. |
+| ACP feature-map ingress | `dma_acp_fmap_result/M_AXI_MM2S` -> `axi_acp_interconnect/S00_AXI` plus `M_AXIS_MM2S` | `S_AXI_ACP_FPD`, fallback `S_AXI_HPC0_FPD` / `S_AXI_HPC1_FPD` | `S_AXIS_ACP_FMAP` | 128-bit AXI4-Stream into NPU | DDR-to-NPU direction for feature maps and L2 ingress traffic. |
+| ACP result egress | `dma_acp_fmap_result/M_AXI_S2MM` -> `axi_acp_interconnect/S01_AXI` plus `S_AXIS_S2MM` | `S_AXI_ACP_FPD`, fallback `S_AXI_HPC0_FPD` / `S_AXI_HPC1_FPD` | `M_AXIS_ACP_RESULT` | 128-bit AXI4-Stream out of NPU | NPU-to-DDR direction for result traffic. |
+
+The `system_bd.tcl` fallback interface-name lists are intentional because
+Vivado exposes different Zynq UltraScale+ PS pin names across board-file
+and IP versions. Do not treat a fallback name as a separate allocation.
+
 ## Prerequisites
 
 - Vivado/Vitis with Zynq UltraScale+ support. Record the exact version


### PR DESCRIPTION
Docs-only stacked on PR #82.\n\n- Documents the AXI-Lite, HP weight DMA, and ACP fmap/result allocation implemented by hw/vivado/system_bd.tcl.\n- Calls out that DMA control offsets come from the generated address_map.rpt after assign_bd_address.\n- Does not record a timing, bitstream, or board-deploy claim.