### PR TITLE
docs(release): v002.1 signoff evidence list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ Pages, bilingual EN / KO).
   [TIMING_EVIDENCE.md](TIMING_EVIDENCE.md)
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
+- v002.1 sign-off evidence file list:
+  [evidence/v002.1-signoff-evidence-list.md](evidence/v002.1-signoff-evidence-list.md)
 - Documentation root (language picker):
   <https://pccxai.github.io/pccx/en/index.html>
 - pccx source repository:

--- a/docs/evidence/v002.1-signoff-evidence-list.md
+++ b/docs/evidence/v002.1-signoff-evidence-list.md
@@ -1,0 +1,198 @@
+# v002.1 Sign-Off Evidence File List
+
+Date: 2026-05-07
+
+This document is the explicit file list for a future v002.1 sign-off
+bundle. It does not claim sign-off, release readiness, timing closure,
+bitstream availability, KV260 inference, Gemma 3N E4B hardware execution,
+or measured throughput.
+
+Source citations:
+
+- PR [#95](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/95),
+  `docs/evidence/v002.1-evidence-inventory.md`: inventory of the v002.1
+  evidence stack, generated evidence paths, blocked board/runtime paths,
+  and missing gates.
+- PR [#82](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/82),
+  `docs/runbooks/v002.1-bitstream-build.md`: full-top KV260 bitstream
+  runbook, Vivado log/report names, pre-deploy gates, SD packaging, and
+  board-smoke capture directory.
+
+## Status Rule
+
+Every file listed here is required evidence for sign-off unless marked
+optional or conditional. A file appearing in this list only means "must be
+collected or explicitly marked blocked"; it does not mean the file exists
+or that the corresponding gate passed.
+
+## Source-Control Evidence
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `docs/evidence/v002.1-evidence-inventory.md` | PR #95 inventory | Snapshot the PR evidence stack and missing-gate state used for sign-off review. |
+| `docs/runbooks/v002.1-bitstream-build.md` | PR #82 runbook | Keep the full-top bitstream runbook used for the sign-off attempt. |
+| `hw/vivado/system_bd.tcl` | PR #82 runbook | Keep the BD scaffold used by the full-top flow. |
+| `docs/evidence/v002.1-signoff-evidence-list.md` | This file | Keep the exact file checklist reviewed for the sign-off attempt. |
+
+## Simulation Evidence
+
+PR #95 records the xsim evidence boundary and expected generated artifact
+locations. For each testbench included in the candidate regression, retain:
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `hw/sim/work/<tb_name>/xvlog.log` | PR #95 inventory | Compile log for the testbench run. |
+| `hw/sim/work/<tb_name>/xelab.log` | PR #95 inventory | Elaboration log for the testbench run. |
+| `hw/sim/work/<tb_name>/xsim.log` | PR #95 inventory | Simulation log with pass/fail evidence. |
+| `hw/sim/work/<tb_name>/from_xsim_log.log` | PR #95 inventory | Trace-conversion log, when the runner emits it. |
+| `hw/sim/work/<tb_name>/<tb_name>.pccx` | PR #95 inventory | pccx-lab trace artifact for timeline review. |
+| `docs/evidence/v002.1-signoff/<run_id>/xsim-summary.txt` | PR #95 inventory | Sign-off bundle summary naming the command, commit SHA, Vivado/xsim version, and per-TB result. |
+
+If a testbench does not produce a `.pccx` trace or converter log, the
+sign-off bundle must include a note in `xsim-summary.txt` explaining why.
+
+## Synth And Timing Evidence
+
+PR #95 lists generic post-synthesis and post-implementation evidence
+paths. PR #82 adds full-top report basenames for the BD flow. Retain the
+files below from the candidate SHA.
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `hw/build/reports/utilization_post_synth.rpt` | PR #95 inventory | OOC or existing synth utilization report, if that flow is part of the candidate evidence. |
+| `hw/build/reports/clocks_post_synth.rpt` | PR #95 inventory | Post-synth clock report. |
+| `hw/build/reports/clock_interaction_post_synth.rpt` | PR #95 inventory | Post-synth clock interaction report. |
+| `hw/build/reports/timing_summary_post_synth.rpt` | PR #95 inventory | Post-synth timing summary. |
+| `hw/build/reports/drc_post_synth.rpt` | PR #95 inventory | Post-synth DRC report. |
+| `hw/build/reports/synth_baseline.json` | PR #95 inventory | v002.1 synth-baseline JSON when that flow is executed. |
+| `hw/build/v002-timing-evidence/<run_id>/summary.txt` | PR #95 inventory | Timing helper summary using the approved status vocabulary. |
+| `hw/build/reports/utilization_full_top_post_synth.rpt` | PR #82 runbook | Full-top post-synth utilization report from `system_bd.tcl synth`. |
+| `hw/build/reports/clocks_full_top_post_synth.rpt` | PR #82 runbook | Full-top post-synth clock report. |
+| `hw/build/reports/clock_interaction_full_top_post_synth.rpt` | PR #82 runbook | Full-top post-synth clock interaction report. |
+| `hw/build/reports/timing_summary_full_top_post_synth.rpt` | PR #82 runbook | Full-top post-synth timing summary. |
+| `hw/build/reports/drc_full_top_post_synth.rpt` | PR #82 runbook | Full-top post-synth DRC report. |
+| `hw/build/reports/utilization_full_top_post_impl.rpt` | PR #82 runbook | Full-top post-implementation utilization report. |
+| `hw/build/reports/clock_interaction_full_top_post_impl.rpt` | PR #82 runbook | Full-top post-implementation clock interaction report. |
+| `hw/build/reports/route_status_full_top_post_impl.rpt` | PR #82 runbook | Full-top route status report. |
+| `hw/build/reports/timing_summary_full_top_post_impl.rpt` | PR #82 runbook | Full-top post-implementation timing summary. |
+| `hw/build/reports/drc_full_top_post_impl.rpt` | PR #82 runbook | Full-top post-implementation DRC report. |
+| `hw/build/reports/methodology_full_top_post_impl.rpt` | PR #82 `system_bd.tcl` | Full-top post-implementation methodology report. |
+| `hw/build/reports/power_full_top_post_impl.rpt` | PR #82 runbook | Full-top post-implementation power report. |
+| `hw/build/reports/timing_summary_full_top_bitstream_checkpoint.rpt` | PR #82 `system_bd.tcl` | Timing summary after opening the implementation checkpoint for bitstream write. |
+
+If both generic and full-top report names are present, the sign-off bundle
+must state which set is authoritative for the candidate bitstream.
+
+## Vivado Run Logs
+
+PR #82 defines the full-top commands and log names. Retain both `.log`
+and `.jou` files for every launched action.
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `hw/build/logs/v002_1_bd_prepare.log` | PR #82 runbook | BD prepare log. |
+| `hw/build/logs/v002_1_bd_prepare.jou` | PR #82 runbook | BD prepare journal. |
+| `hw/build/logs/v002_1_full_top_synth.log` | PR #82 runbook | Full-top synth log. |
+| `hw/build/logs/v002_1_full_top_synth.jou` | PR #82 runbook | Full-top synth journal. |
+| `hw/build/logs/v002_1_full_top_impl.log` | PR #82 runbook | Full-top implementation log. |
+| `hw/build/logs/v002_1_full_top_impl.jou` | PR #82 runbook | Full-top implementation journal. |
+| `hw/build/logs/v002_1_full_top_bitstream.log` | PR #82 runbook | Full-top bitstream-write log. |
+| `hw/build/logs/v002_1_full_top_bitstream.jou` | PR #82 runbook | Full-top bitstream-write journal. |
+| `hw/build/reports/address_map.rpt` | PR #82 runbook | Address map used for AXI-Lite and DMA board smoke. |
+
+## Bitstream And SD Packaging Evidence
+
+Generated bitstreams and Vivado build directories remain out of git.
+Retain these as release artifacts or external sign-off evidence.
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `hw/build/pccx_v002_kv260.bit` | PR #82 runbook, PR #95 inventory | Generated bitstream artifact; do not commit it. |
+| `hw/build/pccx_v002_kv260.bit.bin` | PR #82 runbook | Bootgen-converted bitstream image when the SD image requires it. |
+| `hw/build/pccx_v002_kv260.bif` | PR #82 runbook | Bootgen input file used for `.bit.bin` conversion. |
+| `hw/build/reports/bitstream_sha256.txt` | PR #82 runbook | SHA256 for `.bit` and `.bit.bin`. |
+| `docs/evidence/v002.1-signoff/<run_id>/sd-staging-log.txt` | PR #82 runbook | Sanitized copy/staging log for firmware placement. |
+| `docs/evidence/v002.1-signoff/<run_id>/vivado-version.txt` | PR #82 runbook | Exact Vivado/Vitis version used for the bitstream attempt. |
+| `docs/evidence/v002.1-signoff/<run_id>/commit-sha.txt` | PR #82 runbook, PR #95 inventory | Candidate Git commit SHA. |
+
+## KV260 Board-Smoke Evidence
+
+PR #82 recommends `docs/evidence/kv260-bitstream/<run_id>/` for board
+smoke capture. A sign-off bundle must retain these files for the candidate
+bitstream attempt.
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `docs/evidence/kv260-bitstream/<run_id>/summary.txt` | PR #82 runbook | Board-smoke verdict summary, including blocked status if any gate fails. |
+| `docs/evidence/kv260-bitstream/<run_id>/board-id.txt` | PR #82 runbook | Board identifier or reason it could not be recorded. |
+| `docs/evidence/kv260-bitstream/<run_id>/commit-sha.txt` | PR #82 runbook | Candidate Git commit SHA loaded on the board. |
+| `docs/evidence/kv260-bitstream/<run_id>/vivado-version.txt` | PR #82 runbook | Vivado/Vitis version used for the loaded bitstream. |
+| `docs/evidence/kv260-bitstream/<run_id>/bitstream_sha256.txt` | PR #82 runbook | SHA256 of the bitstream loaded or attempted. |
+| `docs/evidence/kv260-bitstream/<run_id>/xmutil-listapps.txt` | PR #82 runbook | `xmutil listapps` output. |
+| `docs/evidence/kv260-bitstream/<run_id>/xmutil-loadapp.txt` | PR #82 runbook | `xmutil loadapp pccx_npu` output or failure. |
+| `docs/evidence/kv260-bitstream/<run_id>/dmesg-after-load.txt` | PR #82 runbook | Kernel log after load attempt. |
+| `docs/evidence/kv260-bitstream/<run_id>/devmem-read.txt` | PR #82 runbook | AXI-Lite read output or failure. |
+| `docs/evidence/kv260-bitstream/<run_id>/devmem-kick.txt` | PR #82 runbook | AXI-Lite kick write output or failure. |
+| `docs/evidence/kv260-bitstream/<run_id>/dmesg-after-devmem.txt` | PR #82 runbook | Kernel log after AXI-Lite smoke. |
+| `docs/evidence/kv260-bitstream/<run_id>/xbutil-examine.txt` | PR #82 runbook | Conditional: required only for XRT images. |
+| `docs/evidence/kv260-bitstream/<run_id>/xrt-smi-examine.txt` | PR #82 runbook | Conditional: required only for XRT images. |
+
+## Gemma 3N E4B Runtime Evidence
+
+PR #95 records current blocked KV260/Gemma evidence paths and says only a
+future `PASS_KV260_NPU` directory with logs, bitstream hash, commit SHA,
+runtime output, and measurement method should be treated as KV260 NPU
+smoke evidence.
+
+| Required file | Source | Requirement |
+| --- | --- | --- |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/summary.txt` | PR #95 inventory | Runtime summary with `result_status`, commit, bitstream basename/SHA, token count, and tok/s fields. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/blocker.txt` | PR #95 inventory | Required when status is `BLOCKED_*` or a dry run. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/host_stdout.log` | Local runner used by PR #95 paths | Host-side runner stdout. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/host_stderr.log` | Local runner used by PR #95 paths | Host-side runner stderr. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/input.txt` | Local runner used by PR #95 paths | Prompt fixture used for the smoke run. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/requested_tokens.txt` | Local runner used by PR #95 paths | Requested max-new-token count. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/remote_result.env` | Local runner used by PR #95 paths | Board-side result fields fetched from the runtime run. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/generated_output.txt` | Local runner used by PR #95 paths | Generated output fetched from the board run. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/runtime_stdout.log` | Local runner used by PR #95 paths | Runtime stdout fetched from the board. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/runtime_stderr.log` | Local runner used by PR #95 paths | Runtime stderr fetched from the board. |
+| `docs/evidence/kv260-gemma3n-e4b/<run_id>/measurement-method.txt` | PR #95 inventory | Required for any measured throughput statement. |
+
+`PASS_KV260_FALLBACK` and `BLOCKED_*` directories are useful readiness
+evidence, but they are not KV260 NPU inference evidence.
+
+## Sign-Off Bundle Index
+
+Create this index for the actual candidate review:
+
+```text
+docs/evidence/v002.1-signoff/<run_id>/MANIFEST.md
+```
+
+The manifest must map every required file above to one of:
+
+- `present`
+- `not_run`
+- `blocked`
+- `not_applicable`
+
+Use `not_applicable` only for conditional files such as XRT-specific logs.
+Every `blocked` or `not_run` entry needs a short reason and a next action.
+
+## Claim Guard
+
+Allowed wording for this document:
+
+- "required evidence files are listed"
+- "evidence paths are identified"
+- "blocked or missing files must be recorded before sign-off"
+
+Do not write:
+
+- sign-off complete
+- release ready
+- timing-closure success
+- bitstream ready
+- KV260 inference success
+- Gemma 3N E4B hardware-run success
+- 20 tok/s measured on hardware


### PR DESCRIPTION
## Summary
- Add docs/evidence/v002.1-signoff-evidence-list.md as the explicit required-file checklist for a future v002.1 sign-off bundle.
- Cite PR #95 evidence inventory and PR #82 bitstream runbook as the source basis for required simulation, Vivado, bitstream, board-smoke, and runtime evidence files.
- Link the new evidence list from docs/README.md.

## Validation
- git diff --check HEAD~1..HEAD
- bash scripts/v002/claim-scan.sh -> UNSUPPORTED_CLAIM_FOUND=no
- bash scripts/v002/artifact-safety-check.sh -> ARTIFACT_SAFETY=PASS

## Claim guard
Documentation-only. This PR lists required evidence files and does not claim sign-off, release readiness, timing closure, bitstream availability, KV260 inference, Gemma 3N E4B hardware execution, measured throughput, or production release status.

Refs #95, #82.