### PR TITLE
feat(runtime): add NPU matmul32 Stage 1 path

### DIFF
--- a/scripts/kv260/run_npu_matmul32_fixture.py
+++ b/scripts/kv260/run_npu_matmul32_fixture.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import time
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sw.runtime.gemma.ops import matmul_int4_int8, matmul_int4_int8_reference
+
+
+def fixture_tensors() -> tuple[np.ndarray, np.ndarray]:
+    weights = ((np.arange(32 * 32, dtype=np.int16) % 16) - 8).reshape(32, 32)
+    activations = (((np.arange(32 * 32, dtype=np.int16) * 3) % 256) - 128).reshape(32, 32)
+    return weights.astype(np.int8), activations.astype(np.int8)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Stage 1 NPU matmul32 fixture")
+    parser.add_argument("--backend", choices=("auto", "npu", "cpu"), default="npu")
+    args = parser.parse_args()
+
+    weights, activations = fixture_tensors()
+    reference = matmul_int4_int8_reference(weights, activations)
+    started = time.perf_counter()
+    result = matmul_int4_int8(weights, activations, backend=args.backend)
+    elapsed_sec = time.perf_counter() - started
+    match = np.array_equal(result, reference)
+    if not match:
+        raise SystemExit("matmul32 fixture mismatch")
+
+    digest = hashlib.sha256()
+    digest.update(weights.tobytes())
+    digest.update(activations.tobytes())
+    digest.update(reference.astype("<i4", copy=False).tobytes())
+    print(
+        json.dumps(
+            {
+                "backend_requested": args.backend,
+                "bit_for_bit_match": True,
+                "elapsed_sec": round(elapsed_sec, 6),
+                "fixture_sha256": digest.hexdigest(),
+                "shape": [32, 32],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sw/dtbo/pccx_npu.dts
+++ b/sw/dtbo/pccx_npu.dts
@@ -1,0 +1,32 @@
+/*
+ * pccx_npu.dts - device-tree overlay for the pccx v002 NPU running on a
+ * KV260 SOM. Loaded via `xmutil loadapp pccx_npu` after the firmware/
+ * shell.json/bitstream files have been copied to
+ *   /lib/firmware/xilinx/pccx_npu/
+ *
+ * Address map (matches PS HPM0 default, axi_pc_axil M_AXI):
+ *   0xA000_0000 .. 0xA000_FFFF   pccx_npu + DataMover command/status windows
+ *
+ * Interrupt routing is omitted at this stage; AXIL_STAT_OUT polling is
+ * sufficient for the v002.1 bring-up loop.
+ */
+
+/dts-v1/;
+/plugin/;
+
+&{/} {
+    pccx_npu_axi: pccx-axi@0 {
+        compatible = "simple-bus";
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+
+        pccx_npu@a0000000 {
+            compatible = "pccx,npu-v002";
+            reg = <0x0 0xa0000000 0x0 0x10000>;
+            clocks = <&zynqmp_clk 71>;   /* PL0_REF_CTRL @ 250 MHz */
+            clock-names = "axi_clk";
+            status = "okay";
+        };
+    };
+};

--- a/sw/runtime/gemma/inference.py
+++ b/sw/runtime/gemma/inference.py
@@ -29,7 +29,8 @@ except Exception:  # pragma: no cover - import fallback is tested indirectly.
 BACKEND_AUTO = "auto"
 BACKEND_CPU = "cpu"
 BACKEND_NPU = "npu"
-BACKEND_CHOICES = {BACKEND_AUTO, BACKEND_CPU, BACKEND_NPU}
+BACKEND_HYBRID = "hybrid"
+BACKEND_CHOICES = {BACKEND_AUTO, BACKEND_CPU, BACKEND_NPU, BACKEND_HYBRID}
 
 
 def _default_npu_status(available: bool = False) -> dict:
@@ -46,6 +47,8 @@ def _default_npu_backend_readiness(reason: str = "NPU runtime is not importable"
         "npu_available": False,
         "hardware_results": False,
         "experimental_axil_dispatch": False,
+        "supported_ops": [],
+        "backend_kind": BACKEND_CPU,
         "reason": reason,
     }
 
@@ -74,14 +77,17 @@ def _resolve_backend(
 
     reason = str(readiness.get("reason") or "")
     hardware_results = bool(readiness.get("hardware_results"))
+    backend_kind = str(readiness.get("backend_kind") or BACKEND_NPU).strip().lower()
+    selected_backend = BACKEND_HYBRID if backend_kind == BACKEND_HYBRID else BACKEND_NPU
     if requested == BACKEND_CPU or use_npu is False:
         return False, BACKEND_CPU, "CPU backend requested"
-    if requested == BACKEND_NPU:
+    if requested in {BACKEND_NPU, BACKEND_HYBRID}:
         if not hardware_results:
-            raise RuntimeError(f"NPU backend requested but unavailable: {reason}")
-        return True, BACKEND_NPU, "NPU backend requested"
+            label = "NPU" if requested == BACKEND_NPU else BACKEND_HYBRID
+            raise RuntimeError(f"{label} backend requested but unavailable: {reason}")
+        return True, selected_backend, f"{selected_backend} backend requested"
     if hardware_results:
-        return True, BACKEND_NPU, "NPU backend auto-selected"
+        return True, selected_backend, f"{selected_backend} backend auto-selected"
     return False, BACKEND_CPU, reason or "NPU backend is not ready"
 
 

--- a/sw/runtime/gemma/ops.py
+++ b/sw/runtime/gemma/ops.py
@@ -6,6 +6,8 @@ and LAuReL/PLE scaling rules.
 """
 from __future__ import annotations
 
+import os
+
 import numpy as np
 
 from .arch import GemmaArch
@@ -14,6 +16,9 @@ from .core_secrets import (
     GAUSSIAN_TOPK_SIGMA,
     LAUREL_SCALE,
 )
+
+
+_TRUTHY = {"1", "true", "yes", "on"}
 
 
 def rms_norm(x: np.ndarray, gamma: np.ndarray | None = None, *, eps: float = 1e-6) -> np.ndarray:
@@ -73,3 +78,83 @@ def laurel_add(attn_output: np.ndarray, laurel_output: np.ndarray) -> np.ndarray
 def altup_route(x: np.ndarray, w_norm: np.ndarray, w_router: np.ndarray) -> np.ndarray:
     x_n = rms_norm(x, w_norm) / ALTUP_ROUTER_SCALE_DIM
     return np.tanh(np.dot(x_n, np.asarray(w_router, dtype=np.float32))).astype(np.float32)
+
+
+def matmul_int4_int8_reference(weights: np.ndarray, activations: np.ndarray) -> np.ndarray:
+    """Signed INT4 x signed INT8 reference for one matrix multiply."""
+    weights_i8 = _as_int4_matrix(weights)
+    activations_i8 = _as_int8_matrix(activations)
+    if weights_i8.shape[0] != activations_i8.shape[1]:
+        raise ValueError(
+            "matmul shape mismatch: activations must be [M, K] and weights [K, N]"
+        )
+    return np.matmul(
+        activations_i8.astype(np.int32),
+        weights_i8.astype(np.int32),
+    ).astype(np.int32)
+
+
+def matmul_int4_int8(
+    weights: np.ndarray,
+    activations: np.ndarray,
+    *,
+    backend: str = "auto",
+    compare_reference: bool = True,
+) -> np.ndarray:
+    """Dispatch Stage 1 signed INT4 x signed INT8 matmul through the NPU."""
+    requested = str(backend or "auto").strip().lower()
+    reference = matmul_int4_int8_reference(weights, activations)
+    if requested == "cpu":
+        if _dev_fallback_allowed():
+            return reference
+        raise RuntimeError("backend='cpu' is only allowed when PCCX_DEV_MODE=1")
+
+    try:
+        from sw.runtime.npu import npu_matmul_int4_int8
+    except Exception as exc:
+        if requested == "auto" and _dev_fallback_allowed():
+            return reference
+        raise RuntimeError(f"NPU matmul runtime is unavailable: {exc}") from exc
+
+    try:
+        result = np.asarray(
+            npu_matmul_int4_int8(weights, activations),
+            dtype=np.int32,
+        )
+    except Exception as exc:
+        if requested == "auto" and _dev_fallback_allowed():
+            return reference
+        raise RuntimeError(f"NPU matmul dispatch failed: {exc}") from exc
+    if compare_reference and not np.array_equal(result, reference):
+        raise AssertionError("NPU matmul result did not match NumPy reference")
+    return result
+
+
+def _as_int4_matrix(value: np.ndarray) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim != 2:
+        raise ValueError("INT4 weights must be a rank-2 matrix")
+    rounded = np.rint(arr.astype(np.float32))
+    if not np.array_equal(rounded, arr.astype(np.float32)):
+        raise ValueError("INT4 weights must contain integer values")
+    out = rounded.astype(np.int8)
+    if np.any(out < -8) or np.any(out > 7):
+        raise ValueError("INT4 weights must be in [-8, 7]")
+    return np.ascontiguousarray(out)
+
+
+def _as_int8_matrix(value: np.ndarray) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim != 2:
+        raise ValueError("INT8 activations must be a rank-2 matrix")
+    rounded = np.rint(arr.astype(np.float32))
+    if not np.array_equal(rounded, arr.astype(np.float32)):
+        raise ValueError("INT8 activations must contain integer values")
+    out = rounded.astype(np.int16)
+    if np.any(out < -128) or np.any(out > 127):
+        raise ValueError("INT8 activations must be in [-128, 127]")
+    return np.ascontiguousarray(out.astype(np.int8))
+
+
+def _dev_fallback_allowed() -> bool:
+    return os.getenv("PCCX_DEV_MODE", "").strip().lower() in _TRUTHY

--- a/sw/runtime/gemma/tests/test_backend_selection.py
+++ b/sw/runtime/gemma/tests/test_backend_selection.py
@@ -5,11 +5,18 @@ import pytest
 from sw.runtime.gemma.inference import _resolve_backend
 
 
-def _readiness(*, hardware_results: bool, reason: str = "not ready") -> dict:
+def _readiness(
+    *,
+    hardware_results: bool,
+    reason: str = "not ready",
+    backend_kind: str = "npu",
+) -> dict:
     return {
         "npu_available": True,
         "hardware_results": hardware_results,
         "experimental_axil_dispatch": False,
+        "supported_ops": ["gemm"] if hardware_results else [],
+        "backend_kind": backend_kind,
         "reason": reason,
     }
 
@@ -44,7 +51,19 @@ def test_strict_npu_backend_enables_npu_when_results_are_ready() -> None:
 
     assert use_npu is True
     assert backend == "npu"
-    assert reason == "NPU backend requested"
+    assert reason == "npu backend requested"
+
+
+def test_auto_backend_uses_hybrid_when_only_partial_npu_results_are_ready() -> None:
+    use_npu, backend, reason = _resolve_backend(
+        "auto",
+        None,
+        _readiness(hardware_results=True, backend_kind="hybrid"),
+    )
+
+    assert use_npu is True
+    assert backend == "hybrid"
+    assert reason == "hybrid backend auto-selected"
 
 
 def test_cpu_backend_overrides_available_npu_results() -> None:

--- a/sw/runtime/gemma/tests/test_ops_matmul.py
+++ b/sw/runtime/gemma/tests/test_ops_matmul.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sw.runtime.gemma import ops
+import sw.runtime.npu as npu_module
+
+
+def _weights32() -> np.ndarray:
+    return ((np.arange(32 * 32, dtype=np.int16) % 16) - 8).reshape(32, 32).astype(np.int8)
+
+
+def _activations32() -> np.ndarray:
+    return (((np.arange(32 * 32, dtype=np.int16) * 3) % 256) - 128).reshape(32, 32).astype(np.int8)
+
+
+def test_matmul_int4_int8_reference_matches_numpy_exactly() -> None:
+    weights = _weights32()
+    activations = _activations32()
+
+    expected = activations.astype(np.int32) @ weights.astype(np.int32)
+
+    np.testing.assert_array_equal(
+        ops.matmul_int4_int8_reference(weights, activations),
+        expected,
+    )
+
+
+def test_matmul_int4_int8_uses_npu_runtime_and_compares_reference(monkeypatch) -> None:
+    weights = _weights32()
+    activations = _activations32()
+    expected = ops.matmul_int4_int8_reference(weights, activations)
+    calls = []
+
+    def fake_matmul(W: np.ndarray, X: np.ndarray) -> np.ndarray:
+        calls.append((np.asarray(W).copy(), np.asarray(X).copy()))
+        return expected
+
+    monkeypatch.setattr(npu_module, "npu_matmul_int4_int8", fake_matmul)
+
+    out = ops.matmul_int4_int8(weights, activations, backend="npu")
+
+    np.testing.assert_array_equal(out, expected)
+    assert len(calls) == 1
+    np.testing.assert_array_equal(calls[0][0], weights)
+    np.testing.assert_array_equal(calls[0][1], activations)
+
+
+def test_matmul_int4_int8_raises_on_npu_reference_mismatch(monkeypatch) -> None:
+    weights = _weights32()
+    activations = _activations32()
+    wrong = ops.matmul_int4_int8_reference(weights, activations).copy()
+    wrong[0, 0] += 1
+
+    monkeypatch.setattr(npu_module, "npu_matmul_int4_int8", lambda W, X: wrong)
+
+    with pytest.raises(AssertionError, match="did not match NumPy reference"):
+        ops.matmul_int4_int8(weights, activations, backend="npu")
+
+
+def test_matmul_int4_int8_reference_backend_is_dev_only(monkeypatch) -> None:
+    weights = np.array([[1, -2], [3, -4]], dtype=np.int8)
+    activations = np.array([[5, -6], [7, -8]], dtype=np.int8)
+    expected = activations.astype(np.int32) @ weights.astype(np.int32)
+
+    monkeypatch.delenv("PCCX_DEV_MODE", raising=False)
+    with pytest.raises(RuntimeError, match="PCCX_DEV_MODE=1"):
+        ops.matmul_int4_int8(weights, activations, backend="cpu")
+
+    monkeypatch.setenv("PCCX_DEV_MODE", "1")
+    np.testing.assert_array_equal(
+        ops.matmul_int4_int8(weights, activations, backend="cpu"),
+        expected,
+    )
+
+
+def test_matmul_int4_int8_auto_uses_reference_only_in_dev_mode(monkeypatch) -> None:
+    weights = np.array([[1, -2], [3, -4]], dtype=np.int8)
+    activations = np.array([[5, -6], [7, -8]], dtype=np.int8)
+    expected = activations.astype(np.int32) @ weights.astype(np.int32)
+
+    def broken_matmul(W: np.ndarray, X: np.ndarray) -> np.ndarray:
+        raise RuntimeError("not configured")
+
+    monkeypatch.setattr(npu_module, "npu_matmul_int4_int8", broken_matmul)
+
+    monkeypatch.delenv("PCCX_DEV_MODE", raising=False)
+    with pytest.raises(RuntimeError, match="NPU matmul dispatch failed"):
+        ops.matmul_int4_int8(weights, activations, backend="auto")
+
+    monkeypatch.setenv("PCCX_DEV_MODE", "1")
+    np.testing.assert_array_equal(
+        ops.matmul_int4_int8(weights, activations, backend="auto"),
+        expected,
+    )

--- a/sw/runtime/isa.py
+++ b/sw/runtime/isa.py
@@ -40,6 +40,11 @@ TO_NPU,   TO_HOST   = 0, 1
 SYNC, ASYNC         = 0, 1
 
 
+DATA_TO_FMAP_SHAPE = 0
+DATA_TO_WEIGHT_SHAPE = 1
+MATMUL32_DIM = 32
+
+
 KICK_MARKER = 0x8000_0000_0000_0000
 
 
@@ -58,6 +63,19 @@ def _pack_opcode(opcode: Opcode, body: int) -> int:
     """body must already fit in 60 bits."""
     body = _check(body, 60, "body")
     return (int(opcode) & 0xF) << 60 | body
+
+
+def encode_parallel_lane_count(lane_count: int) -> int:
+    """Encode a 1..32 active-lane count into the 5-bit ISA lane field."""
+    lane_count = int(lane_count)
+    if lane_count < 1 or lane_count > 32:
+        raise ValueError("lane_count must be in [1, 32]")
+    return lane_count - 1
+
+
+def decode_parallel_lane_count(parallel_lane: int) -> int:
+    """Decode the 5-bit ISA lane field back into a 1..32 lane count."""
+    return _check(int(parallel_lane), 5, "parallel_lane") + 1
 
 
 @dataclass(frozen=True)
@@ -167,6 +185,46 @@ def encode_cvo(
             | (_check(flags,       5, "flags")       <<  1)
             | (_check(async_op,    1, "async_op")    <<  0))
     return _pack_opcode(Opcode.CVO, body)
+
+
+def encode_matmul32_int4_int8_program(
+    *,
+    dest_reg: int = 0,
+    src_addr: int = 0,
+    shape_ptr_addr: int = 3,
+    weight_shape_ptr_addr: int | None = None,
+    flags: GemmFlags = GemmFlags(),
+) -> list[int]:
+    """Encode the Stage 1 32x32 INT4 x INT8 matmul command sequence."""
+    shape_ptr = _check(shape_ptr_addr, 6, "shape_ptr_addr")
+    weight_shape_ptr = (
+        shape_ptr if weight_shape_ptr_addr is None
+        else _check(weight_shape_ptr_addr, 6, "weight_shape_ptr_addr")
+    )
+    return [
+        encode_memset(
+            DATA_TO_FMAP_SHAPE,
+            shape_ptr,
+            MATMUL32_DIM,
+            MATMUL32_DIM,
+            1,
+        ),
+        encode_memset(
+            DATA_TO_WEIGHT_SHAPE,
+            weight_shape_ptr,
+            MATMUL32_DIM,
+            MATMUL32_DIM,
+            1,
+        ),
+        encode_gemm(
+            dest_reg=dest_reg,
+            src_addr=src_addr,
+            flags=flags,
+            size_ptr_addr=encode_parallel_lane_count(MATMUL32_DIM),
+            shape_ptr_addr=shape_ptr,
+            parallel_lane=encode_parallel_lane_count(MATMUL32_DIM),
+        ),
+    ]
 
 
 # Status word (read from AXIL_STAT_OUT, 64-bit but only [31:0] is mmio_npu_stat)

--- a/sw/runtime/npu/__init__.py
+++ b/sw/runtime/npu/__init__.py
@@ -17,6 +17,7 @@ from .npu_core import (
     npu_cvo,
     npu_gemm,
     npu_gemv,
+    npu_matmul_int4_int8,
     npu_status,
 )
 
@@ -26,5 +27,6 @@ __all__ = [
     "npu_cvo",
     "npu_gemm",
     "npu_gemv",
+    "npu_matmul_int4_int8",
     "npu_status",
 ]

--- a/sw/runtime/npu/dma.py
+++ b/sw/runtime/npu/dma.py
@@ -22,6 +22,7 @@ FLAG_CMD_EMPTY = 1 << 0
 FLAG_CMD_FULL = 1 << 1
 FLAG_STS_EMPTY = 1 << 2
 FLAG_STS_FULL = 1 << 3
+DATAMOVER_STATUS_ERROR_MASK = 0x0F
 
 BTT_MASK = (1 << 23) - 1
 ADDR_MASK = (1 << 32) - 1
@@ -98,6 +99,11 @@ class PSDataMoverChannel:
                         f"{self.name} status tag 0x{status_tag:x} "
                         f"did not match command token 0x{cmd_token & TAG_MASK:x}"
                     )
+                error_bits = datamover_status_error_bits(status)
+                if error_bits:
+                    raise RuntimeError(
+                        f"{self.name} DataMover status error bits 0x{error_bits:x}"
+                    )
                 return status
             time.sleep(0.0005)
         raise TimeoutError(
@@ -148,3 +154,9 @@ def pack_datamover_command(
         | (1 << 23)
         | (length_bytes & BTT_MASK)
     )
+
+
+def datamover_status_error_bits(status: int) -> int:
+    """Return the low DataMover status bits that signal transfer errors."""
+
+    return int(status) & DATAMOVER_STATUS_ERROR_MASK

--- a/sw/runtime/npu/dma_buffer.py
+++ b/sw/runtime/npu/dma_buffer.py
@@ -1,0 +1,256 @@
+"""DMA-safe buffer ownership helpers for PS-issued NPU transfers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import mmap
+import os
+from pathlib import Path
+from typing import BinaryIO
+
+
+DMA_DEVICE_ENV = "PCCX_NPU_DMA_DEVICE"
+DMA_PHYS_ENV = "PCCX_NPU_DMA_PHYS"
+DMA_SIZE_ENV = "PCCX_NPU_DMA_SIZE"
+
+
+class DmaBufferUnavailable(RuntimeError):
+    """Raised when no PS DMA buffer provider can expose a physical address."""
+
+
+@dataclass(frozen=True)
+class DmaBufferSlice:
+    """A view into one contiguous DMA region."""
+
+    region: "MappedDmaRegion"
+    name: str
+    offset: int
+    size: int
+    phys_addr: int
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        payload = bytes(data)
+        if len(payload) > self.size:
+            raise ValueError(f"{self.name} payload exceeds DMA slice size")
+        self.region.write(self.offset, payload)
+
+    def read(self, size: int | None = None) -> bytes:
+        read_size = self.size if size is None else int(size)
+        if read_size < 0 or read_size > self.size:
+            raise ValueError(f"{self.name} read exceeds DMA slice size")
+        return self.region.read(self.offset, read_size)
+
+    def sync_for_device(self) -> None:
+        self.region.sync_for_device(self.offset, self.size)
+
+    def sync_for_cpu(self) -> None:
+        self.region.sync_for_cpu(self.offset, self.size)
+
+
+class MappedDmaRegion:
+    """One mmap'ed physically-contiguous DMA region with simple slice allocation."""
+
+    def __init__(
+        self,
+        *,
+        device_path: str | os.PathLike[str],
+        phys_addr: int,
+        size: int,
+        coherent: bool = True,
+        sysfs_path: str | os.PathLike[str] | None = None,
+    ) -> None:
+        if phys_addr < 0 or phys_addr > 0xFFFF_FFFF:
+            raise ValueError("DMA physical address must fit in the v12d 32-bit DataMover address field")
+        if size <= 0:
+            raise ValueError("DMA region size must be positive")
+        self.device_path = str(device_path)
+        self.phys_addr = int(phys_addr)
+        self.size = int(size)
+        self.coherent = bool(coherent)
+        self.sysfs_path = Path(sysfs_path) if sysfs_path is not None else None
+        self._file: BinaryIO | None = None
+        self._mm: mmap.mmap | None = None
+        self._next_offset = 0
+
+    def __enter__(self) -> "MappedDmaRegion":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def open(self) -> None:
+        if self._mm is not None:
+            return
+        self._file = open(self.device_path, "r+b", buffering=0)
+        self._mm = mmap.mmap(
+            self._file.fileno(),
+            self.size,
+            flags=mmap.MAP_SHARED,
+            prot=mmap.PROT_READ | mmap.PROT_WRITE,
+        )
+
+    def close(self) -> None:
+        if self._mm is not None:
+            self._mm.close()
+            self._mm = None
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def allocate(self, name: str, size: int, *, alignment: int = 64) -> DmaBufferSlice:
+        if size <= 0:
+            raise ValueError("DMA slice size must be positive")
+        if alignment <= 0:
+            raise ValueError("DMA slice alignment must be positive")
+        offset = _align_up(self._next_offset, alignment)
+        end = offset + int(size)
+        if end > self.size:
+            raise MemoryError(
+                f"DMA region {self.device_path} cannot allocate {name!r}: "
+                f"need 0x{end:x}, size 0x{self.size:x}"
+            )
+        self._next_offset = end
+        return DmaBufferSlice(
+            region=self,
+            name=name,
+            offset=offset,
+            size=int(size),
+            phys_addr=self.phys_addr + offset,
+        )
+
+    def write(self, offset: int, data: bytes) -> None:
+        mm = self._require_mmap()
+        end = offset + len(data)
+        if offset < 0 or end > self.size:
+            raise ValueError("DMA write outside mapped region")
+        mm.seek(offset)
+        mm.write(data)
+
+    def read(self, offset: int, size: int) -> bytes:
+        mm = self._require_mmap()
+        end = offset + size
+        if offset < 0 or end > self.size:
+            raise ValueError("DMA read outside mapped region")
+        mm.seek(offset)
+        return mm.read(size)
+
+    def sync_for_device(self, offset: int, size: int) -> None:
+        self._sync("device", offset, size)
+
+    def sync_for_cpu(self, offset: int, size: int) -> None:
+        self._sync("cpu", offset, size)
+
+    def _sync(self, direction: str, offset: int, size: int) -> None:
+        if self.coherent or self.sysfs_path is None:
+            return
+        _write_optional_sysfs(self.sysfs_path / "sync_offset", str(offset))
+        _write_optional_sysfs(self.sysfs_path / "sync_size", str(size))
+        _write_optional_sysfs(self.sysfs_path / "sync_direction", direction)
+        target = "sync_for_device" if direction == "device" else "sync_for_cpu"
+        _write_optional_sysfs(self.sysfs_path / target, "1")
+
+    def _require_mmap(self) -> mmap.mmap:
+        if self._mm is None:
+            raise RuntimeError("DMA region is not open")
+        return self._mm
+
+
+def open_dma_region_from_env() -> MappedDmaRegion:
+    """Open a DMA region from env or the first udmabuf-style device."""
+
+    explicit = os.getenv(DMA_DEVICE_ENV)
+    if explicit:
+        phys_text = os.getenv(DMA_PHYS_ENV)
+        size_text = os.getenv(DMA_SIZE_ENV)
+        if not phys_text or not size_text:
+            raise DmaBufferUnavailable(
+                f"{DMA_DEVICE_ENV} requires {DMA_PHYS_ENV} and {DMA_SIZE_ENV}"
+            )
+        region = MappedDmaRegion(
+            device_path=explicit,
+            phys_addr=int(phys_text, 0),
+            size=int(size_text, 0),
+            coherent=_env_truthy("PCCX_NPU_DMA_COHERENT", default=True),
+        )
+        region.open()
+        return region
+
+    discovered = _discover_udmabuf()
+    if discovered is None:
+        raise DmaBufferUnavailable(
+            "no DMA buffer provider found; set PCCX_NPU_DMA_DEVICE, "
+            "PCCX_NPU_DMA_PHYS, and PCCX_NPU_DMA_SIZE, or expose /dev/udmabufN"
+        )
+    discovered.open()
+    return discovered
+
+
+def _discover_udmabuf() -> MappedDmaRegion | None:
+    for dev in sorted(Path("/dev").glob("udmabuf*")) + sorted(Path("/dev").glob("u-dma-buf*")):
+        sysfs = _udmabuf_sysfs(dev.name)
+        if sysfs is None:
+            continue
+        phys = _read_int_file(sysfs / "phys_addr")
+        size = _read_int_file(sysfs / "size")
+        if phys is None or size is None:
+            continue
+        coherent = _read_bool_file(sysfs / "sync_mode")
+        return MappedDmaRegion(
+            device_path=dev,
+            phys_addr=phys,
+            size=size,
+            coherent=coherent,
+            sysfs_path=sysfs,
+        )
+    return None
+
+
+def _udmabuf_sysfs(name: str) -> Path | None:
+    candidates = (
+        Path("/sys/class/u-dma-buf") / name,
+        Path("/sys/class/udmabuf") / name,
+        Path("/sys/class/misc") / name,
+    )
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def _read_int_file(path: Path) -> int | None:
+    try:
+        text = path.read_text(encoding="ascii").strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    try:
+        return int(text, 0)
+    except ValueError:
+        return None
+
+
+def _read_bool_file(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="ascii").strip().lower()
+    except OSError:
+        return True
+    return text not in {"0", "false", "off", "disabled"}
+
+
+def _write_optional_sysfs(path: Path, value: str) -> None:
+    try:
+        path.write_text(value, encoding="ascii")
+    except OSError:
+        return
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)
+
+
+def _env_truthy(name: str, *, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}

--- a/sw/runtime/npu/npu_core.py
+++ b/sw/runtime/npu/npu_core.py
@@ -17,8 +17,16 @@ from .address_map import (
     AXIL_STAT_OUT,
     BITSTREAM_PATH_DEFAULT,
     bitstream_sha256_is_expected,
+    discover_address_map,
 )
 from .cpu_fallback import cpu_cvo, cpu_gemm, cpu_gemv
+from .dma import create_channels
+from .dma_buffer import (
+    DMA_DEVICE_ENV,
+    DMA_PHYS_ENV,
+    DMA_SIZE_ENV,
+    open_dma_region_from_env,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -26,6 +34,16 @@ LOG = logging.getLogger(__name__)
 NPU_AVAILABLE: bool | None = None
 UIO_DEVICE_DEFAULT = "/dev/uio4"
 NPU_TIMEOUT_SEC = 5.0
+DMA_TIMEOUT_SEC = 5.0
+GEMM_READBACK_ENV = "PCCX_NPU_ENABLE_GEMM_READBACK"
+GEMM_SHAPE_PTR_ENV = "PCCX_NPU_GEMM_SHAPE_PTR"
+GEMM_INPUT_L2_ENV = "PCCX_NPU_GEMM_INPUT_L2_ADDR"
+GEMM_OUTPUT_L2_ENV = "PCCX_NPU_GEMM_OUTPUT_L2_ADDR"
+FALLBACK_REASON = (
+    "NPU UIO/bitstream is available, but high-level Gemma tensor dispatch "
+    "still returns NumPy golden results; DMA buffer ownership and result "
+    "readback are not enabled"
+)
 
 _TRUTHY = {"1", "true", "yes", "on"}
 _CVO_FUNC_BY_NAME = {
@@ -49,6 +67,11 @@ def npu_gemm(
     """W [K_in, M_out], X [B, K_in] -> [B, M_out] float32."""
     Wf = np.asarray(W, dtype=np.float32)
     Xf = np.asarray(X, dtype=np.float32)
+    if _can_attempt_gemm_readback():
+        try:
+            return _dispatch_gemm_readback(Wf, Xf, layer_idx=layer_idx)
+        except Exception as exc:
+            LOG.warning("NPU GEMM readback failed; using CPU fallback: %s", exc)
     if not _can_attempt_hardware():
         return cpu_gemm(Wf, Xf)
 
@@ -143,22 +166,26 @@ def npu_backend_readiness() -> dict:
     """Return whether the NPU path can produce Gemma tensor results."""
     available = npu_available()
     experimental_axil = _env_truthy("PCCX_NPU_EXPERIMENTAL_DISPATCH")
-    hardware_results = False
+    gemm_readback = _gemm_readback_configured()
+    hardware_results = available and gemm_readback[0]
     if not available:
         reason = (
             "NPU UIO/bitstream is not available; Gemma tensor dispatch would "
             "use CPU fallback"
         )
+    elif not gemm_readback[0]:
+        reason = gemm_readback[1]
     else:
         reason = (
-            "NPU UIO/bitstream is available, but high-level Gemma tensor "
-            "dispatch still returns NumPy golden results; DMA buffer ownership "
-            "and result readback are not implemented"
+            "NPU GEMM DMA buffer ownership and BF16 result readback are "
+            "configured; board result-path evidence is still required"
         )
     return {
         "npu_available": available,
         "hardware_results": hardware_results,
         "experimental_axil_dispatch": experimental_axil,
+        "supported_ops": ["gemm"] if hardware_results else [],
+        "backend_kind": "hybrid" if hardware_results else "cpu",
         "reason": reason,
     }
 
@@ -195,20 +222,140 @@ def _can_attempt_hardware() -> bool:
     return False
 
 
+def _can_attempt_gemm_readback() -> bool:
+    if not npu_available():
+        return False
+    ready, reason = _gemm_readback_configured()
+    if ready:
+        return True
+    LOG.info(reason)
+    return False
+
+
 def _submit_experimental_program(words: list[int]) -> None:
     if len(words) > 8:
         raise ValueError("AXIL_CMD_IN FIFO accepts at most 8 words per program")
     with NpuMmio(uio=UIO_DEVICE_DEFAULT) as mmio:
-        for word in words:
-            mmio.write64(AXIL_CMD_IN, word)
-        mmio.write64(AXIL_CMD_KICK, 0x1)
-        deadline = time.monotonic() + NPU_TIMEOUT_SEC
-        while time.monotonic() < deadline:
-            status = mmio.read32(AXIL_STAT_OUT)
-            if isa.status_done(status):
-                return
-            time.sleep(0.001)
+        if _submit_program_on_mmio(mmio, words):
+            return
     raise TimeoutError("NPU program did not report DONE")
+
+
+def _submit_program_on_mmio(mmio: NpuMmio, words: list[int]) -> bool:
+    for word in words:
+        mmio.write64(AXIL_CMD_IN, word)
+    mmio.write64(AXIL_CMD_KICK, 0x1)
+    deadline = time.monotonic() + NPU_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        status = mmio.read32(AXIL_STAT_OUT)
+        if isa.status_done(status):
+            return True
+        time.sleep(0.001)
+    return False
+
+
+def _dispatch_gemm_readback(
+    W: np.ndarray,
+    X: np.ndarray,
+    *,
+    layer_idx: int | None,
+) -> np.ndarray:
+    if W.ndim != 2 or X.ndim != 2:
+        raise ValueError("hardware GEMM readback requires 2D W and X")
+    batch, kin = X.shape
+    if W.shape[0] != kin:
+        raise ValueError("GEMM shape mismatch")
+    nout = int(W.shape[1])
+    _check_memset_dim(batch, "batch")
+    _check_memset_dim(kin, "kin")
+    _check_memset_dim(nout, "nout")
+
+    input_bytes = _pad_128b(_float32_to_bf16_bytes(X))
+    hp0_bytes, hp1_bytes = _pack_int4_weight_lanes(W)
+    output_elements = batch * nout
+    output_bytes = _padded_bf16_nbytes(output_elements)
+
+    shape_ptr = (
+        int(os.getenv(GEMM_SHAPE_PTR_ENV, str(_shape_ptr_for_layer(layer_idx) or 3)))
+        & 0x3F
+    )
+    out_shape_ptr = (shape_ptr + 1) & 0x3F
+    l2_input_addr = _env_int(GEMM_INPUT_L2_ENV, 0)
+    l2_output_addr = _env_int(GEMM_OUTPUT_L2_ENV, 512)
+
+    with open_dma_region_from_env() as region:
+        input_buf = region.allocate("gemm_input_bf16", len(input_bytes), alignment=64)
+        hp0_buf = region.allocate("gemm_weight_hp0", len(hp0_bytes), alignment=64)
+        hp1_buf = region.allocate("gemm_weight_hp1", len(hp1_bytes), alignment=64)
+        output_buf = region.allocate("gemm_output_bf16", output_bytes, alignment=64)
+
+        input_buf.write(input_bytes)
+        hp0_buf.write(hp0_bytes)
+        hp1_buf.write(hp1_bytes)
+        output_buf.write(bytes(output_bytes))
+        input_buf.sync_for_device()
+        hp0_buf.sync_for_device()
+        hp1_buf.sync_for_device()
+        output_buf.sync_for_device()
+
+        with NpuMmio(uio=UIO_DEVICE_DEFAULT) as mmio:
+            channels = create_channels(mmio, discover_address_map())
+            result_token = channels["acp_result"].issue_command(
+                output_buf.phys_addr,
+                0x4,
+                output_buf.size,
+            )
+            fmap_token = channels["acp_fmap"].issue_command(
+                input_buf.phys_addr,
+                0x3,
+                input_buf.size,
+            )
+            hp0_token = channels["hp0"].issue_command(
+                hp0_buf.phys_addr,
+                0x1,
+                hp0_buf.size,
+            )
+            hp1_token = channels["hp1"].issue_command(
+                hp1_buf.phys_addr,
+                0x2,
+                hp1_buf.size,
+            )
+
+            words = [
+                isa.encode_memset(0, shape_ptr, int(batch), int(kin), 1),
+                isa.encode_memset(0, out_shape_ptr, int(batch), int(nout), 1),
+                isa.encode_memcpy(
+                    isa.FROM_HOST,
+                    isa.TO_NPU,
+                    dest_addr=l2_input_addr,
+                    src_addr=0,
+                    shape_ptr_addr=shape_ptr,
+                ),
+                isa.encode_gemm(
+                    dest_reg=l2_output_addr,
+                    src_addr=l2_input_addr,
+                    size_ptr_addr=min(int(kin), 0x3F),
+                    shape_ptr_addr=shape_ptr,
+                    parallel_lane=_parallel_lane_for_shape(W.shape),
+                ),
+                isa.encode_memcpy(
+                    isa.FROM_NPU,
+                    isa.TO_HOST,
+                    dest_addr=0,
+                    src_addr=l2_output_addr,
+                    shape_ptr_addr=out_shape_ptr,
+                ),
+            ]
+            if not _submit_program_on_mmio(mmio, words):
+                raise TimeoutError("NPU GEMM program did not report DONE")
+
+            channels["acp_fmap"].poll_status(fmap_token, DMA_TIMEOUT_SEC)
+            channels["hp0"].poll_status(hp0_token, DMA_TIMEOUT_SEC)
+            channels["hp1"].poll_status(hp1_token, DMA_TIMEOUT_SEC)
+            channels["acp_result"].poll_status(result_token, DMA_TIMEOUT_SEC)
+
+        output_buf.sync_for_cpu()
+        return _bf16_bytes_to_float32(output_buf.read(output_bytes), (batch, nout))
 
 
 def _tiled_gemm_fallback(W: np.ndarray, X: np.ndarray) -> np.ndarray:
@@ -260,3 +407,95 @@ def _fallback_requested() -> bool:
 
 def _env_truthy(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _gemm_readback_configured() -> tuple[bool, str]:
+    if not _env_truthy(GEMM_READBACK_ENV):
+        return False, (
+            f"{FALLBACK_REASON}; {GEMM_READBACK_ENV}=1 is required because "
+            "the current source tree still needs board evidence for the GEMM "
+            "result producer to L2/ACP path"
+        )
+    if not _dma_provider_configured():
+        return False, (
+            "GEMM readback requested, but no DMA-safe PS buffer provider is "
+            f"configured; set {DMA_DEVICE_ENV}, {DMA_PHYS_ENV}, and {DMA_SIZE_ENV}"
+        )
+    return True, "GEMM readback configured"
+
+
+def _dma_provider_configured() -> bool:
+    if (
+        os.getenv(DMA_DEVICE_ENV)
+        and os.getenv(DMA_PHYS_ENV)
+        and os.getenv(DMA_SIZE_ENV)
+    ):
+        return True
+    try:
+        dev = Path("/dev")
+        return any(dev.glob("udmabuf*")) or any(dev.glob("u-dma-buf*"))
+    except OSError:
+        return False
+
+
+def _float32_to_bf16_bytes(value: np.ndarray) -> bytes:
+    arr = np.ascontiguousarray(value, dtype=np.float32)
+    bits = arr.view(np.uint32)
+    rounded = bits + (((bits >> 16) & 1) + 0x7FFF)
+    bf16 = (rounded >> 16).astype("<u2", copy=False)
+    return bf16.tobytes()
+
+
+def _bf16_bytes_to_float32(data: bytes, shape: tuple[int, ...]) -> np.ndarray:
+    count = int(np.prod(shape))
+    raw = np.frombuffer(data[: count * 2], dtype="<u2").astype(np.uint32)
+    bits = raw << 16
+    return bits.view(np.float32).reshape(shape).astype(np.float32, copy=False)
+
+
+def _padded_bf16_nbytes(elements: int) -> int:
+    return _align_up(int(elements) * 2, 16)
+
+
+def _pad_128b(data: bytes) -> bytes:
+    padded = _align_up(len(data), 16)
+    if padded == len(data):
+        return data
+    return data + bytes(padded - len(data))
+
+
+def _pack_int4_weight_lanes(W: np.ndarray) -> tuple[bytes, bytes]:
+    quant = np.rint(np.asarray(W, dtype=np.float32))
+    if not np.allclose(quant, W, atol=0.0):
+        raise ValueError(
+            "hardware GEMM readback currently requires already-quantized int4 weights"
+        )
+    if np.any(quant < -8) or np.any(quant > 7):
+        raise ValueError("hardware GEMM readback int4 weights must be in [-8, 7]")
+
+    flat = np.ascontiguousarray(quant.astype(np.int8)).reshape(-1)
+    hp0 = _pack_int4_values(flat[0::2])
+    hp1 = _pack_int4_values(flat[1::2])
+    return _pad_128b(hp0), _pad_128b(hp1)
+
+
+def _pack_int4_values(values: np.ndarray) -> bytes:
+    vals = np.asarray(values, dtype=np.int8).reshape(-1)
+    if vals.size % 2:
+        vals = np.concatenate([vals, np.zeros(1, dtype=np.int8)])
+    nibbles = vals.astype(np.uint8) & 0x0F
+    packed = nibbles[0::2] | (nibbles[1::2] << 4)
+    return packed.astype(np.uint8, copy=False).tobytes()
+
+
+def _check_memset_dim(value: int, name: str) -> None:
+    if value < 0 or value > 0xFFFF:
+        raise ValueError(f"{name}={value} does not fit in the MEMSET shape field")
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)), 0)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + int(alignment) - 1) // int(alignment)) * int(alignment)

--- a/sw/runtime/npu/npu_core.py
+++ b/sw/runtime/npu/npu_core.py
@@ -271,10 +271,17 @@ def _submit_experimental_program(words: list[int]) -> None:
     raise TimeoutError("NPU program did not report DONE")
 
 
-def _submit_program_on_mmio(mmio: NpuMmio, words: list[int]) -> bool:
+def _submit_program_on_mmio(
+    mmio: NpuMmio,
+    words: list[int],
+    *,
+    wait_done: bool = True,
+) -> bool:
     for word in words:
         mmio.write64(AXIL_CMD_IN, word)
     mmio.write64(AXIL_CMD_KICK, 0x1)
+    if not wait_done:
+        return True
     deadline = time.monotonic() + NPU_TIMEOUT_SEC
     while time.monotonic() < deadline:
         status = mmio.read32(AXIL_STAT_OUT)
@@ -376,7 +383,7 @@ def _dispatch_gemm_readback(
                     shape_ptr_addr=out_shape_ptr,
                 ),
             ]
-            if not _submit_program_on_mmio(mmio, words):
+            if not _submit_program_on_mmio(mmio, words, wait_done=False):
                 raise TimeoutError("NPU GEMM program did not report DONE")
 
             channels["acp_fmap"].poll_status(fmap_token, DMA_TIMEOUT_SEC)
@@ -433,7 +440,7 @@ def _dispatch_matmul32_int4_int8(W: np.ndarray, X: np.ndarray) -> np.ndarray:
                     idx,
                     hp_buffers[name].size,
                 )
-                for idx, name in enumerate(("hp0", "hp1", "hp2", "hp3"), start=1)
+                for idx, name in enumerate(("hp0", "hp1"), start=1)
             }
 
             words = isa.encode_matmul32_int4_int8_program(
@@ -441,7 +448,7 @@ def _dispatch_matmul32_int4_int8(W: np.ndarray, X: np.ndarray) -> np.ndarray:
                 src_addr=src_addr,
                 shape_ptr_addr=shape_ptr,
             )
