### PR TITLE
fix(runtime): fail fast for unavailable npu backend

### DIFF
--- a/sw/runtime/gemma/inference.py
+++ b/sw/runtime/gemma/inference.py
@@ -19,9 +19,17 @@ from .tokenizer import GemmaTokenizer
 from .weights import DEFAULT_MODEL_DIR, GemmaGlobalWeights, GemmaWeights, matmul_weight
 
 try:  # pragma: no cover - exercised when the board runtime module lands.
+    from sw.runtime.npu import npu_backend_readiness as _runtime_npu_backend_readiness
     from sw.runtime.npu import npu_status as _runtime_npu_status
 except Exception:  # pragma: no cover - import fallback is tested indirectly.
+    _runtime_npu_backend_readiness = None
     _runtime_npu_status = None
+
+
+BACKEND_AUTO = "auto"
+BACKEND_CPU = "cpu"
+BACKEND_NPU = "npu"
+BACKEND_CHOICES = {BACKEND_AUTO, BACKEND_CPU, BACKEND_NPU}
 
 
 def _default_npu_status(available: bool = False) -> dict:
@@ -31,6 +39,50 @@ def _default_npu_status(available: bool = False) -> dict:
         "done": False,
         "available": available,
     }
+
+
+def _default_npu_backend_readiness(reason: str = "NPU runtime is not importable") -> dict:
+    return {
+        "npu_available": False,
+        "hardware_results": False,
+        "experimental_axil_dispatch": False,
+        "reason": reason,
+    }
+
+
+def _read_npu_backend_readiness() -> dict:
+    if _runtime_npu_backend_readiness is None:
+        return _default_npu_backend_readiness()
+    try:
+        return dict(_runtime_npu_backend_readiness())
+    except Exception as exc:
+        return _default_npu_backend_readiness(f"{type(exc).__name__}: {exc}")
+
+
+def _resolve_backend(
+    requested_backend: str,
+    use_npu: bool | None,
+    readiness: dict,
+) -> tuple[bool, str, str]:
+    requested = str(requested_backend or BACKEND_AUTO).strip().lower()
+    if requested not in BACKEND_CHOICES:
+        raise ValueError(
+            f"backend must be one of {sorted(BACKEND_CHOICES)}, got {requested_backend!r}"
+        )
+    if requested == BACKEND_NPU and use_npu is False:
+        raise ValueError("backend='npu' conflicts with use_npu=False")
+
+    reason = str(readiness.get("reason") or "")
+    hardware_results = bool(readiness.get("hardware_results"))
+    if requested == BACKEND_CPU or use_npu is False:
+        return False, BACKEND_CPU, "CPU backend requested"
+    if requested == BACKEND_NPU:
+        if not hardware_results:
+            raise RuntimeError(f"NPU backend requested but unavailable: {reason}")
+        return True, BACKEND_NPU, "NPU backend requested"
+    if hardware_results:
+        return True, BACKEND_NPU, "NPU backend auto-selected"
+    return False, BACKEND_CPU, reason or "NPU backend is not ready"
 
 
 def _sample(logits: np.ndarray, temperature: float, top_p: float) -> int:
@@ -55,19 +107,26 @@ class GemmaInferenceSession:
         self,
         model_dir: str = DEFAULT_MODEL_DIR,
         *,
-        use_npu: bool = True,
+        use_npu: bool | None = None,
+        backend: str = BACKEND_AUTO,
         max_seq_len: int = 1024,
         dtype: str = "fp16",
     ) -> None:
         self.arch: GemmaArch = GEMMA_3N_E4B_DEFAULTS
         self.arch.validate()
         self.model_dir = model_dir
-        self.use_npu = use_npu
+        self.backend_requested = str(backend or BACKEND_AUTO).strip().lower()
+        self.npu_backend_readiness = _read_npu_backend_readiness()
+        self.use_npu, self.backend, self.backend_reason = _resolve_backend(
+            self.backend_requested,
+            use_npu,
+            self.npu_backend_readiness,
+        )
         self.max_seq_len = max_seq_len
         self.dtype = dtype
         self.weights = GemmaWeights(model_dir, arch=self.arch)
         self.tokenizer = GemmaTokenizer(model_dir)
-        self.decoder = GemmaDecoderLayer(self.arch, use_npu=use_npu)
+        self.decoder = GemmaDecoderLayer(self.arch, use_npu=self.use_npu)
         self._globals: GemmaGlobalWeights | None = None
         self._sessions: dict[str, dict] = {}
         self._tokens_total = 0

