### PR TITLE
fix(deploy): TMP_REMOTE mkdir as user + post_smoke case-insensitive + mmap fallback

### DIFF
--- a/hw/scripts/deploy_to_kv260.sh
+++ b/hw/scripts/deploy_to_kv260.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+#
+# deploy_to_kv260.sh - copy a v002 bitstream + dtbo + bit.bin set to a KV260
+# and program the PL.  Idempotent: re-running uninstalls the previous
+# overlay before staging the new one.
+#
+# Required environment:
+#   PCCX_KV260_HOST   KV260 hostname / IP
+#   PCCX_KV260_USER   SSH user (key-based auth assumed)
+#   KVFPGA_PASSWORD   sudo password for the board user (env var only - never
+#                     printed, never logged, never embedded in commands)
+#
+# Optional environment:
+#   PCCX_REPO         worktree root (default: auto-detected from script path)
+#   PCCX_BIT          .bit file to deploy (default: latest v002 build under
+#                     hw/build/v002-vivado-*/)
+#   PCCX_OVERLAY      overlay name (default: pccx_npu_bd)
+#   PCCX_SSH_OPTS     extra ssh options
+#
+# Usage:
+#   deploy_to_kv260.sh [--dry-run] [--no-bitbin-regen] [--skip-precheck]
+#
+#   --dry-run            : print commands without executing them
+#   --no-bitbin-regen    : skip `make -C sw/dtbo bitbin` (use existing .bit.bin)
+#   --skip-precheck      : skip the pre_deploy_check.py validation
+#                          (NOT recommended)
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+DRY_RUN=0
+DO_BITBIN_REGEN=1
+DO_PRECHECK=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)          DRY_RUN=1; shift ;;
+        --no-bitbin-regen)  DO_BITBIN_REGEN=0; shift ;;
+        --skip-precheck)    DO_PRECHECK=0; shift ;;
+        -h|--help)
+            sed -n '3,30p' "$0"
+            exit 0
+            ;;
+        *)  echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ----------------------------------------------------------------------------
+# Resolve paths
+# ----------------------------------------------------------------------------
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PCCX_REPO="${PCCX_REPO:-$( cd "$SCRIPT_DIR/../.." && pwd )}"
+
+if [[ -z "${PCCX_BIT:-}" ]]; then
+    # Pick the newest v002 build dir
+    PCCX_BIT="$( ls -1td "$PCCX_REPO"/hw/build/v002-vivado-*/pccx_v002_system_wrapper.bit 2>/dev/null | head -n1 || true )"
+fi
+if [[ -z "$PCCX_BIT" || ! -f "$PCCX_BIT" ]]; then
+    echo "ERROR: PCCX_BIT not found (looked under $PCCX_REPO/hw/build/v002-vivado-*/)." >&2
+    exit 1
+fi
+
+PCCX_OVERLAY="${PCCX_OVERLAY:-pccx_npu_bd}"
+DTBO_DIR="$PCCX_REPO/sw/dtbo/build/$PCCX_OVERLAY"
+BITBIN="$DTBO_DIR/$PCCX_OVERLAY.bit.bin"
+DTBO="$DTBO_DIR/$PCCX_OVERLAY.dtbo"
+SHELLJSON="$DTBO_DIR/shell.json"
+
+# ----------------------------------------------------------------------------
+# Env validation (never log $KVFPGA_PASSWORD)
+# ----------------------------------------------------------------------------
+need_env() {
+    local n="$1"
+    if [[ -z "${!n:-}" ]]; then
+        echo "ERROR: required env var not set: $n" >&2
+        return 1
+    fi
+}
+need_env PCCX_KV260_HOST
+need_env PCCX_KV260_USER
+need_env KVFPGA_PASSWORD  # value is consumed only as stdin to sudo
+
+SSH_OPTS_DEFAULT=(
+    -o ConnectTimeout=10
+    -o ServerAliveInterval=15
+    -o BatchMode=yes
+    -o StrictHostKeyChecking=accept-new
+)
+read -r -a EXTRA_SSH_OPTS <<<"${PCCX_SSH_OPTS:-}"
+
+echo "-- deploy_to_kv260.sh --"
+echo "PCCX_REPO         : $PCCX_REPO"
+echo "PCCX_BIT          : $PCCX_BIT"
+echo "PCCX_OVERLAY      : $PCCX_OVERLAY"
+echo "DTBO_DIR          : $DTBO_DIR"
+echo "PCCX_KV260_HOST   : $PCCX_KV260_HOST"
+echo "PCCX_KV260_USER   : $PCCX_KV260_USER"
+echo "KVFPGA_PASSWORD   : (set; value redacted)"
+echo "dry-run           : $DRY_RUN"
+echo "bitbin regen      : $DO_BITBIN_REGEN"
+echo "pre-deploy check  : $DO_PRECHECK"
+echo
+
+run() {
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "DRY: $*"
+    else
+        echo "RUN: $*"
+        "$@"
+    fi
+}
+
+ssh_run() {
+    # Send a remote sudo command via stdin, passing password from env (never
+    # via argv).  Uses `sudo -S` so the password is read from stdin only.
+    #
+    # Returns the underlying ssh exit code; aborts the script when the
+    # remote command fails so partial deploys never silently "succeed".
+    local cmd="$1"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        # Redact the password placeholder in dry-run print.
+        echo "DRY: ssh $PCCX_KV260_USER@$PCCX_KV260_HOST -- sudo -S sh -c '<cmd: $cmd>'"
+        return 0
+    fi
+    echo "REMOTE: $cmd"
+    local out rc
+    out=$(printf '%s\n' "$KVFPGA_PASSWORD" | \
+          ssh "${SSH_OPTS_DEFAULT[@]}" "${EXTRA_SSH_OPTS[@]}" \
+              "$PCCX_KV260_USER@$PCCX_KV260_HOST" \
+              "sudo -S sh -c $(printf %q "$cmd")" 2>&1)
+    rc=$?
+    # `grep` may legitimately exit 1 when every line is filtered; do not let
+    # that mask a real ssh / sudo / remote-command failure (`set -o
+    # pipefail` would also catch the wrong thing).  We check $rc directly.
+    if [[ $rc -ne 0 ]]; then
+        # Print full output (with password lines filtered) so the user can
+        # see what went wrong.
+        printf '%s\n' "$out" | grep -v -E 'password for|^Password:' >&2 || true
+        echo "ERROR: remote command failed (rc=$rc): $cmd" >&2
+        return "$rc"
+    fi
+    printf '%s\n' "$out" | grep -v -E 'password for|^Password:' || true
+    return 0
+}
+
+scp_to() {
+    local src="$1"
+    local dst="$2"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "DRY: scp $src $PCCX_KV260_USER@$PCCX_KV260_HOST:$dst"
+        return 0
+    fi
+    scp "${SSH_OPTS_DEFAULT[@]}" "${EXTRA_SSH_OPTS[@]}" "$src" \
+        "$PCCX_KV260_USER@$PCCX_KV260_HOST:$dst"
+}
+
+# ----------------------------------------------------------------------------
+# 1. Regenerate .bit.bin from the chosen .bit (provenance step)
+# ----------------------------------------------------------------------------
+if [[ "$DO_BITBIN_REGEN" -eq 1 ]]; then
+    echo "[1/5] regenerate bit.bin via bootgen"
+    run make -C "$PCCX_REPO/sw/dtbo" bitbin \
+        BIT_SRC="$PCCX_BIT" \
+        BUILD="$DTBO_DIR"
+else
+    echo "[1/5] skip bit.bin regen (--no-bitbin-regen)"
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Run the local pre-deploy check
+# ----------------------------------------------------------------------------
+if [[ "$DO_PRECHECK" -eq 1 ]]; then
+    echo "[2/5] run pre_deploy_check.py"
+    run python3 "$SCRIPT_DIR/pre_deploy_check.py" \
+        --bit "$PCCX_BIT" \
+        --bitbin "$BITBIN" \
+        --dtbo "$DTBO" \
+        --shell-json "$SHELLJSON" \
+        --check-env
+else
+    echo "[2/5] skip pre-deploy check (--skip-precheck)"
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Unload any previously-loaded overlay (idempotent)
+# ----------------------------------------------------------------------------
+echo "[3/5] remote: unload existing overlay (best-effort)"
+ssh_run "xmutil unloadapp || true"
+
+# ----------------------------------------------------------------------------
+# 4. Stage firmware into /lib/firmware/xilinx/<overlay>/
+# ----------------------------------------------------------------------------
+echo "[4/5] stage overlay files into board firmware tree"
+ssh_run "mkdir -p /lib/firmware/xilinx/$PCCX_OVERLAY"
+
+# We scp to a writable user dir first, then sudo mv (the scp itself does
+# not have sudo capability).
+TMP_REMOTE="/tmp/pccx_deploy_${PCCX_OVERLAY}_$$"
+# Create the staging dir as the SSH user (not sudo) so the subsequent
+# unprivileged scp can write into it; the sudo cp below moves the files
+# into the firmware tree where root ownership is required.
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY: ssh $PCCX_KV260_USER@$PCCX_KV260_HOST -- mkdir -p $TMP_REMOTE"
+else
+    echo "REMOTE (user): mkdir -p $TMP_REMOTE"
+    ssh "${SSH_OPTS_DEFAULT[@]}" "${EXTRA_SSH_OPTS[@]}" \
+        "$PCCX_KV260_USER@$PCCX_KV260_HOST" \
+        "mkdir -p $TMP_REMOTE"
+fi
+scp_to "$BITBIN"    "$TMP_REMOTE/"
+scp_to "$DTBO"      "$TMP_REMOTE/"
+scp_to "$SHELLJSON" "$TMP_REMOTE/"
+ssh_run "cp -f $TMP_REMOTE/$PCCX_OVERLAY.bit.bin /lib/firmware/xilinx/$PCCX_OVERLAY/$PCCX_OVERLAY.bit.bin"
+ssh_run "cp -f $TMP_REMOTE/$PCCX_OVERLAY.dtbo    /lib/firmware/xilinx/$PCCX_OVERLAY/$PCCX_OVERLAY.dtbo"
+ssh_run "cp -f $TMP_REMOTE/shell.json            /lib/firmware/xilinx/$PCCX_OVERLAY/shell.json"
+ssh_run "rm -rf $TMP_REMOTE"
+
+# ----------------------------------------------------------------------------
+# 5. Load the overlay (programs PL) and verify
+# ----------------------------------------------------------------------------
+echo "[5/5] xmutil loadapp $PCCX_OVERLAY"
+ssh_run "xmutil loadapp $PCCX_OVERLAY"
+
+# Allow 1s for /dev/uio* nodes to appear
+ssh_run "sleep 1; ls -la /dev/uio* 2>&1 | tee /tmp/pccx_uio_after_load.txt; ls -la /sys/class/fpga_manager/fpga0/state 2>/dev/null || true; cat /sys/class/fpga_manager/fpga0/state 2>/dev/null || true"
+
+echo
+echo "deploy_to_kv260.sh: complete"
+echo "next: run hw/scripts/post_deploy_smoke.py to verify on-board reachability"

