### PR TITLE
Tighten public documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pccx — Bare-Metal Transformer Accelerator on Kria KV260
 
+PCCX™ technology / operated by Altifigence™.
+
 > This repository is the KV260 + PCCX v002 LLM application integration
 > repo. The reusable v002 IP-core is pinned at `third_party/pccx-v002`.
 > Future v003 IP-core will live in `pccx-v003`.
@@ -8,27 +10,28 @@ Open SystemVerilog NPU for experimental Gemma-class LLM acceleration on
 AMD/Xilinx Kria KV260.
 
 ```text
-PCCX KV260 Roadmap
+PCCX KV260 Evidence State
 
-RTL Alpha        ███████████████░░  85%
-Verification     ███████████░░░░░  70%
-Driver Bring-up  ███████░░░░░░░░░  45%
-Bitstream        ████░░░░░░░░░░░░  25%
-Public Release   ██░░░░░░░░░░░░░░  15%
-
-Next milestone: v0.2.0 evidence pack
+xsim: PASS 12/0
+post-synth timing: RTL synthesis-closed (WNS 0.052)
+post-impl timing recovery in progress; evidence pending
+bitstream: not generated
+KV260 board execution: no evidence
+Gemma 3N E4B runtime: no evidence
+throughput: no measurement
 ```
 
-**Current status:** RTL alpha · timing closure and full runtime bring-up in progress.
+**Current status:** RTL synthesis-closed (WNS 0.052); post-impl timing recovery in progress; evidence pending.
 
 This repo is the **KV260 + PCCX v002 LLM application integration** repo.
 It hosts board integration, bare-metal driver source, application wiring,
 and the Vivado/sim wrappers that consume the reusable `pccx-v002` LLM
 package through `third_party/pccx-v002` and `hw/vivado/filelist.v002.f`.
 
-This is not a timing-closed production bitstream release — Vivado
-synthesis, trace-driven verification, and full Gemma 3N E4B application
-wiring are still in progress or planned.
+This is not a production bitstream release. xsim and RTL synthesis
+evidence are present; post-impl timing recovery, bitstream generation,
+board execution, and full Gemma 3N E4B application wiring remain in
+progress or pending.
 
 > ### Start with the architecture docs
 >
@@ -48,9 +51,9 @@ Related repos: [pccx (spec)](https://github.com/pccxai/pccx) · [pccx-lab (profi
 ## Project status
 
 **Public alpha** — `v0.1.0-alpha` is published as a prerelease. Core
-RTL and ISA are stable; verification and KV260 bring-up are in
-progress. This is not a timing-closed bitstream release. Feedback and
-issues are welcome.
+RTL and ISA are available; verification and KV260 bring-up are in
+progress. This is not a bitstream release. Feedback and issues are
+welcome.
 
 | Entry point | Link |
 | --- | --- |

--- a/docs/GEMMA3N_HANDOFF.md
+++ b/docs/GEMMA3N_HANDOFF.md
@@ -82,7 +82,7 @@ Use:
 Avoid:
 
 - wording that presents Gemma 3N E4B board execution as complete
-- wording that presents KV260 inference as proven without logs
+- wording that presents board inference as proven without logs
 - throughput wording without tied evidence
 - production-readiness wording
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,6 @@ Pages, bilingual EN / KO).
 | `Attention_RoPE.md`              | [Gemma 3N attention / RoPE](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_attention_rope.html)               |
 | `PLE_LAuReL.md`                  | [Gemma 3N PLE & LAuReL](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ple_laurel.html)                       |
 | `FFN_Sparsity.md`                | [Gemma 3N FFN sparsity](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_ffn_sparsity.html)                     |
-| *(new)* how the model runs here  | [Gemma 3N on pccx v002 execution](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_execution.html)              |
+| *(new)* target-model mapping here | [Gemma 3N on pccx v002 execution](https://pccx.pages.dev/en/docs/v002/Models/gemma3n_execution.html)              |
 
 For the Korean mirror, swap `/en/` for `/ko/` in any of the links above.

--- a/docs/RELEASE_EVIDENCE_CHECKLIST.md
+++ b/docs/RELEASE_EVIDENCE_CHECKLIST.md
@@ -73,7 +73,7 @@ date: 2026-04-20, design: NPU_top, device: xck26-sfvc784-2LV-c).
 - [ ] Utilization post-implementation recorded
 - [ ] Clock interaction post-implementation recorded
 - [ ] Critical path summary noted in release notes
