### PR TITLE
Use Cloudflare canonical docs link

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ abstract: >-
 type: software
 license: Apache-2.0
 repository-code: "https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260"
-url: "https://pccxai.github.io/pccx/"
+url: "https://pccx.pages.dev/"
 authors:
   - family-names: Kim
     given-names: Hyunwoo

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ wiring are still in progress or planned.
 > specifies — read the spec first, then come back here for the KV260
 > integration flow.
 >
-> **→ [pccx v002 — Architecture & ISA spec](https://pccxai.github.io/pccx/en/docs/v002/index.html)**
-> &nbsp;·&nbsp; [Gemma 3N E4B on pccx v002](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
-> &nbsp;·&nbsp; [한국어 문서](https://pccxai.github.io/pccx/ko/docs/v002/index.html)
+> **→ [pccx v002 — Architecture & ISA spec](https://pccx.pages.dev/en/docs/v002/index.html)**
+> &nbsp;·&nbsp; [Gemma 3N E4B on pccx v002](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_execution.html)
+> &nbsp;·&nbsp; [한국어 문서](https://pccx.pages.dev/ko/docs/v002/index.html)
 
 Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profiler / simulator)](https://github.com/pccxai/pccx-lab) · [llm-bottleneck-lab (related research)](https://github.com/hkimw/llm-bottleneck-lab)
 
@@ -54,7 +54,7 @@ issues are welcome.
 
 | Entry point | Link |
 | --- | --- |
-| Architecture & ISA spec | <https://pccxai.github.io/pccx/en/docs/v002/index.html> |
+| Architecture & ISA spec | <https://pccx.pages.dev/en/docs/v002/index.html> |
 | RTL consumed by KV260 | [`third_party/pccx-v002/LLM/rtl/`](third_party/pccx-v002/LLM/rtl/) + [`third_party/pccx-v002/common/rtl/`](third_party/pccx-v002/common/rtl/) via [`hw/vivado/filelist.v002.f`](hw/vivado/filelist.v002.f); top [`pccx_npu_top.sv`](third_party/pccx-v002/LLM/rtl/top/pccx_npu_top.sv) |
 | Releases | <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/releases> |
 | `v0.1.0-alpha` notes | [docs/releases/v0.1.0-alpha.md](docs/releases/v0.1.0-alpha.md) |
@@ -67,7 +67,7 @@ issues are welcome.
 
 > The repository **Wiki** is intentionally empty — RTL- and bring-up
 > questions belong in **Discussions**, and the canonical architecture
-> documentation lives on the [pccx Sphinx site](https://pccxai.github.io/pccx/en/docs/v002/index.html).
+> documentation lives on the [pccx Sphinx site](https://pccx.pages.dev/en/docs/v002/index.html).
 
 ---
 
@@ -75,15 +75,15 @@ issues are welcome.
 
 | Layer                                | Lives in                                   | Authoritative source                                                                     |
 | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Architecture / ISA / driver spec     | `pccx/docs/v002/`                          | [pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)               |
-| Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://pccxai.github.io/pccx/en/docs/v002/Models/index.html)        |
+| Architecture / ISA / driver spec     | `pccx/docs/v002/`                          | [pccx v002 docs](https://pccx.pages.dev/en/docs/v002/index.html)               |
+| Target-model pipeline (Gemma 3N E4B) | `pccx/docs/v002/Models/`                   | [Models section](https://pccx.pages.dev/en/docs/v002/Models/index.html)        |
 | Reusable v002 IP-core RTL            | `third_party/pccx-v002/LLM/`, `third_party/pccx-v002/common/` | `pccx-v002` compatibility contract + [`third_party/PINS.md`](third_party/PINS.md) |
 | KV260 Vivado integration             | this repo — `hw/vivado/`                   | Wrapper, Tcl flow, and [`filelist.v002.f`](hw/vivado/filelist.v002.f)                 |
-| Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://pccxai.github.io/pccx/en/docs/v002/Drivers/api.html)  |
+| Bare-metal driver (C/C++)            | this repo — `sw/driver/`                   | API spec: [Drivers/api](https://pccx.pages.dev/en/docs/v002/Drivers/api.html)  |
 | Application (planned, v0.2.0)        | this repo — `sw/gemma3NE4B/` (not yet in tree) | —                                                                                     |
 
 If you want to **read about how the accelerator works**, head to the
-**[pccx v002 docs](https://pccxai.github.io/pccx/en/docs/v002/index.html)** —
+**[pccx v002 docs](https://pccx.pages.dev/en/docs/v002/index.html)** —
 that's the canonical source for every architectural decision in this repo.
 If you want to **inspect the KV260 integration wrapper, the submodule
 pin, or the board flow**, stay here.
@@ -92,7 +92,7 @@ pin, or the board flow**, stay here.
 
 ## Architecture Snapshot (pccx v002)
 
-[![pccx v002 architecture](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/architecture_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/top_level.html)
+[![pccx v002 architecture](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/architecture_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/top_level.html)
 
 *Click the diagram for the annotated top-level page on the pccx site.*
 
@@ -109,8 +109,8 @@ Three heterogeneous cores around a centralized L2 URAM cache:
 - **Activation path**: host DDR4 → ACP DMA → L2 URAM (1.75 MB, true dual port).
 - **Direct-connect FIFO**: GEMV → SFU, so softmax runs without an L2 round-trip.
 
-Full rationale and numbers: [Top-Level →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/top_level.html)
-· [Design rationale →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/rationale.html)
+Full rationale and numbers: [Top-Level →](https://pccx.pages.dev/en/docs/v002/Architecture/top_level.html)
+· [Design rationale →](https://pccx.pages.dev/en/docs/v002/Architecture/rationale.html)
 
 ---
 
@@ -120,16 +120,16 @@ Weight-stationary 2D systolic layout. Activations broadcast along
 columns, partial sums propagate vertically into the result accumulator.
 Used only during prefill; idle during decode.
 
-[![GEMM array layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_1_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
+[![GEMM array layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_1_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/gemm_core.html)
 
 Inside each PE — a DSP48E2 wrapped with input flip-flops on both
 Activation and Weight ports, and an accumulator with a P-register
 output:
 
-[![GEMM single PE](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_2_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
+[![GEMM single PE](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_2_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/gemm_core.html)
 
-Details: [GEMM core →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemm_core.html)
-· [GEMM dataflow →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Details: [GEMM core →](https://pccx.pages.dev/en/docs/v002/Architecture/gemm_core.html)
+· [GEMM dataflow →](https://pccx.pages.dev/en/docs/v002/ISA/dataflow.html)
 
 ---
 
@@ -140,15 +140,15 @@ Activation broadcast and a Weight row. Outputs feed a reduction tree
 that collapses partial products into the final vector entry register.
 The primary compute path during autoregressive decode.
 
-[![GEMV core layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_1_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
+[![GEMV core layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_1_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/gemv_core.html)
 
 Per-cycle operand shapes — a 1×N activation row multiplied against an
 N×N weight tile:
 
-[![GEMV operand shapes](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_2_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
+[![GEMV operand shapes](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMV_2_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/gemv_core.html)
 
-Details: [GEMV core →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/gemv_core.html)
-· [GEMV dataflow →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Details: [GEMV core →](https://pccx.pages.dev/en/docs/v002/Architecture/gemv_core.html)
+· [GEMV dataflow →](https://pccx.pages.dev/en/docs/v002/ISA/dataflow.html)
 
 ---
 
@@ -159,12 +159,12 @@ The DSP48E2 has a single 27×18 multiplier, not two. pccx v002 bit-packs
 port B, so each DSP emits **two MACs per cycle** into the 48-bit
 accumulator with a 19-bit guard band between the two channels.
 
-[![DSP48E2 W4A8 port layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_4_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+[![DSP48E2 W4A8 port layout](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_4_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 After accumulation, a sign-recovery step restores the upper channel
 when the lower channel borrowed a carry:
 
-[![Sign recovery SV snippet](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_5_v002.png)](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+[![Sign recovery SV snippet](https://raw.githubusercontent.com/pccxai/pccx/main/assets/images/Architecture/v002/Processing_Elements_GEMM_5_v002.png)](https://pccx.pages.dev/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 - Maximum accumulations before draining the ACCM: **2^10 ≈ 1024** per
   channel (guard-band limited).
@@ -173,7 +173,7 @@ when the lower channel borrowed a carry:
   tree and merges the partial sums.
 - Peak: **2048 MAC × 400 MHz ≈ 819 GMAC/s** across the two systolic arrays.
 
-Details: [DSP48E2 W4A8 bit-packing →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)
+Details: [DSP48E2 W4A8 bit-packing →](https://pccx.pages.dev/en/docs/v002/Architecture/dsp48e2_w4a8.html)
 
 ---
 
@@ -196,12 +196,12 @@ End-to-end decode flow, per-cycle overlap strategy, instruction-level
 mapping, memory layout, and the performance budget all live in the
 pccx Models section:
 
-- [Gemma 3N overview](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)
-- [Full operator pipeline (embedding → sampling)](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)
-- [Attention & RoPE constraints](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)
-- [PLE & LAuReL routing rules](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)
-- [FFN Gaussian Top-K sparsity](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)
-- [**Execution & scheduling on pccx v002**](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)
+- [Gemma 3N overview](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_overview.html)
+- [Full operator pipeline (embedding → sampling)](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_pipeline.html)
+- [Attention & RoPE constraints](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_attention_rope.html)
+- [PLE & LAuReL routing rules](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ple_laurel.html)
+- [FFN Gaussian Top-K sparsity](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ffn_sparsity.html)
+- [**Execution & scheduling on pccx v002**](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_execution.html)
 
 ---
 
@@ -217,8 +217,8 @@ Five opcodes, 64 bits each: `[63:60]` opcode + `[59:0]` body.
 | `4'h3` | `OP_MEMSET`| Write shape / size / scale constants to the Constant Cache              |
 | `4'h4` | `OP_CVO`   | Element-wise non-linear (exp, sqrt, GELU, sin, cos, reduce_sum, scale, recip) |
 
-Spec: [Per-instruction encoding →](https://pccxai.github.io/pccx/en/docs/v002/ISA/instructions.html)
-· [Dataflow per opcode →](https://pccxai.github.io/pccx/en/docs/v002/ISA/dataflow.html)
+Spec: [Per-instruction encoding →](https://pccx.pages.dev/en/docs/v002/ISA/instructions.html)
+· [Dataflow per opcode →](https://pccx.pages.dev/en/docs/v002/ISA/dataflow.html)
 
 The pipeline is **fully decoupled**: the front-end decodes and enqueues
 into per-engine FIFOs, and each compute engine fires independently once
@@ -253,7 +253,7 @@ enforced at RTL / memory controller / driver level:
    (`max_tokens = 8192`). Wrap-around overwrites the oldest entries.
    This bounds both OOM risk and worst-case memory traffic.
 
-Details: [KV cache strategy →](https://pccxai.github.io/pccx/en/docs/v002/Architecture/kv_cache.html)
+Details: [KV cache strategy →](https://pccx.pages.dev/en/docs/v002/Architecture/kv_cache.html)
 
 ---
 
@@ -277,8 +277,8 @@ future v003 IP-core ownership will be separate in `pccx-v003`.
 Full phase-by-phase plan, decision points, compute budget, and Year 2
 **Auto-Porting Pipeline α** vision:
 
-**→ [Roadmap (EN)](https://pccxai.github.io/pccx/en/docs/roadmap.html)**
-&nbsp;·&nbsp; [**한국어**](https://pccxai.github.io/pccx/ko/docs/roadmap.html)
+**→ [Roadmap (EN)](https://pccx.pages.dev/en/docs/roadmap.html)**
+&nbsp;·&nbsp; [**한국어**](https://pccx.pages.dev/ko/docs/roadmap.html)
 
 ---
 
@@ -382,7 +382,7 @@ Reusable testbench registration lives in
 sources under `third_party/pccx-v002/LLM/tb/`. Changes to that reusable
 suite belong in `pccx-v002`; this repo should only update KV260-specific
 runtime inputs and wrappers. See
-[pccx-lab's verification-workflow doc](https://pccxai.github.io/pccx/en/lab/verification-workflow.html)
+[pccx-lab's verification-workflow doc](https://pccx.pages.dev/en/lab/verification-workflow.html)
 for the end-to-end flow diagram and the Tauri IPC surface.
 
 ### What plugs into pccx-lab

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Pages, bilingual EN / KO).
 ## Jump straight in
 
 - **Latest architecture — v002** (current target of this repo):
-  <https://pccxai.github.io/pccx/en/docs/v002/index.html>
+  <https://pccx.pages.dev/en/docs/v002/index.html>
 - Repo-local KV260 bring-up checklist:
   [KV260_BRINGUP.md](KV260_BRINGUP.md)
 - Repo-local Gemma 3N handoff boundary:
@@ -21,7 +21,7 @@ Pages, bilingual EN / KO).
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
 - Documentation root (language picker):
-  <https://pccxai.github.io/pccx/en/index.html>
+  <https://pccx.pages.dev/en/index.html>
 - pccx source repository:
   <https://github.com/pccxai/pccx>
 
@@ -29,14 +29,14 @@ Pages, bilingual EN / KO).
 
 | Old file (deleted)               | New location                                                                                                                |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `FPGA_NPU_Architecture_v2.md`    | [v002 Architecture](https://pccxai.github.io/pccx/en/docs/v002/Architecture/index.html)                                  |
-| `ISA.md`                         | [v002 ISA](https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html)                                                    |
-| `HW_Optimization_DSP48E2.md`     | [DSP48E2 W4A8 bit-packing](https://pccxai.github.io/pccx/en/docs/v002/Architecture/dsp48e2_w4a8.html)                    |
-| `GEMMA_3N_E4B.md`                | [Gemma 3N overview](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_overview.html)                             |
-| `Gemma3N_Pipeline_EN.md`         | [Gemma 3N pipeline](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_pipeline.html)                             |
-| `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_attention_rope.html)               |
-| `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
-| `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
-| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://pccxai.github.io/pccx/en/docs/v002/Models/gemma3n_execution.html)              |
+| `FPGA_NPU_Architecture_v2.md`    | [v002 Architecture](https://pccx.pages.dev/en/docs/v002/Architecture/index.html)                                  |
+| `ISA.md`                         | [v002 ISA](https://pccx.pages.dev/en/docs/v002/ISA/index.html)                                                    |
+| `HW_Optimization_DSP48E2.md`     | [DSP48E2 W4A8 bit-packing](https://pccx.pages.dev/en/docs/v002/Architecture/dsp48e2_w4a8.html)                    |
+| `GEMMA_3N_E4B.md`                | [Gemma 3N overview](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_overview.html)                             |
+| `Gemma3N_Pipeline_EN.md`         | [Gemma 3N pipeline](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_pipeline.html)                             |
+| `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_attention_rope.html)               |
+| `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
+| `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
+| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_execution.html)              |
 
 For the Korean mirror, swap `/en/` for `/ko/` in any of the links above.

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,8 +9,8 @@ SPDX-License-Identifier: Apache-2.0
 <head>
 <meta charset="utf-8">
 <title>uXC documentation has moved</title>
-<meta http-equiv="refresh" content="0; url=https://pccxai.github.io/pccx/en/docs/v002/index.html">
-<link rel="canonical" href="https://pccxai.github.io/pccx/en/docs/v002/index.html">
+<meta http-equiv="refresh" content="0; url=https://pccx.pages.dev/en/docs/v002/index.html">
+<link rel="canonical" href="https://pccx.pages.dev/en/docs/v002/index.html">
 <style>
   html, body { margin: 0; padding: 0; background: #0b1021; color: #e6e6e6; font-family: system-ui, -apple-system, sans-serif; }
   main { max-width: 640px; margin: 10vh auto; padding: 0 24px; }
@@ -22,14 +22,14 @@ SPDX-License-Identifier: Apache-2.0
 <main>
 <h1>Documentation moved</h1>
 <p>uXC / pccx documentation now lives at:</p>
-<p><a href="https://pccxai.github.io/pccx/en/docs/v002/index.html">
-https://pccxai.github.io/pccx/en/docs/v002/index.html
+<p><a href="https://pccx.pages.dev/en/docs/v002/index.html">
+https://pccx.pages.dev/en/docs/v002/index.html
 </a></p>
 <p>If you are not redirected automatically, click the link above.</p>
 <p>Source: <a href="https://github.com/pccxai/pccx">github.com/pccxai/pccx</a></p>
 </main>
 <script>
-  window.location.replace("https://pccxai.github.io/pccx/en/docs/v002/index.html");
+  window.location.replace("https://pccx.pages.dev/en/docs/v002/index.html");
 </script>
 </body>
 </html>

--- a/sw/driver/uCA_v1_api.c
+++ b/sw/driver/uCA_v1_api.c
@@ -5,7 +5,7 @@
 // ===| uCA API Implementation |==================================================
 // Builds 64-bit VLIW instructions from structured arguments and issues them
 // to the NPU via the HAL. Encoding per pccx v002 ISA:
-// https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html
+// https://pccx.pages.dev/en/docs/v002/ISA/index.html
 // ================================================================================
 
 #include "uCA_v1_api.h"

--- a/sw/driver/uCA_v1_api.h
+++ b/sw/driver/uCA_v1_api.h
@@ -14,7 +14,7 @@
 // uca_* call returns immediately after issuing to the instruction FIFO.
 // Call uca_sync() to wait for all in-flight operations to complete.
 //
-// Encoding reference: https://pccxai.github.io/pccx/en/docs/v002/ISA/index.html
+// Encoding reference: https://pccx.pages.dev/en/docs/v002/ISA/index.html
 // ================================================================================
 
 #ifndef UCA_V1_API_H


### PR DESCRIPTION
Updates README/docs links to use https://pccx.pages.dev/en/ as the canonical PCCX™ documentation URL. Also keeps trademark and evidence-gated status wording accurate. No code behavior changes.