### PR TITLE
Add PCCX source headers and SPDX notices

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: repo-validate
 
 # Lightweight always-run gate. Fast, decisive, no external installs.

--- a/.library_mapping.xml
+++ b/.library_mapping.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <com.sigasi.hdt.shared.librarymapping.model:LibraryMappings xmlns:com.sigasi.hdt.shared.librarymapping.model="com.sigasi.hdt.vhdl.scoping.librarymapping" Version="2">
   <Mappings Location="Common Libraries/IEEE" Library="ieee"/>
   <Mappings Location="Common Libraries/IEEE Synopsys" Library="ieee"/>

--- a/COMPATIBILITY.yaml
+++ b/COMPATIBILITY.yaml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 application: pccx-FPGA-NPU-LLM-kv260
 board: kv260
 models:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/hw/vivado/create_project.tcl
+++ b/hw/vivado/create_project.tcl
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # =============================================================================
 # create_project.tcl — builds the pccx v002 Vivado project for KV260.
 #

--- a/hw/vivado/impl.tcl
+++ b/hw/vivado/impl.tcl
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # =============================================================================
 # impl.tcl — implementation + bitstream for the pccx v002 NPU core.
 #

--- a/hw/vivado/npu_core_wrapper.sv
+++ b/hw/vivado/npu_core_wrapper.sv
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 `timescale 1ns / 1ps
 
 // ===============================================================================

--- a/hw/vivado/synth.tcl
+++ b/hw/vivado/synth.tcl
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # =============================================================================
 # synth.tcl — out-of-context synthesis pass for the pccx v002 core.
 #

--- a/scripts/kv260/run_gemma3n_e4b_smoke.sh
+++ b/scripts/kv260/run_gemma3n_e4b_smoke.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 set -Eeuo pipefail
 IFS=$'\n\t'
 

--- a/scripts/v002/artifact-safety-check.sh
+++ b/scripts/v002/artifact-safety-check.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Guard against committing heavyweight artifacts, private paths, or secrets.
 
 set -Eeuo pipefail

--- a/scripts/v002/claim-scan.sh
+++ b/scripts/v002/claim-scan.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Scan source/docs for unsupported public claims.
 
 set -Eeuo pipefail

--- a/scripts/v002/run-local-candidate.sh
+++ b/scripts/v002/run-local-candidate.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Run local v002 candidate checks that do not require a board.
 #
 # Logs are written under hw/build/ so run evidence stays out of git.

--- a/scripts/v002/run-throughput-report.sh
+++ b/scripts/v002/run-throughput-report.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Produce a bounded throughput report from KV260/runtime evidence.
 
 set -Eeuo pipefail

--- a/scripts/v002/run-timing-evidence.sh
+++ b/scripts/v002/run-timing-evidence.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Collect bounded v002 timing evidence without claiming closure.
 
 set -Eeuo pipefail

--- a/scripts/v002/use_submodule_sources.sh
+++ b/scripts/v002/use_submodule_sources.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"

--- a/sw/driver/uCA_v1_api.c
+++ b/sw/driver/uCA_v1_api.c
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA API Implementation |==================================================
 // Builds 64-bit VLIW instructions from structured arguments and issues them
 // to the NPU via the HAL. Encoding per pccx v002 ISA:

--- a/sw/driver/uCA_v1_api.h
+++ b/sw/driver/uCA_v1_api.h
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA API (High-Level Driver Interface) |====================================
 // uCA: micro Compute Architecture — AI model acceleration API for FPGA NPU.
 //

--- a/sw/driver/uCA_v1_hal.c
+++ b/sw/driver/uCA_v1_hal.c
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA HAL Implementation |==================================================
 // AXI-Lite MMIO access for bare-metal KV260.
 // Direct pointer-based memory-mapped I/O — no OS, no mmap, no syscalls.

--- a/sw/driver/uCA_v1_hal.h
+++ b/sw/driver/uCA_v1_hal.h
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA HAL (Hardware Abstraction Layer) |=====================================
 // Low-level AXI-Lite MMIO register access for the uCA NPU.
 // This layer owns all physical address reads/writes.

--- a/tools/v002/estimate_tokens_per_second.py
+++ b/tools/v002/estimate_tokens_per_second.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Estimate measured throughput from runtime evidence when complete enough."""
 
 from __future__ import annotations


### PR DESCRIPTION
Adds `PCCX(TM)` + `SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0` to source files that lack a header. No identifiers/modules/packages renamed; no behavior changes; no `PCCX®` claim; no private filing materials. Generated/vendor/lock/binary files skipped.