--- a/sw/runtime/gemma/tests/test_backend_selection.py
+++ b/sw/runtime/gemma/tests/test_backend_selection.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from sw.runtime.gemma.inference import _resolve_backend
+
+
+def _readiness(*, hardware_results: bool, reason: str = "not ready") -> dict:
+    return {
+        "npu_available": True,
+        "hardware_results": hardware_results,
+        "experimental_axil_dispatch": False,
+        "reason": reason,
+    }
+
+
+def test_auto_backend_uses_cpu_when_npu_results_are_not_ready() -> None:
+    use_npu, backend, reason = _resolve_backend(
+        "auto",
+        None,
+        _readiness(hardware_results=False, reason="missing result readback"),
+    )
+
+    assert use_npu is False
+    assert backend == "cpu"
+    assert reason == "missing result readback"
+
+
+def test_strict_npu_backend_errors_when_results_are_not_ready() -> None:
+    with pytest.raises(RuntimeError, match="NPU backend requested but unavailable"):
+        _resolve_backend(
+            "npu",
+            None,
+            _readiness(hardware_results=False, reason="missing DMA ownership"),
+        )
+
+
+def test_strict_npu_backend_enables_npu_when_results_are_ready() -> None:
+    use_npu, backend, reason = _resolve_backend(
+        "npu",
+        None,
+        _readiness(hardware_results=True),
+    )
+
+    assert use_npu is True
+    assert backend == "npu"
+    assert reason == "NPU backend requested"
+
+
+def test_cpu_backend_overrides_available_npu_results() -> None:
+    use_npu, backend, reason = _resolve_backend(
+        "cpu",
+        None,
+        _readiness(hardware_results=True),
+    )
+
+    assert use_npu is False
+    assert backend == "cpu"
+    assert reason == "CPU backend requested"