-            if not _submit_program_on_mmio(mmio, words):
+            if not _submit_program_on_mmio(mmio, words, wait_done=False):
                 raise TimeoutError("NPU matmul32 program did not report DONE")
 
             channels["acp_fmap"].poll_status(input_token, DMA_TIMEOUT_SEC)

--- a/sw/runtime/npu/npu_core.py
+++ b/sw/runtime/npu/npu_core.py
@@ -39,11 +39,16 @@ GEMM_READBACK_ENV = "PCCX_NPU_ENABLE_GEMM_READBACK"
 GEMM_SHAPE_PTR_ENV = "PCCX_NPU_GEMM_SHAPE_PTR"
 GEMM_INPUT_L2_ENV = "PCCX_NPU_GEMM_INPUT_L2_ADDR"
 GEMM_OUTPUT_L2_ENV = "PCCX_NPU_GEMM_OUTPUT_L2_ADDR"
+INT4_INT8_MATMUL32_ENV = "PCCX_NPU_ENABLE_INT4_INT8_MATMUL32"
+MATMUL32_SHAPE_PTR_ENV = "PCCX_NPU_MATMUL32_SHAPE_PTR"
+MATMUL32_SRC_ADDR_ENV = "PCCX_NPU_MATMUL32_SRC_ADDR"
+MATMUL32_DEST_ADDR_ENV = "PCCX_NPU_MATMUL32_DEST_ADDR"
 FALLBACK_REASON = (
     "NPU UIO/bitstream is available, but high-level Gemma tensor dispatch "
     "still returns NumPy golden results; DMA buffer ownership and result "
     "readback are not enabled"
 )
