### PR TITLE
Add PCCX trademark notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,3 +403,11 @@ for the end-to-end flow diagram and the Tauri IPC surface.
 
 Apache 2.0 — same as pccx. This protects the architecture from patent
 risk while keeping the ecosystem open for hardware research.
+
+## Trademark
+
+`PCCX™` is a mark used by the PCCX project. Korean trademark
+applications are pending for PCCX in Classes 09 and 42. Registration
+has not been granted; do not use `PCCX®` until the central trademark
+policy is updated. See
+[`pccx/TRADEMARKS.md`](https://github.com/pccxai/pccx/blob/main/TRADEMARKS.md).


### PR DESCRIPTION
Adds a small public-safe PCCX™ trademark notice and links to the central pccx trademark policy. This does not claim registration and does not include private filing records.