### PR TITLE
Audit README/docs for evidence-gated wording (PCCX™)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,6 @@ risk while keeping the ecosystem open for hardware research.
 
 `PCCX™` is a mark used by the PCCX project. Korean trademark
 applications are pending for PCCX in Classes 09 and 42. Registration
-has not been granted; do not use `PCCX®` until the central trademark
-policy is updated. See
+has not been granted; do not use any registration-mark variant until
+the central trademark policy is updated. See
 [`pccx/TRADEMARKS.md`](https://github.com/pccxai/pccx/blob/main/TRADEMARKS.md).

--- a/docs/RELEASE_EVIDENCE_CHECKLIST.md
+++ b/docs/RELEASE_EVIDENCE_CHECKLIST.md
@@ -104,7 +104,7 @@ include estimated or simulated numbers as hardware-measured results.
 - [ ] Output sample documented (decoded tokens)
 - [ ] Measurement method for latency/throughput (cycle counter, wall clock,
       UART timestamp)
-- [ ] Measured tok/s figure with methodology note
+- [ ] Measured throughput figure with methodology note
 - [ ] Power / thermal notes if available (board PSU measurement or on-chip
       sensor)
 - [ ] Known limitations listed (sequence length cap, unsupported ops, etc.)


### PR DESCRIPTION
| Repo | Token / required item | File:line | Proposed replacement |
| --- | --- | --- | --- |
| `pccx-FPGA-NPU-LLM-kv260` | Brand ownership line | `README.md:3` | Already present: `PCCX™ technology / operated by Altifigence™.` |
| `pccx-FPGA-NPU-LLM-kv260` | `PCCX®` literal in trademark guardrail | `README.md:414` | Use `any registration-mark variant` |
| `pccx-FPGA-NPU-LLM-kv260` | `tok/s` evidence checklist label | `docs/RELEASE_EVIDENCE_CHECKLIST.md:107` | Use `Measured throughput figure` |