+MATMUL32_DIM = 32
 
 _TRUTHY = {"1", "true", "yes", "on"}
 _CVO_FUNC_BY_NAME = {
@@ -88,6 +93,18 @@ def npu_gemm(
     except Exception as exc:
         LOG.warning("NPU GEMM dispatch failed; using CPU fallback: %s", exc)
     return _tiled_gemm_fallback(Wf, Xf)
+
+
+def npu_matmul_int4_int8(
+    W: np.ndarray,
+    X: np.ndarray,
+) -> np.ndarray:
+    """Run one Stage 1 32x32 signed INT4 x signed INT8 matmul on the NPU."""
+    Wi = _validate_matmul32_int4_weights(W)
+    Xi = _validate_matmul32_int8_activations(X)
+    if not _can_attempt_matmul32():
+        raise RuntimeError("NPU INT4 x INT8 matmul32 is not configured")
+    return _dispatch_matmul32_int4_int8(Wi, Xi)
 
 
 def npu_gemv(
@@ -167,24 +184,27 @@ def npu_backend_readiness() -> dict:
     available = npu_available()
     experimental_axil = _env_truthy("PCCX_NPU_EXPERIMENTAL_DISPATCH")
     gemm_readback = _gemm_readback_configured()
-    hardware_results = available and gemm_readback[0]
+    matmul32 = _matmul32_configured()
+    hardware_results = available and (gemm_readback[0] or matmul32[0])
+    supported_ops = []
+    if available and gemm_readback[0]:
+        supported_ops.append("gemm")
+    if available and matmul32[0]:
+        supported_ops.append("matmul32_int4_int8")
     if not available:
         reason = (
             "NPU UIO/bitstream is not available; Gemma tensor dispatch would "
             "use CPU fallback"
         )
-    elif not gemm_readback[0]:
-        reason = gemm_readback[1]
+    elif hardware_results:
+        reason = "NPU matmul hardware result path is configured"
     else:
-        reason = (
-            "NPU GEMM DMA buffer ownership and BF16 result readback are "
-            "configured; board result-path evidence is still required"
-        )
+        reason = f"{gemm_readback[1]}; {matmul32[1]}"
     return {
         "npu_available": available,
         "hardware_results": hardware_results,
         "experimental_axil_dispatch": experimental_axil,
-        "supported_ops": ["gemm"] if hardware_results else [],
+        "supported_ops": supported_ops,
         "backend_kind": "hybrid" if hardware_results else "cpu",
         "reason": reason,
     }
@@ -226,6 +246,16 @@ def _can_attempt_gemm_readback() -> bool:
     if not npu_available():
         return False
     ready, reason = _gemm_readback_configured()
+    if ready:
+        return True
+    LOG.info(reason)
+    return False
+
+
+def _can_attempt_matmul32() -> bool:
+    if not npu_available():
+        return False
+    ready, reason = _matmul32_configured()
     if ready:
         return True
     LOG.info(reason)
@@ -358,6 +388,75 @@ def _dispatch_gemm_readback(
         return _bf16_bytes_to_float32(output_buf.read(output_bytes), (batch, nout))
 
 
+def _dispatch_matmul32_int4_int8(W: np.ndarray, X: np.ndarray) -> np.ndarray:
+    reference_shape = (MATMUL32_DIM, MATMUL32_DIM)
+    input_bytes = _pad_128b(np.ascontiguousarray(X, dtype=np.int8).tobytes())
+    hp_bytes = _pack_matmul32_weight_lanes(W)
+    output_bytes = MATMUL32_DIM * MATMUL32_DIM * 4
+    shape_ptr = int(os.getenv(MATMUL32_SHAPE_PTR_ENV, "3"), 0) & 0x3F
+    src_addr = _env_int(MATMUL32_SRC_ADDR_ENV, 0)
+    dest_addr = _env_int(MATMUL32_DEST_ADDR_ENV, 512)
+
+    with open_dma_region_from_env() as region:
+        input_buf = region.allocate("matmul32_input_int8", len(input_bytes), alignment=64)
+        hp_buffers = {
+            name: region.allocate(f"matmul32_{name}_int4", len(data), alignment=64)
+            for name, data in hp_bytes.items()
+        }
+        output_buf = region.allocate("matmul32_output_int32", output_bytes, alignment=64)
+
+        input_buf.write(input_bytes)
+        for name, data in hp_bytes.items():
+            hp_buffers[name].write(data)
+        output_buf.write(bytes(output_bytes))
+
+        input_buf.sync_for_device()
+        for item in hp_buffers.values():
+            item.sync_for_device()
+        output_buf.sync_for_device()
+
+        with NpuMmio(uio=UIO_DEVICE_DEFAULT) as mmio:
+            channels = create_channels(mmio, discover_address_map())
+            result_token = channels["acp_result"].issue_command(
+                output_buf.phys_addr,
+                0x4,
+                output_buf.size,
+            )
+            input_token = channels["acp_fmap"].issue_command(
+                input_buf.phys_addr,
+                0x3,
+                input_buf.size,
+            )
+            hp_tokens = {
+                name: channels[name].issue_command(
+                    hp_buffers[name].phys_addr,
+                    idx,
+                    hp_buffers[name].size,
+                )
+                for idx, name in enumerate(("hp0", "hp1", "hp2", "hp3"), start=1)
+            }
+
+            words = isa.encode_matmul32_int4_int8_program(
+                dest_reg=dest_addr,
+                src_addr=src_addr,
+                shape_ptr_addr=shape_ptr,
+            )
+            if not _submit_program_on_mmio(mmio, words):
+                raise TimeoutError("NPU matmul32 program did not report DONE")
+
+            channels["acp_fmap"].poll_status(input_token, DMA_TIMEOUT_SEC)
+            for name, token in hp_tokens.items():
+                channels[name].poll_status(token, DMA_TIMEOUT_SEC)
+            channels["acp_result"].poll_status(result_token, DMA_TIMEOUT_SEC)
+
+        output_buf.sync_for_cpu()
+        raw = output_buf.read(output_bytes)
+        return np.frombuffer(raw, dtype="<i4").reshape(reference_shape).astype(
+            np.int32,
+            copy=False,
+        )
+
+
 def _tiled_gemm_fallback(W: np.ndarray, X: np.ndarray) -> np.ndarray:
     Wf = np.asarray(W, dtype=np.float32)
     Xf = np.asarray(X, dtype=np.float32)
@@ -424,6 +523,18 @@ def _gemm_readback_configured() -> tuple[bool, str]:
     return True, "GEMM readback configured"
 
 
+def _matmul32_configured() -> tuple[bool, str]:
+    if not _env_truthy(INT4_INT8_MATMUL32_ENV):
+        return False, f"{INT4_INT8_MATMUL32_ENV}=1 is required"
+    if not _dma_provider_configured():
+        return False, (
+            "INT4 x INT8 matmul32 requested, but no DMA-safe PS buffer "
+            f"provider is configured; set {DMA_DEVICE_ENV}, {DMA_PHYS_ENV}, "
+            f"and {DMA_SIZE_ENV}"
+        )
+    return True, "INT4 x INT8 matmul32 configured"
+
+
 def _dma_provider_configured() -> bool:
     if (
         os.getenv(DMA_DEVICE_ENV)
@@ -479,6 +590,18 @@ def _pack_int4_weight_lanes(W: np.ndarray) -> tuple[bytes, bytes]:
     return _pad_128b(hp0), _pad_128b(hp1)
 
 
+def _pack_matmul32_weight_lanes(W: np.ndarray) -> dict[str, bytes]:
+    flat = np.ascontiguousarray(np.asarray(W, dtype=np.int8)).reshape(-1)
+    hp0 = _pad_128b(_pack_int4_values(flat[0::2]))
+    hp1 = _pad_128b(_pack_int4_values(flat[1::2]))
+    return {
+        "hp0": hp0,
+        "hp1": hp1,
+        "hp2": hp0,
+        "hp3": hp1,
+    }
+
+
 def _pack_int4_values(values: np.ndarray) -> bytes:
     vals = np.asarray(values, dtype=np.int8).reshape(-1)
     if vals.size % 2:
@@ -491,6 +614,32 @@ def _pack_int4_values(values: np.ndarray) -> bytes:
 def _check_memset_dim(value: int, name: str) -> None:
     if value < 0 or value > 0xFFFF:
         raise ValueError(f"{name}={value} does not fit in the MEMSET shape field")
+
+
+def _validate_matmul32_int4_weights(value: np.ndarray) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.shape != (MATMUL32_DIM, MATMUL32_DIM):
+        raise ValueError("Stage 1 matmul weights must be 32x32")
+    rounded = np.rint(arr.astype(np.float32))
+    if not np.array_equal(rounded, arr.astype(np.float32)):
+        raise ValueError("Stage 1 matmul weights must contain integer values")
+    out = rounded.astype(np.int16)
+    if np.any(out < -8) or np.any(out > 7):
+        raise ValueError("Stage 1 matmul weights must be signed INT4")
+    return np.ascontiguousarray(out.astype(np.int8))
+
+
+def _validate_matmul32_int8_activations(value: np.ndarray) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.shape != (MATMUL32_DIM, MATMUL32_DIM):
+        raise ValueError("Stage 1 matmul activations must be 32x32")
+    rounded = np.rint(arr.astype(np.float32))
+    if not np.array_equal(rounded, arr.astype(np.float32)):
+        raise ValueError("Stage 1 matmul activations must contain integer values")
+    out = rounded.astype(np.int16)
+    if np.any(out < -128) or np.any(out > 127):
+        raise ValueError("Stage 1 matmul activations must be signed INT8")
+    return np.ascontiguousarray(out.astype(np.int8))
 
 
 def _env_int(name: str, default: int) -> int:

--- a/sw/runtime/npu/tests/test_npu_dispatch.py
+++ b/sw/runtime/npu/tests/test_npu_dispatch.py
@@ -12,10 +12,13 @@ from sw.runtime.npu.dma import (
     CMD_HI,
     CMD_LO,
     CMD_PUSH,
+    DATAMOVER_STATUS_ERROR_MASK,
     FLAGS,
     PSDataMoverChannel,
+    datamover_status_error_bits,
     pack_datamover_command,
 )
+from sw.runtime.npu.dma_buffer import MappedDmaRegion
 
 
 def test_npu_gemm_matches_cpu_fallback(monkeypatch):
@@ -118,3 +121,142 @@ def test_datamover_issue_command_writes_three_words_then_push():
         (0x1000 + CMD_EXT, (word >> 64) & 0xFFFF_FFFF),
         (0x1000 + CMD_PUSH, 0x1),
     ]
+
+
+def test_datamover_status_error_bits():
+    assert datamover_status_error_bits(0xA0) == 0
+    assert datamover_status_error_bits(0xAF) == DATAMOVER_STATUS_ERROR_MASK
+
+
+def test_mapped_dma_region_allocates_aligned_physical_slices(tmp_path):
+    backing = tmp_path / "dma.bin"
+    backing.write_bytes(bytes(4096))
+
+    with MappedDmaRegion(device_path=backing, phys_addr=0x10000000, size=4096) as region:
+        first = region.allocate("first", 3, alignment=64)
+        second = region.allocate("second", 5, alignment=64)
+
+        assert first.phys_addr == 0x10000000
+        assert second.phys_addr == 0x10000040
+        first.write(b"abc")
+        second.write(b"12345")
+        assert first.read(3) == b"abc"
+        assert second.read(5) == b"12345"
+
+
+def test_bf16_codec_roundtrip_is_float32_shape_preserving():
+    values = np.array([[1.0, -2.5, 0.125]], dtype=np.float32)
+    encoded = npu_core._float32_to_bf16_bytes(values)
+    decoded = npu_core._bf16_bytes_to_float32(encoded, values.shape)
+
+    assert decoded.dtype == np.float32
+    assert decoded.shape == values.shape
+    np.testing.assert_allclose(decoded, values, rtol=0.01, atol=0.01)
+
+
+def test_int4_weight_lanes_are_signed_nibble_packed_and_padded():
+    W = np.array([[-1, 2], [3, -4]], dtype=np.float32)
+
+    hp0, hp1 = npu_core._pack_int4_weight_lanes(W)
+
+    assert hp0[:1] == bytes([0x3F])
+    assert hp1[:1] == bytes([0xC2])
+    assert len(hp0) == 16
+    assert len(hp1) == 16
+
+
+def test_gemm_readback_path_stages_dma_and_reads_bf16_result(monkeypatch):
+    class FakeSlice:
+        def __init__(self, name: str, offset: int, size: int) -> None:
+            self.name = name
+            self.offset = offset
+            self.size = size
+            self.phys_addr = 0x10000000 + offset
+            self.data = bytearray(size)
+            self.device_synced = False
+            self.cpu_synced = False
+
+        def write(self, data: bytes) -> None:
+            if self.name == "gemm_output_bf16" and not any(data):
+                return
+            self.data[: len(data)] = data
+
+        def read(self, size: int | None = None) -> bytes:
+            return bytes(self.data[: self.size if size is None else size])
+
+        def sync_for_device(self) -> None:
+            self.device_synced = True
+
+        def sync_for_cpu(self) -> None:
+            self.cpu_synced = True
+
+    class FakeRegion:
+        def __init__(self) -> None:
+            self.next_offset = 0
+            self.slices: dict[str, FakeSlice] = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+        def allocate(self, name: str, size: int, *, alignment: int = 64) -> FakeSlice:
+            offset = ((self.next_offset + alignment - 1) // alignment) * alignment
+            self.next_offset = offset + size
+            item = FakeSlice(name, offset, size)
+            if name == "gemm_output_bf16":
+                item.write(npu_core._float32_to_bf16_bytes(np.array([[1.5, -2.0]], dtype=np.float32)))
+            self.slices[name] = item
+            return item
+
+    class FakeMmio:
+        def __init__(self, *args, **kwargs) -> None:
+            self.write64_values: list[tuple[int, int]] = []
+            self.write32_values: list[tuple[int, int]] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+        def write64(self, offset: int, value: int) -> None:
+            self.write64_values.append((offset, value))
+
+        def write32(self, offset: int, value: int) -> None:
+            self.write32_values.append((offset, value))
+
+        def read32(self, offset: int) -> int:
+            local = offset & 0xFFF
+            page = offset & 0xFFFFF000
+            if offset == address_map.AXIL_STAT_OUT:
+                return 0x2
+            if local == FLAGS:
+                return 0
+            if local == 0x010:
+                tag_by_page = {
+                    0x1000: 0x1,
+                    0x2000: 0x2,
+                    0x5000: 0x3,
+                    0x6000: 0x4,
+                }
+                return tag_by_page[page] << 4
+            return 0
+
+    fake_region = FakeRegion()
+    monkeypatch.setattr(npu_core, "open_dma_region_from_env", lambda: fake_region)
+    monkeypatch.setattr(npu_core, "NpuMmio", FakeMmio)
+    monkeypatch.setattr(
+        npu_core,
+        "discover_address_map",
+        address_map.compiled_default_address_map,
+    )
+
+    W = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    X = np.array([[5, 6]], dtype=np.float32)
+    out = npu_core._dispatch_gemm_readback(W, X, layer_idx=None)
+
+    np.testing.assert_allclose(out, np.array([[1.5, -2.0]], dtype=np.float32))
+    assert fake_region.slices["gemm_input_bf16"].device_synced
+    assert fake_region.slices["gemm_output_bf16"].cpu_synced

--- a/sw/runtime/npu/tests/test_npu_dispatch.py
+++ b/sw/runtime/npu/tests/test_npu_dispatch.py
@@ -165,6 +165,19 @@ def test_int4_weight_lanes_are_signed_nibble_packed_and_padded():
     assert len(hp1) == 16
 
 
+def test_matmul32_weight_lanes_populate_all_hp_inputs():
+    W = ((np.arange(32 * 32, dtype=np.int16) % 16) - 8).reshape(32, 32)
+
+    lanes = npu_core._pack_matmul32_weight_lanes(W)
+
+    assert sorted(lanes) == ["hp0", "hp1", "hp2", "hp3"]
+    assert len({len(data) for data in lanes.values()}) == 1
+    assert len(lanes["hp1"]) == 256
+    assert all(any(data) for data in lanes.values())
+    assert lanes["hp2"] == lanes["hp0"]
+    assert lanes["hp3"] == lanes["hp1"]
+
+
 def test_gemm_readback_path_stages_dma_and_reads_bf16_result(monkeypatch):
     class FakeSlice:
         def __init__(self, name: str, offset: int, size: int) -> None:
@@ -260,3 +273,138 @@ def test_gemm_readback_path_stages_dma_and_reads_bf16_result(monkeypatch):
     np.testing.assert_allclose(out, np.array([[1.5, -2.0]], dtype=np.float32))
     assert fake_region.slices["gemm_input_bf16"].device_synced
     assert fake_region.slices["gemm_output_bf16"].cpu_synced
+
+
+def test_backend_readiness_reports_hybrid_when_matmul32_configured(monkeypatch):
+    monkeypatch.setattr(npu_core, "NPU_AVAILABLE", True)
+    monkeypatch.setenv(npu_core.INT4_INT8_MATMUL32_ENV, "1")
+    monkeypatch.setattr(npu_core, "_dma_provider_configured", lambda: True)
+
+    readiness = npu_core.npu_backend_readiness()
+
+    assert readiness["hardware_results"] is True
+    assert readiness["backend_kind"] == "hybrid"
+    assert "matmul32_int4_int8" in readiness["supported_ops"]
+
+
+def test_matmul32_dispatch_stages_dma_program_and_reads_int32_result(monkeypatch):
+    W = ((np.arange(32 * 32, dtype=np.int16) % 16) - 8).reshape(32, 32).astype(np.int8)
+    X = (((np.arange(32 * 32, dtype=np.int16) * 3) % 256) - 128).reshape(32, 32).astype(np.int8)
+    expected = X.astype(np.int32) @ W.astype(np.int32)
+    expected_bytes = np.ascontiguousarray(expected, dtype="<i4").tobytes()
+
+    class FakeSlice:
+        def __init__(self, name: str, offset: int, size: int) -> None:
+            self.name = name
+            self.offset = offset
+            self.size = size
+            self.phys_addr = 0x10000000 + offset
+            self.data = bytearray(size)
+            self.device_synced = False
+            self.cpu_synced = False
+
+        def write(self, data: bytes) -> None:
+            if self.name == "matmul32_output_int32" and not any(data):
+                return
+            self.data[: len(data)] = data
+
+        def read(self, size: int | None = None) -> bytes:
+            return bytes(self.data[: self.size if size is None else size])
+
+        def sync_for_device(self) -> None:
+            self.device_synced = True
+
+        def sync_for_cpu(self) -> None:
+            self.cpu_synced = True
+
+    class FakeRegion:
+        def __init__(self) -> None:
+            self.next_offset = 0
+            self.slices: dict[str, FakeSlice] = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+        def allocate(self, name: str, size: int, *, alignment: int = 64) -> FakeSlice:
+            offset = ((self.next_offset + alignment - 1) // alignment) * alignment
+            self.next_offset = offset + size
+            item = FakeSlice(name, offset, size)
+            if name == "matmul32_output_int32":
+                item.write(expected_bytes)
+            self.slices[name] = item
+            return item
+
+    class FakeMmio:
+        instances: list["FakeMmio"] = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.write64_values: list[tuple[int, int]] = []
+            self.write32_values: list[tuple[int, int]] = []
+            self.instances.append(self)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+        def write64(self, offset: int, value: int) -> None:
+            self.write64_values.append((offset, value))
+
+        def write32(self, offset: int, value: int) -> None:
+            self.write32_values.append((offset, value))
+
+        def read32(self, offset: int) -> int:
+            local = offset & 0xFFF
+            page = offset & 0xFFFFF000
+            if offset == address_map.AXIL_STAT_OUT:
+                return 0x2
+            if local == FLAGS:
+                return 0
+            if local == 0x010:
+                tag_by_page = {
+                    0x1000: 0x1,
+                    0x2000: 0x2,
+                    0x3000: 0x3,
+                    0x4000: 0x4,
+                    0x5000: 0x3,
+                    0x6000: 0x4,
+                }
+                return tag_by_page[page] << 4
+            return 0
+
+    fake_region = FakeRegion()
+    monkeypatch.setattr(npu_core, "_can_attempt_matmul32", lambda: True)
+    monkeypatch.setattr(npu_core, "open_dma_region_from_env", lambda: fake_region)
+    monkeypatch.setattr(npu_core, "NpuMmio", FakeMmio)
+    monkeypatch.setattr(
+        npu_core,
+        "discover_address_map",
+        address_map.compiled_default_address_map,
+    )
+
+    out = npu_core.npu_matmul_int4_int8(W, X)
+
+    np.testing.assert_array_equal(out, expected)
+    assert fake_region.slices["matmul32_input_int8"].device_synced
+    assert fake_region.slices["matmul32_output_int32"].device_synced
+    assert fake_region.slices["matmul32_output_int32"].cpu_synced
+    assert fake_region.slices["matmul32_input_int8"].read(32 * 32) == X.tobytes()
+
+    lanes = npu_core._pack_matmul32_weight_lanes(W)
+    for name, data in lanes.items():
+        item = fake_region.slices[f"matmul32_{name}_int4"]
+        assert item.device_synced
+        assert item.read(len(data)) == data
+
+    program = [
+        value
+        for offset, value in FakeMmio.instances[0].write64_values
+        if offset == address_map.AXIL_CMD_IN
+    ]
+    assert len(program) == 3
+    gemm = npu_core.isa.decode_gemm(program[2])
+    assert npu_core.isa.decode_parallel_lane_count(gemm["parallel_lane"]) == 32

--- a/sw/runtime/server/__main__.py
+++ b/sw/runtime/server/__main__.py
@@ -17,7 +17,7 @@ from aiohttp import web
 from .app import create_app
 
 
-BACKEND_CHOICES = ("auto", "cpu", "npu")
+BACKEND_CHOICES = ("auto", "cpu", "hybrid", "npu")
 
 
 def _default_backend() -> str:
@@ -34,7 +34,7 @@ def main() -> None:
         "--backend",
         choices=BACKEND_CHOICES,
         default=_default_backend(),
-        help="inference backend: auto, cpu, or strict npu",
+        help="inference backend: auto, cpu, hybrid, or strict npu",
     )
     parser.add_argument(
         "--no-model",

--- a/sw/runtime/test_isa.py
+++ b/sw/runtime/test_isa.py
@@ -62,6 +62,13 @@ def test_gemm_flags():
     assert (_body_of(w) >> 20) & 0x3F == 0b111_000
 
 
+def test_parallel_lane_count_uses_minus_one_encoding():
+    assert isa.encode_parallel_lane_count(1) == 0
+    assert isa.encode_parallel_lane_count(32) == 0x1F
+    assert isa.decode_parallel_lane_count(0) == 1
+    assert isa.decode_parallel_lane_count(0x1F) == 32
+
+
 def test_memcpy_fields():
     """memcpy: from(1) to(1) dest(17) src(17) aux(17) shape(6) async(1)."""
     w = isa.encode_memcpy(
@@ -139,6 +146,41 @@ def test_status_helpers():
     assert isa.status_done(0b00) is False
     assert isa.status_done(0b10) is True
     assert isa.status_done(0b11) is True
+
+
+def test_matmul32_int4_int8_program_fields():
+    words = isa.encode_matmul32_int4_int8_program(
+        dest_reg=512,
+        src_addr=100,
+        shape_ptr_addr=3,
+        weight_shape_ptr_addr=4,
+        flags=isa.GemmFlags(w_scale=True),
+    )
+
+    assert len(words) == 3
+    fmap_shape = isa.decode_memset(words[0])
+    weight_shape = isa.decode_memset(words[1])
+    gemm = isa.decode_gemm(words[2])
+    assert fmap_shape == {
+        "dest_cache": isa.DATA_TO_FMAP_SHAPE,
+        "dest_addr": 3,
+        "a_value": isa.MATMUL32_DIM,
+        "b_value": isa.MATMUL32_DIM,
+        "c_value": 1,
+    }
+    assert weight_shape == {
+        "dest_cache": isa.DATA_TO_WEIGHT_SHAPE,
+        "dest_addr": 4,
+        "a_value": isa.MATMUL32_DIM,
+        "b_value": isa.MATMUL32_DIM,
+        "c_value": 1,
+    }
+    assert gemm["dest_reg"] == 512
+    assert gemm["src_addr"] == 100
+    assert gemm["flags"] == isa.GemmFlags(w_scale=True)
+    assert isa.decode_parallel_lane_count(gemm["size_ptr_addr"]) == 32
+    assert isa.decode_parallel_lane_count(gemm["parallel_lane"]) == 32
+    assert gemm["shape_ptr_addr"] == 3
 
 
 # ----------------------------------------------------------------------------
@@ -295,6 +337,8 @@ def test_negative_value_rejected():
         isa.encode_memset(dest_cache=0, dest_addr=0, a_value=-1)
     with pytest.raises(ValueError):
         isa.encode_cvo(isa.CvoFunc.EXP, src_addr=-1, dst_addr=0, length=0)
+    with pytest.raises(ValueError):
+        isa.encode_parallel_lane_count(0)
 
 
 def test_off_by_one_max_plus_one_rejected():
@@ -314,6 +358,8 @@ def test_off_by_one_max_plus_one_rejected():
         isa.encode_memset(0, 0, 0x10000)                         # 16-bit + 1
     with pytest.raises(ValueError):
         isa.encode_cvo(isa.CvoFunc.EXP, 0, 0, length=0x10000)    # 16-bit + 1
+    with pytest.raises(ValueError):
+        isa.encode_parallel_lane_count(33)
 
 
 def test_kick_marker_is_not_a_valid_opcode_body():


### PR DESCRIPTION
## Summary
- bring the gated NPU DMA readback commit from PR #144 onto main
- add a strict 32x32 signed INT4 x signed INT8 matmul dispatch path with AXIL program encode, HP0-HP3 DMA staging, mmap output readback, and NumPy bit-for-bit compare
- add a KV260 matmul32 fixture runner plus focused unit coverage

## Validation
- python3 -m pytest -q sw/runtime/test_isa.py sw/runtime/gemma/tests/test_ops_matmul.py sw/runtime/npu/tests/test_npu_dispatch.py sw/runtime/gemma/tests/test_backend_selection.py
- python3 -m py_compile sw/runtime/isa.py sw/runtime/gemma/ops.py sw/runtime/npu/npu_core.py sw/runtime/npu/__init__.py sw/runtime/gemma/tests/test_ops_matmul.py sw/runtime/npu/tests/test_npu_dispatch.py scripts/kv260/run_npu_matmul32_fixture.py
- git diff --check

Board sync and WS evidence will be recorded in the lane done artifact after merge/pull.