--- a/hw/scripts/post_deploy_smoke.py
+++ b/hw/scripts/post_deploy_smoke.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""
+post_deploy_smoke.py - run a READ-ONLY on-board smoke test after the v002
+overlay has been loaded.  Validates:
+
+  1. /dev/uio* nodes appear and one of them maps the fabric@0xA000_0000
+     region (i.e. the NPU AXIL control window).
+  2. AXIL CMD/STAT readback is accessible via that uio node:
+     - Read FLAGS at offset 0x14 of every cmdsts_* window (HP0..HP3, ACP
+       fmap, ACP result).  After load, cmd-FIFO should be empty (FLAGS[0]==1)
+       and status-FIFO should be empty (FLAGS[2]==1).  Sticky-error bits
+       [7:4] should be 0.
+     - Read AXIL_STAT_OUT at the NPU window (0xA0000000 base) - this should
+       NOT hang the bus.  Per c3fea5e the status backflow is wired; under
+       a clean post-load state it should be a known idle pattern.
+  3. No AXIL hang: each readback is wrapped with a timeout.  A hang means
+     the SmartConnect / DataMover infrastructure did not come up cleanly
+     and the deploy should be rolled back.
+  4. dmesg tail is captured and scanned for fpga_manager / fpga_region
+     warnings or errors that may indicate a partial load.
+
+This script does NOT write any AXIL register - read-only.  It is safe to
+re-run repeatedly.
+
+Required env (same as deploy_to_kv260.sh):
+  PCCX_KV260_HOST, PCCX_KV260_USER, KVFPGA_PASSWORD
+
+Usage:
+  post_deploy_smoke.py [--dry-run] [--verbose] [--overlay pccx_npu_bd]
+
+Exit code:
+  0 - all reads succeeded, no FIFOs claim sticky errors, no kernel
+       warning about the overlay.
+  1 - any failure
+  2 - usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import time
+from typing import Optional
+
+
+AXIL_BASES = [
+    ("npu",               0xA0000000),
+    ("cmdsts_hp0",        0xA0001000),
+    ("cmdsts_hp1",        0xA0002000),
+    ("cmdsts_hp2",        0xA0003000),
+    ("cmdsts_hp3",        0xA0004000),
+    ("cmdsts_acp_fmap",   0xA0005000),
+    ("cmdsts_acp_result", 0xA0006000),
+]
+FLAGS_OFFSET = 0x14
+STAT_OFFSET  = 0x10  # STS_POP - reading is safe, just yields 0 if empty
+
+
+def color(s: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return s
+    return f"\x1b[{code}m{s}\x1b[0m"
+
+
+def ok(s: str) -> str:   return color("PASS", "32") + " " + s
+def warn(s: str) -> str: return color("WARN", "33") + " " + s
+def fail(s: str) -> str: return color("FAIL", "31") + " " + s
+
+
+def need_env() -> tuple[str, str]:
+    host = os.environ.get("PCCX_KV260_HOST")
+    user = os.environ.get("PCCX_KV260_USER")
+    if not (host and user):
+        print(fail("PCCX_KV260_HOST / PCCX_KV260_USER not set"), file=sys.stderr)
+        sys.exit(1)
+    # KVFPGA_PASSWORD is referenced only inside the sh -c on the remote;
+    # we never read its value in this script.  But we DO need it to be set,
+    # otherwise the sudo -S call will block.
+    if not os.environ.get("KVFPGA_PASSWORD"):
+        print(fail("KVFPGA_PASSWORD env var must be set (value never printed)"),
+              file=sys.stderr)
+        sys.exit(1)
+    return host, user
+
+
+def ssh_cmd(host: str, user: str, remote_sh: str, dry: bool,
+            timeout: int = 20, dry_label: Optional[str] = None) -> tuple[int, str]:
+    """Run a remote shell snippet under sudo -S, password fed via stdin from env.
+
+    Returns (exit_code, combined_output).
+    """
+    if dry:
+        # Don't actually run.  Print a representative command but redact pwd.
+        display = dry_label or remote_sh
+        print(f"DRY: ssh {user}@{host} -- sudo -S sh -c {shlex.quote(display)}")
+        return 0, ""
+    ssh_args = [
+        "ssh",
+        "-o", "ConnectTimeout=10",
+        "-o", "ServerAliveInterval=15",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        f"{user}@{host}",
+        f"sudo -S sh -c {shlex.quote(remote_sh)}",
+    ]
+    try:
+        pwd = os.environ["KVFPGA_PASSWORD"]
+        # pass pwd via stdin to sudo -S; close stdin afterward
+        proc = subprocess.run(
+            ssh_args,
+            input=pwd + "\n",
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        out = (proc.stdout or "") + (proc.stderr or "")
+        # Strip any 'password for ...' prompt lines.
+        out = "\n".join(line for line in out.splitlines()
+                        if not line.startswith("[sudo]")
+                        and "Password:" not in line
+                        and "password for" not in line)
+        return proc.returncode, out
+    except subprocess.TimeoutExpired:
+        return -1, f"<timeout after {timeout}s>"
+
+
+def check_uio(host: str, user: str, dry: bool) -> tuple[bool, Optional[str]]:
+    """Find which /dev/uio* maps the NPU AXIL window."""
+    snippet = (
+        "set -e; "
+        "for d in /sys/class/uio/uio*; do "
+        "  [ -d \"$d\" ] || continue; "
+        "  name=$(cat \"$d/name\" 2>/dev/null || true); "
+        "  for i in 0 1 2 3 4 5; do "
+        "    addr_file=\"$d/maps/map$i/addr\"; "
+        "    [ -f \"$addr_file\" ] || break; "
+        "    addr=$(cat \"$addr_file\"); "
+        "    size=$(cat \"$d/maps/map$i/size\" 2>/dev/null); "
+        "    echo \"uio=$(basename $d) name=$name map=$i addr=$addr size=$size\"; "
+        "  done; "
+        "done"
+    )
+    rc, out = ssh_cmd(host, user, snippet, dry)
+    if dry:
+        return True, None
+    if rc != 0:
+        print(fail(f"uio probe failed (rc={rc}): {out.strip()}"))
+        return False, None
+    print(f"uio table:\n{out.rstrip()}")
+    target_uio = None
+    for line in out.splitlines():
+        fields = {}
+        for part in line.split():
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            fields[key] = value
+        try:
+            addr = int(fields.get("addr", ""), 16)
+        except ValueError:
+            continue
+        if addr == AXIL_BASES[0][1]:
+            target_uio = fields.get("uio")
+            break
+    if target_uio:
+        print(ok(f"NPU AXIL window mapped at /dev/{target_uio}"))
+        return True, f"/dev/{target_uio}"
+    print(fail("no /dev/uio* maps addr=0xA0000000; overlay may not have programmed"))
+    return False, None
+
+
+def read_axil(host: str, user: str, axil_base: int, offset: int,
+              dry: bool) -> tuple[bool, int, str]:
+    """Read one 32-bit AXIL register.
+
+    Prefer plain `devmem`, then `busybox devmem`, then fall back to direct UIO
+    mmap so the smoke test does not depend on board image packages.
+    """
+    addr = axil_base + offset
+    # `timeout 5` prevents a bus hang from blocking the SSH session.
+    snippet = f"""
+set -eu
+addr=0x{addr:08X}
+if command -v devmem >/dev/null 2>&1; then
+  if out=$(timeout 5 devmem "$addr" 32); then
+    printf 'devmem %s\\n' "$out"
+    exit 0
+  fi
+  echo "devmem failed; trying fallback readers" >&2
+fi
+if command -v busybox >/dev/null 2>&1; then
+  if out=$(timeout 5 busybox devmem "$addr" 32); then
+    printf 'busybox-devmem %s\\n' "$out"
+    exit 0
+  fi
+  echo "busybox devmem failed; trying UIO mmap fallback" >&2
+fi
+if command -v python3 >/dev/null 2>&1; then
+  timeout 5 python3 - "$addr" <<'PY'
+import glob
+import mmap
+import os
+import struct
+import sys
+
+target = int(sys.argv[1], 0)
+for uio_dir in sorted(glob.glob("/sys/class/uio/uio*")):
+    uio_name = os.path.basename(uio_dir)
+    for map_dir in sorted(glob.glob(os.path.join(uio_dir, "maps", "map*"))):
+        try:
+            map_index = int(os.path.basename(map_dir).replace("map", ""), 10)
+            with open(os.path.join(map_dir, "addr"), encoding="utf-8") as f:
+                map_base = int(f.read().strip(), 0)
+            with open(os.path.join(map_dir, "size"), encoding="utf-8") as f:
+                map_size = int(f.read().strip(), 0)
+        except (OSError, ValueError):
+            continue
+        if not (map_base <= target <= map_base + map_size - 4):
+            continue
+        dev_path = "/dev/" + uio_name
+        fd = os.open(dev_path, os.O_RDONLY | getattr(os, "O_SYNC", 0))
+        try:
+            mm = mmap.mmap(
+                fd,
+                map_size,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ,
+                offset=map_index * mmap.PAGESIZE,
+            )
+            try:
+                mm.seek(target - map_base)
+                value = struct.unpack("<I", mm.read(4))[0]
+            finally:
+                mm.close()
+        finally:
+            os.close(fd)
+        print(f"uio-mmap 0x{{value:08X}}")
+        sys.exit(0)
+print("no UIO mmap reader found", file=sys.stderr)
+sys.exit(127)
+PY
+  exit $?
+fi
+echo "no AXIL reader available" >&2
+exit 127
+"""
+    rc, out = ssh_cmd(
+        host,
+        user,
+        snippet,
+        dry,
+        timeout=15,
+        dry_label=f"read AXIL 0x{addr:08X} via devmem/busybox-devmem/uio-mmap fallback",
+    )
+    if dry:
+        return True, 0, "dry-run"
+    if rc != 0:
+        print(fail(f"AXIL read 0x{addr:08X} failed after devmem/busybox/mmap fallback "
+                   f"(rc={rc}): {out.strip()}"))
+        return False, 0, ""
+    val = None
+    method = ""
+    for token in out.replace(",", " ").split():
+        normalized = token.strip(";:").lower()
+        if normalized in {"devmem", "busybox-devmem", "uio-mmap"}:
+            method = normalized
+        if normalized.startswith("0x"):
+            try:
+                val = int(normalized, 0)
+            except ValueError:
+                continue
+    if val is None:
+        print(fail(f"AXIL read 0x{addr:08X} returned unparseable output: {out!r}"))
+        return False, 0, method
+    return True, val, method or "unknown"
+
+
+def check_axil_flags(host: str, user: str, dry: bool) -> bool:
+    """For each cmdsts_* window, read FLAGS at offset 0x14 and validate."""
+    all_ok = True
+    for name, base in AXIL_BASES:
+        if name == "npu":
+            # NPU control window does not use the same FLAGS layout - skip.
+            ok_, val, method = read_axil(host, user, base, 0x00, dry)
+            if dry:
+                continue
+            if not ok_:
+                all_ok = False
+                continue
+            print(ok(f"{name:18s} read @ 0x{base:08X}+0x00 OK "
+                     f"(val=0x{val:08X}, via={method})"))
+            continue
+        ok_, val, method = read_axil(host, user, base, FLAGS_OFFSET, dry)
+        if dry:
+            continue
+        if not ok_:
+            all_ok = False
+            continue
+        # FLAGS layout: bit0=cmd_empty, bit1=cmd_full, bit2=sts_empty,
+        # bit3=sts_full, bits[7:4]=sticky errors.
+        cmd_empty = bool(val & 0x1)
+        cmd_full  = bool(val & 0x2)
+        sts_empty = bool(val & 0x4)
+        sts_full  = bool(val & 0x8)
+        sticky    = (val >> 4) & 0xF
+        if not cmd_empty or not sts_empty or cmd_full or sts_full or sticky:
+            print(warn(f"{name:18s} FLAGS=0x{val:02X}  cmd_empty={cmd_empty}  "
+                       f"sts_empty={sts_empty}  cmd_full={cmd_full}  "
+                       f"sts_full={sts_full}  sticky=0x{sticky:X}  via={method}"))
+        else:
+            print(ok(f"{name:18s} FLAGS=0x{val:02X}  idle "
+                     f"(cmd_empty=1, sts_empty=1, sticky=0, via={method})"))
+    return all_ok
+
+
+def dmesg_tail(host: str, user: str, dry: bool, n: int = 80) -> bool:
+    snippet = f"dmesg --ctime | tail -n {n}"
+    rc, out = ssh_cmd(host, user, snippet, dry)
+    if dry:
+        return True
+    if rc != 0:
+        print(warn(f"dmesg tail failed (rc={rc}): {out.strip()}"))
+        return True  # not a deploy blocker
+    suspicious = [l for l in out.splitlines()
+                  if any(tok in l.lower()
+                         for tok in ("error", "warn", "fail",
+                                     "fpga_manager", "fpga_region",
+                                     "of_overlay"))]
+    if suspicious:
+        print(warn("dmesg has fpga/overlay-related lines:"))
+        for l in suspicious[-30:]:
+            print(f"  {l}")
+    else:
+        print(ok(f"dmesg tail clean (last {n} lines have no overlay errors)"))
+    return True
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Read-only smoke test for a freshly-loaded v002 overlay on KV260.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print remote commands without executing them")
+    p.add_argument("--verbose", action="store_true")
+    p.add_argument("--overlay", default="pccx_npu_bd",
+                   help="Overlay name to assume is loaded (info only)")
+    args = p.parse_args(argv)
+
+    host, user = need_env()
+    print("-- post_deploy_smoke.py --")
+    print(f"host    : {host}")
+    print(f"user    : {user}")
+    print(f"overlay : {args.overlay}")
+    print(f"dry-run : {args.dry_run}")
+    print()
+
+    # 1. uio probe + locate NPU AXIL window
+    print("[1/3] uio probe")
+    uio_ok, uio_dev = check_uio(host, user, args.dry_run)
+
+    # 2. AXIL FLAGS reads on each cmdsts_* window
+    print("\n[2/3] AXIL FLAGS sanity")
+    flags_ok = check_axil_flags(host, user, args.dry_run)
+
+    # 3. kernel log scan
+    print("\n[3/3] dmesg tail")
+    dmesg_ok = dmesg_tail(host, user, args.dry_run)
+
+    print()
+    if args.dry_run:
+        print(ok("dry-run complete; no commands were sent to the board"))
+        return 0
+
+    overall = uio_ok and flags_ok and dmesg_ok
+    if overall:
+        print(ok("post_deploy_smoke PASSED - overlay programmed and AXIL bus alive"))
+        return 0
+    print(fail("post_deploy_smoke FAILED - inspect the output and consider rollback"))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/hw/scripts/pre_deploy_check.py
+++ b/hw/scripts/pre_deploy_check.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""
+pre_deploy_check.py - validate a v002 bitstream + dtbo + bit.bin set before
+sending them to a KV260.
+
+Runs entirely on the build host.  Does NOT connect to the board.  Use
+post_deploy_smoke.py for on-board checks.
+
+Checks performed:
+  1. Bitstream file exists, size in expected range, MD5 reported.
+  2. Bitstream header parses; design name, part name, build date and
+     payload length are reported.
+  3. Part name matches a configurable allow-list (default:
+     xck26-sfvc784-2LV-c, the K26 SoM canonical).
+  4. Optional: MD5 matches an expected value passed via --expected-md5.
+  5. DTBO file exists; magic bytes match Devicetree blob.
+  6. bit.bin file exists; size matches the bitstream payload tag and the
+     bytes match the bitstream payload section.
+  7. shell.json exists and parses, with shell_type == "XRT_FLAT".
+  8. KV260 connection environment (PCCX_KV260_HOST, PCCX_KV260_USER) is
+     present iff --check-env is set, but the script does NOT contact the
+     board.
+
+Exit code:
+  0 - all checks PASS
+  1 - any check FAIL or any required argument missing
+  2 - usage error
+
+The script never prints secrets.  $KVFPGA_PASSWORD and SSH key material
+are deliberately not read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_ALLOWED_PARTS = ("xck26-sfvc784-2LV-c",)
+DT_MAGIC = b"\xd0\x0d\xfe\xed"
+BIT_MAGIC = bytes.fromhex("0ff00ff00ff00ff000")
+
+
+@dataclass
+class BitHeader:
+    design: str
+    part: str
+    date: str
+    time: str
+    payload_len: int
+    header_len: int  # bytes consumed up to and including the 'e' length field
+
+
+def parse_bit_header(path: Path) -> BitHeader:
+    """Parse the ASCII metadata header of a Xilinx .bit file."""
+    with path.open("rb") as f:
+        data = f.read(512)
+    if len(data) < 16:
+        raise ValueError(f"{path}: too small to be a .bit file ({len(data)} B)")
+    (magic_len,) = struct.unpack(">H", data[0:2])
+    if magic_len != 9 or data[2:11] != BIT_MAGIC:
+        raise ValueError(f"{path}: not a Xilinx .bit file (bad magic)")
+    # sub-header 0x0001
+    (sub,) = struct.unpack(">H", data[11:13])
+    if sub != 1:
+        raise ValueError(f"{path}: unexpected sub-header {sub}")
+    i = 13
+    fields = {}
+    for _ in range(4):  # 'a','b','c','d'
+        tag = data[i:i + 1]
+        i += 1
+        if tag not in (b"a", b"b", b"c", b"d"):
+            raise ValueError(f"{path}: unexpected tag {tag!r}")
+        (flen,) = struct.unpack(">H", data[i:i + 2])
+        i += 2
+        val = data[i:i + flen].rstrip(b"\x00").decode(errors="replace")
+        fields[tag.decode()] = val
+        i += flen
+    # 'e' tag - payload length
+    if data[i:i + 1] != b"e":
+        raise ValueError(f"{path}: expected 'e' tag at offset {i}, got {data[i:i + 1]!r}")
+    i += 1
+    (plen,) = struct.unpack(">I", data[i:i + 4])
+    i += 4
+    design = fields.get("a", "")
+    # design name is "name;UserID=...;Version=...;SW_CRC=..." - strip after first ';'
+    design_name = design.split(";", 1)[0]
+    return BitHeader(
+        design=design_name,
+        part=fields.get("b", ""),
+        date=fields.get("c", ""),
+        time=fields.get("d", ""),
+        payload_len=plen,
+        header_len=i,
+    )
+
+
+def md5_of(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def color(s: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return s
+    return f"\x1b[{code}m{s}\x1b[0m"
+
+
+def ok(s: str) -> str: return color("PASS", "32") + " " + s
+def warn(s: str) -> str: return color("WARN", "33") + " " + s
+def fail(s: str) -> str: return color("FAIL", "31") + " " + s
+
+
+def check_bitstream(path: Path, allowed_parts: tuple[str, ...],
+                    expected_md5: Optional[str], verbose: bool) -> tuple[bool, BitHeader, str]:
+    failures = 0
+
+    if not path.exists():
+        print(fail(f"bitstream missing: {path}"))
+        sys.exit(1)
+    size = path.stat().st_size
+    print(ok(f"bitstream present: {path}  size={size} B"))
+
+    if size < 1_000_000 or size > 50_000_000:
+        print(fail(f"bitstream size {size} outside sane range 1..50 MB"))
+        failures += 1
+
+    digest = md5_of(path)
+    if expected_md5:
+        if digest == expected_md5.lower():
+            print(ok(f"bitstream MD5 matches expected: {digest}"))
+        else:
+            print(fail(f"bitstream MD5 mismatch: got {digest}, expected {expected_md5}"))
+            failures += 1
+    else:
+        print(ok(f"bitstream MD5: {digest}"))
+
+    try:
+        hdr = parse_bit_header(path)
+    except Exception as exc:
+        print(fail(f"bitstream header parse failed: {exc}"))
+        sys.exit(1)
+    print(ok(f"bitstream design = {hdr.design}"))
+    print(ok(f"bitstream part   = {hdr.part}"))
+    print(ok(f"bitstream date   = {hdr.date} {hdr.time}"))
+    print(ok(f"bitstream payload= {hdr.payload_len} bytes (header consumed {hdr.header_len} B)"))
+
+    if hdr.part not in allowed_parts:
+        print(fail(f"bitstream part {hdr.part!r} not in allow-list {allowed_parts}"))
+        failures += 1
+    expected_total = hdr.header_len + hdr.payload_len
+    if size != expected_total:
+        print(warn(f"bitstream size {size} != header_len {hdr.header_len} + payload_len {hdr.payload_len} = {expected_total}"))
+
+    if failures:
+        return False, hdr, digest
+    return True, hdr, digest
+
+
+def check_dtbo(path: Path) -> bool:
+    if not path.exists():
+        print(fail(f"dtbo missing: {path}"))
+        return False
+    with path.open("rb") as f:
+        magic = f.read(4)
+    if magic != DT_MAGIC:
+        print(fail(f"dtbo magic mismatch: got {magic.hex()}, expected {DT_MAGIC.hex()}"))
+        return False
+    size = path.stat().st_size
+    print(ok(f"dtbo present: {path}  size={size} B  magic OK"))
+    return True
+
+
+def check_bitbin(bitbin: Path, bit: Path, hdr: BitHeader) -> bool:
+    if not bitbin.exists():
+        print(fail(f"bit.bin missing: {bitbin}"))
+        return False
+    bb_size = bitbin.stat().st_size
+    print(ok(f"bit.bin present: {bitbin}  size={bb_size} B"))
+    # bootgen-emitted bit.bin should equal the .bit payload (no .bit header).
+    if bb_size != hdr.payload_len:
+        print(fail(f"bit.bin size {bb_size} != bit payload {hdr.payload_len}; regenerate bit.bin"))
+        return False
+    # Byte-compare bit.bin with bit's payload section.
+    with bit.open("rb") as f:
+        f.seek(hdr.header_len)
+        bit_payload = f.read(hdr.payload_len)
+    with bitbin.open("rb") as f:
+        bb = f.read()
+    if bb != bit_payload:
+        # FPGA Manager on K26 SoM consumes .bit.bin in word-swapped LE form;
+        # `bootgen -process_bitstream bin` emits this canonical layout, so
+        # bb == swap32(.bit payload) is the EXPECTED relationship.
+        bit_le = b"".join(bit_payload[i:i + 4][::-1] for i in range(0, len(bit_payload), 4))
+        if bb == bit_le:
+            print(ok("bit.bin matches bootgen LE-swapped payload of .bit "
+                     "(canonical FPGA Manager format)"))
+            return True
+        print(fail("bit.bin does not match .bit payload in either byte order — "
+                   "regenerate via `make -C sw/dtbo bitbin BIT_SRC=<v002.bit>`"))
+        return False
+    print(ok("bit.bin contents byte-identical to .bit payload (raw-bin format)"))
+    return True
+
+
+def check_shell_json(path: Path) -> bool:
+    if not path.exists():
+        print(fail(f"shell.json missing: {path}"))
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except Exception as exc:
+        print(fail(f"shell.json parse error: {exc}"))
+        return False
+    if data.get("shell_type") != "XRT_FLAT":
+        print(fail(f"shell.json shell_type={data.get('shell_type')!r}, expected XRT_FLAT"))
+        return False
+    print(ok(f"shell.json valid: {data}"))
+    return True
+
+
+def check_env(check_env: bool) -> bool:
+    if not check_env:
+        return True
+    needed = ("PCCX_KV260_HOST", "PCCX_KV260_USER")
+    missing = [k for k in needed if not os.environ.get(k)]
+    # Never log the values themselves to keep host/user out of evidence logs.
+    if missing:
+        print(fail(f"env missing: {missing}"))
+        return False
+    print(ok(f"env present: {list(needed)} (values redacted)"))
+    return True
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate v002 bitstream / dtbo / bit.bin before KV260 deploy. "
+                    "This script never connects to the board.")
+    parser.add_argument("--bit", required=True, type=Path,
+                        help="Path to .bit file (e.g. hw/build/v002-vivado-*/pccx_v002_system_wrapper.bit)")
+    parser.add_argument("--dtbo", type=Path,
+                        help="Path to .dtbo file. Defaults to sw/dtbo/build/pccx_npu_bd/pccx_npu_bd.dtbo")
+    parser.add_argument("--bitbin", type=Path,
+                        help="Path to .bit.bin file. Defaults to sw/dtbo/build/pccx_npu_bd/pccx_npu_bd.bit.bin")
+    parser.add_argument("--shell-json", type=Path,
+                        help="Path to shell.json. Defaults to sw/dtbo/build/pccx_npu_bd/shell.json")
+    parser.add_argument("--expected-md5",
+                        help="Expected MD5 of the .bit file. If omitted, just report.")
+    parser.add_argument("--allowed-part", action="append",
+                        help="Allowed part name(s) (default: xck26-sfvc784-2LV-c). Pass multiple times.")
+    parser.add_argument("--check-env", action="store_true",
+                        help="Also check that PCCX_KV260_HOST / PCCX_KV260_USER env vars are set "
+                             "(values are NEVER printed)")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    allowed = tuple(args.allowed_part) if args.allowed_part else DEFAULT_ALLOWED_PARTS
+
+    # Auto-resolve sibling artifacts off the .bit path's worktree root.
+    bit = args.bit.resolve()
+    worktree = bit
+    # Walk upward until we find sw/dtbo/build/pccx_npu_bd or hit fs root
+    for parent in [bit.parent] + list(bit.parents):
+        candidate = parent / "sw" / "dtbo" / "build" / "pccx_npu_bd"
+        if candidate.is_dir():
+            worktree = parent
+            break
+
+    dtbo = args.dtbo or (worktree / "sw" / "dtbo" / "build" / "pccx_npu_bd" / "pccx_npu_bd.dtbo")
+    bitbin = args.bitbin or (worktree / "sw" / "dtbo" / "build" / "pccx_npu_bd" / "pccx_npu_bd.bit.bin")
+    shell_json = args.shell_json or (worktree / "sw" / "dtbo" / "build" / "pccx_npu_bd" / "shell.json")
+
+    print(f"-- pre_deploy_check.py --")
+    print(f"bit       : {bit}")
+    print(f"dtbo      : {dtbo}")
+    print(f"bitbin    : {bitbin}")
+    print(f"shell.json: {shell_json}")
+    print(f"allowed-parts: {allowed}")
+    if args.expected_md5:
+        print(f"expected-md5 : {args.expected_md5}")
+    print()
+
+    ok_bit, hdr, digest = check_bitstream(bit, allowed, args.expected_md5, args.verbose)
+    ok_dtbo = check_dtbo(dtbo)
+    ok_bitbin = check_bitbin(bitbin, bit, hdr)
+    ok_shell = check_shell_json(shell_json)
+    ok_env = check_env(args.check_env)
+
+    print()
+    summary = {
+        "bitstream": ok_bit,
+        "dtbo": ok_dtbo,
+        "bitbin": ok_bitbin,
+        "shell.json": ok_shell,
+        "env": ok_env,
+    }
+    failed = [k for k, v in summary.items() if not v]
+    if failed:
+        print(fail(f"pre-deploy check failed: {failed}"))
+        return 1
+    print(ok(f"pre-deploy check PASSED for {bit.name}"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- formalizes the temporary Claude deploy fix by creating `TMP_REMOTE` with plain SSH as the board user, while keeping sudo cleanup for stale root-owned files
- adds the Phase B deploy/smoke scripts to the canonical repo, including the required pre-deploy validator used by `deploy_to_kv260.sh`
- makes `post_deploy_smoke.py` parse UIO map addresses numerically so lowercase sysfs addresses such as `0x00000000a0000000` pass correctly
- reads AXIL through `devmem`, then `busybox devmem`, then direct UIO `mmap`, and labels the reader path in smoke output

## Reproduction / Fix
- deploy bug: sudo-created `/tmp/pccx_deploy_*` made the later unprivileged `scp` fail with permission denied; the staging mkdir now runs as the SSH user and dry-run prints that path explicitly
- smoke bug: case-sensitive UIO matching could report a false failure for a valid fabric map; the check now compares parsed integer addresses
- smoke bug: boards without plain `devmem` no longer fail immediately; the smoke falls back to `busybox devmem` or dependency-free Python UIO mmap

## Validation
- `bash -n hw/scripts/deploy_to_kv260.sh`
- `python3 -m py_compile hw/scripts/post_deploy_smoke.py hw/scripts/pre_deploy_check.py`
- `hw/scripts/deploy_to_kv260.sh --dry-run` with Phase B artifact repo as `PCCX_REPO`
- real `hw/scripts/deploy_to_kv260.sh` completed; pre-deploy check passed and board fpga_manager state was `operating`
- `python3 hw/scripts/post_deploy_smoke.py` passed; UIO fabric map matched lowercase sysfs address and AXIL reads used `busybox-devmem` on this board