-- [ ] Bitstream generated (`.bit` not committed to git — attach to GitHub
+- [ ] Bitstream evidence recorded (`.bit` not committed to git — attach to GitHub
       Release or record SHA + generation command)
 
 ---

--- a/docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md
+++ b/docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Connection to board smoke:
 
 Not yet verified by this template:
 
-- KV260 NPU inference.
+- KV260 NPU execution.
 - Gemma 3N E4B hardware execution.
-- 20 tok/s throughput.
+- Measured throughput.
 - Timing closure.

--- a/docs/internal/kv260_gemma3n_e4b_hardware_handoff.md
+++ b/docs/internal/kv260_gemma3n_e4b_hardware_handoff.md
@@ -335,7 +335,7 @@ owner is not surprised when the next clean-host synth surfaces them.
   and `drc_post_synth.rpt` before promoting to impl.
 - The wrapper change is signal-level only — no behavioural delta on
   `NPU_top`. The TB suite is the regression evidence (7/7 PASS).
-- Do not claim KV260 inference success or timing closure unless the
+- Do not claim board inference success or timing closure unless the
   board run logs prove it. Until §5 items land, the public alpha
   scope statement (“FPGA bring-up in progress, no production claims”)
   is the only honest description.

--- a/docs/internal/stage_c_completion_notes.md
+++ b/docs/internal/stage_c_completion_notes.md
@@ -18,7 +18,7 @@ Per the Stage C decisions memo:
 - **Out of scope** (hard limits):
   - No FPGA RTL functional changes.
   - No top-level interface changes.
-  - No KV260 inference claims.
+  - No board inference claims.
   - No timing-closed claims.
   - No release / tag creation.
 
@@ -230,7 +230,7 @@ throughout.
 This batch did **not** touch:
 
 - Release tags (no v0.1.1-alpha or anything similar).
-- README claims about FPGA stable / timing-closed / KV260 inference.
+- README claims about FPGA stable / timing-closed / board inference.
 - The `docs/RELEASE_EVIDENCE_CHECKLIST.md` content.
 
 The internal docs added under `docs/internal/` describe engineering


### PR DESCRIPTION
| Repo | Token / required item | File:line | Proposed replacement |
| --- | --- | --- | --- |
| `pccx-FPGA-NPU-LLM-kv260` | Brand ownership line missing | `README.md:1` | Add `PCCX™ technology / operated by Altifigence™.` after the title |
| `pccx-FPGA-NPU-LLM-kv260` | Evidence state was percentage/vague status wording | `README.md:10` | Replace with evidence-state lines: xsim PASS 12/0; RTL synthesis-closed (WNS 0.052); post-impl timing recovery in progress; evidence pending; bitstream not generated; no board/runtime evidence; no throughput measurement |
| `pccx-FPGA-NPU-LLM-kv260` | `Gemma 3N` paired with `runs` wording | `docs/README.md:40` | Use `target-model mapping here` |
| `pccx-FPGA-NPU-LLM-kv260` | `KV260 inference` | `docs/GEMMA3N_HANDOFF.md:85` | Use `board inference` |
| `pccx-FPGA-NPU-LLM-kv260` | `Bitstream generated` | `docs/RELEASE_EVIDENCE_CHECKLIST.md:76` | Use `Bitstream evidence recorded` |
| `pccx-FPGA-NPU-LLM-kv260` | Inference wording adjacent to unverified board state | `docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md:29` | Use `KV260 NPU execution` |
| `pccx-FPGA-NPU-LLM-kv260` | `20 tok/s` | `docs/evidence/kv260-gemma3n-e4b/MANIFEST_TEMPLATE.md:31` | Use `Measured throughput` |
| `pccx-FPGA-NPU-LLM-kv260` | `KV260 inference` | `docs/internal/stage_c_completion_notes.md:21` | Use `board inference` |
| `pccx-FPGA-NPU-LLM-kv260` | `KV260 inference` | `docs/internal/stage_c_completion_notes.md:233` | Use `board inference` |
| `pccx-FPGA-NPU-LLM-kv260` | `KV260 inference` | `docs/internal/kv260_gemma3n_e4b_hardware_handoff.md:338` | Use `board inference` |