--- a/sw/runtime/npu/__init__.py
+++ b/sw/runtime/npu/__init__.py
@@ -11,10 +11,18 @@ experimental and golden-vector gated.
 """
 from __future__ import annotations
 
-from .npu_core import npu_available, npu_cvo, npu_gemm, npu_gemv, npu_status
+from .npu_core import (
+    npu_available,
+    npu_backend_readiness,
+    npu_cvo,
+    npu_gemm,
+    npu_gemv,
+    npu_status,
+)
 
 __all__ = [
     "npu_available",
+    "npu_backend_readiness",
     "npu_cvo",
     "npu_gemm",
     "npu_gemv",

--- a/sw/runtime/npu/npu_core.py
+++ b/sw/runtime/npu/npu_core.py
@@ -139,6 +139,30 @@ def npu_status() -> dict:
     }
 
 
+def npu_backend_readiness() -> dict:
+    """Return whether the NPU path can produce Gemma tensor results."""
+    available = npu_available()
+    experimental_axil = _env_truthy("PCCX_NPU_EXPERIMENTAL_DISPATCH")
+    hardware_results = False
+    if not available:
+        reason = (
+            "NPU UIO/bitstream is not available; Gemma tensor dispatch would "
+            "use CPU fallback"
+        )
+    else:
+        reason = (
+            "NPU UIO/bitstream is available, but high-level Gemma tensor "
+            "dispatch still returns NumPy golden results; DMA buffer ownership "
+            "and result readback are not implemented"
+        )
+    return {
+        "npu_available": available,
+        "hardware_results": hardware_results,
+        "experimental_axil_dispatch": experimental_axil,
+        "reason": reason,
+    }
+
+
 def npu_available() -> bool:
     """True iff /dev/uio4 opens and the loaded bitstream hash is expected."""
     global NPU_AVAILABLE

--- a/sw/runtime/server/__main__.py
+++ b/sw/runtime/server/__main__.py
@@ -10,10 +10,19 @@ except Exception:
     pass
 
 import argparse
+import os
 
 from aiohttp import web
 
 from .app import create_app
+
+
+BACKEND_CHOICES = ("auto", "cpu", "npu")
+
+
+def _default_backend() -> str:
+    value = os.getenv("PCCX_BACKEND", "auto").strip().lower()
+    return value if value in BACKEND_CHOICES else "auto"
 
 
 def main() -> None:
@@ -22,13 +31,25 @@ def main() -> None:
     parser.add_argument("--host", default="0.0.0.0", help="bind address")
     parser.add_argument("--port", default=7860, type=int, help="bind port")
     parser.add_argument(
+        "--backend",
+        choices=BACKEND_CHOICES,
+        default=_default_backend(),
+        help="inference backend: auto, cpu, or strict npu",
+    )
+    parser.add_argument(
         "--no-model",
         action="store_true",
         help="start HTTP and WebSocket routes without loading a model",
     )
     args = parser.parse_args()
     model_path = None if args.no_model else args.model
-    app = create_app(None, host=args.host, port=args.port, model_path=model_path)
+    app = create_app(
+        None,
+        host=args.host,
+        port=args.port,
+        model_path=model_path,
+        backend=args.backend,
+    )
     web.run_app(app, host=args.host, port=args.port)
 
 

--- a/sw/runtime/server/app.py
+++ b/sw/runtime/server/app.py
@@ -33,6 +33,8 @@ class ServerState:
     loading: bool = False
     load_error: Optional[str] = None
     model_path: Optional[str] = None
+    backend_requested: str = "auto"
+    backend_reason: str = ""
     histories: Dict[str, List[Dict[str, str]]] = field(default_factory=dict)
     tokens_total: int = 0
     tokens_per_sec_last: float = 0.0
@@ -52,7 +54,7 @@ class ServerState:
     @property
     def backend(self) -> str:
         value = getattr(self.session, "backend", None)
-        if value in {"cpu", "npu_uca", "hybrid"}:
+        if value in {"cpu", "npu", "npu_uca", "hybrid"}:
             return str(value)
         return "cpu"
 
@@ -78,12 +80,18 @@ class ServerState:
         self.load_error = None
         self.load_started_at = time.monotonic()
         try:
-            session = await asyncio.to_thread(_construct_gemma_session, model_path)
+            session = await asyncio.to_thread(
+                _construct_gemma_session,
+                model_path,
+                self.backend_requested,
+            )
             await _maybe_call_lifecycle(session, model_path)
             self.session = session
+            self.backend_reason = str(getattr(session, "backend_reason", ""))
         except Exception as exc:  # pragma: no cover - exercised on board images.
             self.session = None
             self.load_error = f"{type(exc).__name__}: {exc}"
+            self.backend_reason = str(exc)
         finally:
             started = self.load_started_at or time.monotonic()
             self.elapsed_load_sec = time.monotonic() - started
@@ -127,6 +135,7 @@ def create_app(
     host: str,
     port: int,
     model_path: Optional[str] = None,
+    backend: str = "auto",
 ) -> web.Application:
     app = web.Application(middlewares=[_cors_middleware])
     app[SERVER_STATE_KEY] = ServerState(
@@ -134,6 +143,7 @@ def create_app(
         host=host,
         port=port,
         model_path=os.path.expanduser(model_path) if model_path else None,
+        backend_requested=backend,
     )
     app[TRACE_EMITTER_KEY] = TraceEmitter()
 
@@ -210,6 +220,8 @@ def status_payload(state: ServerState) -> Dict[str, Any]:
         "npu_done": npu["npu_done"],
         "npu_available": npu["npu_available"],
         "backend": state.backend,
+        "backend_requested": state.backend_requested,
+        "backend_reason": state.backend_reason,
         "uptime_sec": int(time.monotonic() - state.started_at),
         "bitstream_sha": bitstream_sha256(),
         "host": socket.gethostname(),
@@ -290,10 +302,13 @@ def _parse_stat_value(value: Any) -> int:
         return 0
 
 
-def _construct_gemma_session(model_path: str) -> Any:
+def _construct_gemma_session(model_path: str, backend: str = "auto") -> Any:
     module = importlib.import_module("sw.runtime.gemma")
     session_cls = getattr(module, "GemmaInferenceSession")
     for kwargs in (
+        {"model_path": model_path, "backend": backend},
+        {"model_dir": model_path, "backend": backend},
+        {"model": model_path, "backend": backend},
         {"model_path": model_path},
         {"model_dir": model_path},
         {"model": model_path},


### PR DESCRIPTION
## Summary
- add explicit `--backend auto|cpu|npu` / `PCCX_BACKEND` selection for the Gemma daemon
- report backend request/reason in `/api/status`
- make strict `backend=npu` fail fast while Gemma tensor results still return from NumPy fallback

## Tests
- `python3 -m pytest -q sw/runtime/gemma/tests/test_backend_selection.py sw/runtime/npu/tests/test_npu_dispatch.py sw/runtime/test_isa.py`
- `python3 -m py_compile sw/runtime/server/__main__.py sw/runtime/server/app.py sw/runtime/gemma/inference.py sw/runtime/npu/npu_core.py sw/runtime/npu/__init__.py sw/runtime/gemma/tests/test_backend_selection.py`

Local workstation note: `python3 -m sw.runtime.server --help` is blocked in this checkout by missing `aiohttp`; the board service environment already has it.