### PR TITLE
Redefine repository as KV260 + PCCX v002 LLM integration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,90 @@
+# v002 IP-core extraction migration map
+
+This map records reusable IP-core files copied from this KV260 integration repository into `pccx-v002`. The in-tree copies remain in this repository during this phase; a later integration step will consume `pccx-v002` directly before duplicate sources are removed.
+
+Source: `pccx-v002/SOURCE_MANIFEST.md`
+
+| old path | new owner repo | new path | reason |
+| --- | --- | --- | --- |
+| `hw/rtl/Constants/compilePriority_Order/A_const_svh/GLOBAL_CONST.svh` | `pccx-v002` | `common/rtl/packages/legacy/GLOBAL_CONST.svh` | include updated for device profile rename |
+| `hw/rtl/Constants/compilePriority_Order/A_const_svh/NUMBERS.svh` | `pccx-v002` | `common/rtl/packages/NUMBERS.svh` | none |
+| `hw/rtl/Constants/compilePriority_Order/A_const_svh/npu_arch.svh` | `pccx-v002` | `common/rtl/packages/npu_arch.svh` | board reference removed from copied comment |
+| `hw/rtl/Constants/compilePriority_Order/B_device_pkg/device_pkg.sv` | `pccx-v002` | `common/rtl/packages/device_pkg.sv` | none |
+| `hw/rtl/Constants/compilePriority_Order/C_type_pkg/dtype_pkg.sv` | `pccx-v002` | `common/rtl/packages/dtype_pkg.sv` | none |
+| `hw/rtl/Constants/compilePriority_Order/C_type_pkg/mem_pkg.sv` | `pccx-v002` | `common/rtl/packages/mem_pkg.sv` | include updated for device profile rename |
+| `hw/rtl/Constants/compilePriority_Order/D_pipeline_pkg/vec_core_pkg.sv` | `pccx-v002` | `common/rtl/packages/vec_core_pkg.sv` | target-specific comment removed |
+| `hw/rtl/Constants/compilePriority_Order/E_obs_pkg/perf_counter_pkg.sv` | `pccx-v002` | `common/rtl/packages/perf_counter_pkg.sv` | none |
+| `hw/rtl/Library/Algorithms/Algorithms.sv` | `pccx-v002` | `common/rtl/packages/Algorithms.sv` | none |
+| `hw/rtl/Library/Algorithms/BF16_math.sv` | `pccx-v002` | `common/rtl/packages/BF16_math.sv` | none |
+| `hw/rtl/Library/Algorithms/QUEUE/IF_queue.sv` | `pccx-v002` | `common/rtl/interfaces/IF_queue.sv` | none |
+| `hw/rtl/Library/Algorithms/QUEUE/QUEUE.sv` | `pccx-v002` | `common/rtl/wrappers/QUEUE.sv` | none |
+| `hw/rtl/NPU_Controller/npu_interfaces.svh` | `pccx-v002` | `common/rtl/interfaces/npu_interfaces.svh` | none |
+| `hw/rtl/barrel_shifter_BF16.sv` | `pccx-v002` | `common/rtl/wrappers/barrel_shifter_BF16.sv` | none |
+| `hw/rtl/Constants/compilePriority_Order/A_const_svh/kv260_device.svh` | `pccx-v002` | `common/rtl/packages/device_profile.svh` | board-named device profile generalized |
+| `hw/rtl/CVO_CORE/CVO_cordic_unit.sv` | `pccx-v002` | `LLM/rtl/core/cvo/CVO_cordic_unit.sv` | none |
+| `hw/rtl/CVO_CORE/CVO_sfu_unit.sv` | `pccx-v002` | `LLM/rtl/core/cvo/CVO_sfu_unit.sv` | none |
+| `hw/rtl/CVO_CORE/CVO_top.sv` | `pccx-v002` | `LLM/rtl/core/cvo/CVO_top.sv` | none |
+| `hw/rtl/MAT_CORE/FROM_mat_result_packer.sv` | `pccx-v002` | `LLM/rtl/core/mat/FROM_mat_result_packer.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_Array.svh` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_Array.svh` | none |
+| `hw/rtl/MAT_CORE/GEMM_accumulator.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_accumulator.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_dsp_packer.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_dsp_packer.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_dsp_unit.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_dsp_unit.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_dsp_unit_last_ROW.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_dsp_unit_last_ROW.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_fmap_staggered_delay.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_fmap_staggered_delay.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_sign_recovery.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_sign_recovery.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_systolic_array.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_systolic_array.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_systolic_top.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_systolic_top.sv` | none |
+| `hw/rtl/MAT_CORE/GEMM_weight_dispatcher.sv` | `pccx-v002` | `LLM/rtl/core/mat/GEMM_weight_dispatcher.sv` | none |
+| `hw/rtl/MAT_CORE/mat_result_normalizer.sv` | `pccx-v002` | `LLM/rtl/core/mat/mat_result_normalizer.sv` | none |
+| `hw/rtl/MEM_control/IO/mem_IO.svh` | `pccx-v002` | `LLM/rtl/interfaces/mem_IO.svh` | none |
+| `hw/rtl/MEM_control/IO/mem_u_operation_queue.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_u_operation_queue.sv` | none |
+| `hw/rtl/MEM_control/memory/Constant_Memory/shape_const_ram.sv` | `pccx-v002` | `LLM/rtl/core/memory/Constant_Memory/shape_const_ram.sv` | none |
+| `hw/rtl/MEM_control/memory/mem_BUFFER.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_BUFFER.sv` | none |
+| `hw/rtl/MEM_control/memory/mem_GLOBAL_cache.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_GLOBAL_cache.sv` | none |
+| `hw/rtl/MEM_control/top/mem_CVO_stream_bridge.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_CVO_stream_bridge.sv` | none |
+| `hw/rtl/MEM_control/top/mem_HP_buffer.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_HP_buffer.sv` | none |
+| `hw/rtl/MEM_control/top/mem_L2_cache_fmap.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_L2_cache_fmap.sv` | none |
+| `hw/rtl/MEM_control/top/mem_dispatcher.sv` | `pccx-v002` | `LLM/rtl/core/memory/mem_dispatcher.sv` | none |
+| `hw/rtl/NPU_Controller/Global_Scheduler.sv` | `pccx-v002` | `LLM/rtl/core/controller/Global_Scheduler.sv` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_memctrl.svh` | `pccx-v002` | `LLM/rtl/packages/isa/isa_memctrl.svh` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv` | `pccx-v002` | `LLM/rtl/packages/isa/isa_pkg.sv` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_x32.svh` | `pccx-v002` | `LLM/rtl/packages/isa/isa_x32.svh` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_x64.svh` | `pccx-v002` | `LLM/rtl/packages/isa/isa_x64.svh` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_decode_const.svh` | `pccx-v002` | `LLM/rtl/packages/controller/ctrl_decode_const.svh` | none |
+| `hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv` | `pccx-v002` | `LLM/rtl/core/controller/ctrl_npu_decoder.sv` | none |
+| `hw/rtl/NPU_Controller/NPU_frontend/AXIL_CMD_IN.sv` | `pccx-v002` | `LLM/rtl/core/controller/AXIL_CMD_IN.sv` | none |
+| `hw/rtl/NPU_Controller/NPU_frontend/AXIL_STAT_OUT.sv` | `pccx-v002` | `LLM/rtl/core/controller/AXIL_STAT_OUT.sv` | none |
+| `hw/rtl/NPU_Controller/NPU_frontend/ctrl_npu_frontend.sv` | `pccx-v002` | `LLM/rtl/core/controller/ctrl_npu_frontend.sv` | none |
+| `hw/rtl/NPU_Controller/npu_controller_top.sv` | `pccx-v002` | `LLM/rtl/core/controller/npu_controller_top.sv` | none |
+| `hw/rtl/NPU_top.sv` | `pccx-v002` | `LLM/rtl/top/pccx_npu_top.sv` | package top rename |
+| `hw/rtl/PREPROCESS/fmap_cache.sv` | `pccx-v002` | `LLM/rtl/core/preprocess/fmap_cache.sv` | none |
+| `hw/rtl/PREPROCESS/preprocess_bf16_fixed_pipeline.sv` | `pccx-v002` | `LLM/rtl/core/preprocess/preprocess_bf16_fixed_pipeline.sv` | none |
+| `hw/rtl/PREPROCESS/preprocess_fmap.sv` | `pccx-v002` | `LLM/rtl/core/preprocess/preprocess_fmap.sv` | none |
+| `hw/rtl/VEC_CORE/GEMV_Vec_Matrix_MUL.svh` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_Vec_Matrix_MUL.svh` | none |
+| `hw/rtl/VEC_CORE/GEMV_accumulate.sv` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_accumulate.sv` | none |
+| `hw/rtl/VEC_CORE/GEMV_generate_lut.sv` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_generate_lut.sv` | none |
+| `hw/rtl/VEC_CORE/GEMV_reduction.sv` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_reduction.sv` | none |
+| `hw/rtl/VEC_CORE/GEMV_reduction_branch.sv` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_reduction_branch.sv` | none |
+| `hw/rtl/VEC_CORE/GEMV_top.sv` | `pccx-v002` | `LLM/rtl/core/vec/GEMV_top.sv` | none |
+| `hw/sim/run_verification.sh` | `pccx-v002` | `LLM/sim/run_verification.sh` | simulation paths updated for package layout |
+| `hw/tb/tb_FROM_mat_result_packer.sv` | `pccx-v002` | `LLM/tb/tb_FROM_mat_result_packer.sv` | none |
+| `hw/tb/tb_GEMM_dsp_packer_sign_recovery.sv` | `pccx-v002` | `LLM/tb/tb_GEMM_dsp_packer_sign_recovery.sv` | none |
+| `hw/tb/tb_GEMM_fmap_staggered_delay.sv` | `pccx-v002` | `LLM/tb/tb_GEMM_fmap_staggered_delay.sv` | none |
+| `hw/tb/tb_GEMM_weight_dispatcher.sv` | `pccx-v002` | `LLM/tb/tb_GEMM_weight_dispatcher.sv` | none |
+| `hw/tb/tb_barrel_shifter_BF16.sv` | `pccx-v002` | `LLM/tb/tb_barrel_shifter_BF16.sv` | none |
+| `hw/tb/tb_ctrl_npu_decoder.sv` | `pccx-v002` | `LLM/tb/tb_ctrl_npu_decoder.sv` | none |
+| `hw/tb/tb_mat_result_normalizer.sv` | `pccx-v002` | `LLM/tb/tb_mat_result_normalizer.sv` | none |
+| `hw/tb/tb_mem_dispatcher_shape_lookup.sv` | `pccx-v002` | `LLM/tb/tb_mem_dispatcher_shape_lookup.sv` | none |
+| `hw/tb/tb_mem_u_operation_queue.sv` | `pccx-v002` | `LLM/tb/tb_mem_u_operation_queue.sv` | none |
+| `hw/tb/tb_shape_const_ram.sv` | `pccx-v002` | `LLM/tb/tb_shape_const_ram.sv` | none |
+| `hw/tb/tb_v002_runtime_smoke_program.sv` | `pccx-v002` | `LLM/tb/tb_v002_runtime_smoke_program.sv` | none |
+| `formal/sail/Makefile` | `pccx-v002` | `LLM/formal/sail/Makefile` | none |
+| `formal/sail/README.md` | `pccx-v002` | `LLM/formal/sail/README.md` | none |
+| `formal/sail/pccx.sail_project` | `pccx-v002` | `LLM/formal/sail/pccx.sail_project` | none |
+| `formal/sail/src/pccx_decode.sail` | `pccx-v002` | `LLM/formal/sail/src/pccx_decode.sail` | none |
+| `formal/sail/src/pccx_execute.sail` | `pccx-v002` | `LLM/formal/sail/src/pccx_execute.sail` | none |
+| `formal/sail/src/pccx_regs.sail` | `pccx-v002` | `LLM/formal/sail/src/pccx_regs.sail` | target-model example removed from copied comment |
+| `formal/sail/src/pccx_types.sail` | `pccx-v002` | `LLM/formal/sail/src/pccx_types.sail` | none |
+| `formal/sail/src/prelude.sail` | `pccx-v002` | `LLM/formal/sail/src/prelude.sail` | none |
+| `formal/sail/tests/smoke_decode.sail` | `pccx-v002` | `LLM/formal/sail/tests/smoke_decode.sail` | none |
+| `hw/vivado/filelist.f` | `pccx-v002` | `LLM/scripts/filelist.f` | package compile list path with BD shim removed |

--- a/README.md
+++ b/README.md
@@ -256,20 +256,22 @@ Details: [KV cache strategy →](https://pccxai.github.io/pccx/en/docs/v002/Arch
 
 ---
 
-## Roadmap — Two-Track
+## Roadmap — Integration and IP-core lines
 
-This repository hosts the RTL for **both** active tracks. As of
-2026-04-20:
+This repository remains the KV260 + PCCX v002 LLM application
+integration repo. Reusable v002 IP-core ownership moves to `pccx-v002`;
+future v003 IP-core ownership will be separate in `pccx-v003`.
 
-| Track | Target model | Planned target | Horizon | Shared RTL assets |
-|-------|-------------|------|---------|-------------------|
-| **v002 Extended** (this repo, `main`) | Gemma 3N E4B | **20 tok/s** target, evidence-gated | Week 1–49 | sparse weight fetcher (Phase G), EAGLE draft/verify dispatch (Phase H+), SSD scheduler (Phase I), tree mask generator (Phase J) |
-| **v003** (future branch) | Gemma 4 E4B | **12–15 tok/s** target | Week 16–52 (parallel) | reuses v002 Phase G/H/I/J modules with hidden/layer/KV-head re-parameterization |
+| Track | Owner | Target model | Scope | Status |
+|-------|-------|--------------|-------|--------|
+| **v002 integration** | this repo + `pccx-v002` | Gemma 3N E4B | KV260 board flow, bare-metal driver, application wiring, and v002 LLM package consumption | In progress |
+| **v003 IP-core** | `pccx-v003` | Gemma 4 E4B | Separate IP-core line and compatibility contract | Future / TBD |
 
-- v002 freeze → snapshotted into `pccx/codes/v002/` via the pccx
-  version-cutover workflow (`tools/freeze_active.sh`).
-- v003 lives on a later branch of this same repo; the pccx docs site
-  will fork its own `v003/` docs tree at the same time.
+- This repository keeps its in-tree RTL copy during the transition.
+- A later phase will wire `pccx-v002` in as the consumed IP-core source,
+  then remove duplicate in-tree copies once the integration boundary is
+  verified.
+- v003 RTL belongs to the separate IP-core repository line.
 
 Full phase-by-phase plan, decision points, compute budget, and Year 2
 **Auto-Porting Pipeline α** vision:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pccx — Bare-Metal Transformer Accelerator on Kria KV260
 
+> This repository is the KV260 + PCCX v002 LLM application integration
+> repo. The reusable v002 IP-core lives in `pccx-v002` (LLM package).
+> Future v003 IP-core will live in `pccx-v003`.
+
 Open SystemVerilog NPU for experimental Gemma-class LLM acceleration on
 AMD/Xilinx Kria KV260.
 
@@ -17,11 +21,10 @@ Next milestone: v0.2.0 evidence pack
 
 **Current status:** RTL alpha · timing closure and full runtime bring-up in progress.
 
-This repo is the **bare-metal Kria KV260 implementation** of the
-**pccx v002** NPU architecture. It hosts an early SystemVerilog RTL and
-bare-metal driver source snapshot intended to close the loop between the
-pccx architecture specification, source-level RTL inspection, early
-verification setup, and planned KV260 bring-up.
+This repo is the **KV260 + PCCX v002 LLM application integration** repo.
+It hosts board integration, bare-metal driver source, application wiring,
+and a copied RTL baseline while the integration flow is being reworked to
+consume the reusable `pccx-v002` LLM package.
 
 This is not a timing-closed production bitstream release — Vivado
 synthesis, trace-driven verification, and full Gemma 3N E4B application
@@ -51,7 +54,7 @@ issues are welcome.
 | Entry point | Link |
 | --- | --- |
 | Architecture & ISA spec | <https://pccxai.github.io/pccx/en/docs/v002/index.html> |
-| RTL reference (this repo) | [`hw/rtl/`](hw/rtl/) — top wrapper [`NPU_top.sv`](hw/rtl/NPU_top.sv) |
+| RTL baseline copy (transition) | [`hw/rtl/`](hw/rtl/) — top wrapper [`NPU_top.sv`](hw/rtl/NPU_top.sv) |
 | Releases | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/releases> |
 | `v0.1.0-alpha` notes | [docs/releases/v0.1.0-alpha.md](docs/releases/v0.1.0-alpha.md) |
 | Roadmap (project board) | <https://github.com/orgs/pccxai/projects/1> |
@@ -73,14 +76,16 @@ issues are welcome.
 | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | Architecture / ISA / driver spec     | `pccx/docs/v002/`                          | [pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)               |
 | Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://pccxai.github.io/pccx/en/docs/v002/Models/index.html)        |
-| RTL (SystemVerilog)                  | this repo — `hw/rtl/`                      | —                                                                                         |
+| Reusable v002 IP-core RTL            | `pccx-v002/LLM/`, `pccx-v002/common/`      | `pccx-v002` compatibility contract                                                         |
+| KV260 integration RTL copy           | this repo — `hw/rtl/`                      | Transition copy until this repo consumes `pccx-v002`                                       |
 | Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://pccxai.github.io/pccx/en/docs/v002/Drivers/api.html)  |
 | Application (planned, v0.2.0)        | this repo — `sw/gemma3NE4B/` (not yet in tree) | —                                                                                     |
 
 If you want to **read about how the accelerator works**, head to the
 **[pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)** —
 that's the canonical source for every architectural decision in this repo.
-If you want to **read the RTL or synthesize the bitstream**, stay here.
+If you want to **inspect the current KV260 integration copy or run the
+board flow**, stay here.
 
 ---
 


### PR DESCRIPTION
Documentation-only redefinition of this repository's role.

Changes
- README top notice clarifying that this repository is the KV260 + PCCX v002 LLM application integration repo. The reusable v002 IP-core lives in pccx-v002.
- MIGRATION.md mapping every reusable file to its new home in pccx-v002.
- Removed wording that implied v003 RTL would live on a future branch of this repo. v003 will live in pccx-v003.

No source files are removed in this PR. Source removal happens in the stacked PR (PCCX-v002 submodule consumption) referenced below.

## Related PRs (multi-repo v002 extraction)

- https://github.com/pccxai/pccx-v002/pull/1 — Introduce PCCX v002 IP-core package
- https://github.com/pccxai/pccx/pull/60 — Document PCCX v002/v003 repository topology
- https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/128 — Redefine KV260 as PCCX v002 LLM integration
- https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/129 — Consume pccx-v002 via submodule and remove duplicate RTL  *(stacked on the role-redefinition PR)*

Review/merge order: pccx-v002 → pccx → kv260 role → kv260 submodule.
Do not merge until all four are approved.

