### PR TITLE
Add v002 self-contained token runtime

### DIFF
--- a/sw/runtime/__init__.py
+++ b/sw/runtime/__init__.py
@@ -1,7 +1,7 @@
 """pccx v002 NPU runtime — user-space Python bindings for KV260 deployment.
 
 Modules:
-- isa     : 64-bit instruction word encoders (GEMV/GEMM/MEMCPY/MEMSET/CVO)
+- isa     : 64-bit high-level command encoders (LOAD_WEIGHT/LOAD_PROMPT/NEXT_TOKEN)
 - uio     : /dev/uioN mmap helpers (write ADDR_INST, push KICK, poll status)
 - npu     : higher-level submit-and-wait orchestration around isa + uio
 """

--- a/sw/runtime/gemma/inference.py
+++ b/sw/runtime/gemma/inference.py
@@ -19,11 +19,17 @@ from .tokenizer import GemmaTokenizer
 from .weights import DEFAULT_MODEL_DIR, GemmaGlobalWeights, GemmaWeights, matmul_weight
 
 try:  # pragma: no cover - exercised when the board runtime module lands.
+    from sw.runtime.npu import init_activation as _runtime_npu_init_activation
+    from sw.runtime.npu import load_weights_to_l2 as _runtime_npu_load_weights_to_l2
     from sw.runtime.npu import npu_backend_readiness as _runtime_npu_backend_readiness
     from sw.runtime.npu import npu_status as _runtime_npu_status
+    from sw.runtime.npu import run_one_token_step as _runtime_npu_run_one_token_step
 except Exception:  # pragma: no cover - import fallback is tested indirectly.
+    _runtime_npu_init_activation = None
+    _runtime_npu_load_weights_to_l2 = None
     _runtime_npu_backend_readiness = None
     _runtime_npu_status = None
+    _runtime_npu_run_one_token_step = None
 
 
 BACKEND_AUTO = "auto"
@@ -131,6 +137,7 @@ class GemmaInferenceSession:
         self._sessions: dict[str, dict] = {}
         self._tokens_total = 0
         self._tokens_per_sec_last = 0.0
+        self._npu_weights_loaded = False
 
     def _npu_status(self) -> dict:
         if not self.use_npu or _runtime_npu_status is None:
@@ -204,6 +211,64 @@ class GemmaInferenceSession:
         x_final = rms_norm(x_final, globals_.w_final_norm)
         return matmul_weight(x_final, globals_.w_lm_head)
 
+    def _ensure_npu_prompt_loaded(self, input_tokens: list[int]) -> None:
+        if (
+            _runtime_npu_load_weights_to_l2 is None
+            or _runtime_npu_init_activation is None
+        ):
+            raise RuntimeError("NPU token runtime is not importable")
+        if not self._npu_weights_loaded:
+            _runtime_npu_load_weights_to_l2(self.weights)
+            self._npu_weights_loaded = True
+        _runtime_npu_init_activation(input_tokens)
+
+    def _generate_with_npu(
+        self,
+        input_tokens: list[int],
+        *,
+        max_new_tokens: int,
+        temperature: float,
+        top_p: float,
+        session_id: str,
+    ) -> Iterator[Tuple[str, dict]]:
+        if _runtime_npu_run_one_token_step is None:
+            raise RuntimeError("NPU token runtime is not importable")
+
+        self._ensure_npu_prompt_loaded(input_tokens)
+        self._sessions[session_id] = {
+            "pos": len(input_tokens),
+            "backend": BACKEND_NPU,
+        }
+
+        stop_tokens = {1, 106}
+        for _ in range(max_new_tokens):
+            start = time.perf_counter()
+            next_token = int(
+                _runtime_npu_run_one_token_step(
+                    temperature=temperature,
+                    top_p=top_p,
+                )
+            )
+            if next_token in stop_tokens:
+                break
+            elapsed = max(time.perf_counter() - start, 1e-9)
+            self._tokens_total += 1
+            self._tokens_per_sec_last = 1.0 / elapsed
+            piece = self.tokenizer.decode_piece([next_token])
+            event = {
+                "token_id": next_token,
+                "tok_per_sec": self._tokens_per_sec_last,
+                "npu_status": self._npu_status(),
+                "readback_bytes": 4,
+                "layer_progress": {
+                    "current": self.arch.num_layers,
+                    "total": self.arch.num_layers,
+                    "stage": "next_token",
+                    "session_id": session_id,
+                },
+            }
+            yield piece, event
+
     def generate(
         self,
         prompt: str,
@@ -216,11 +281,22 @@ class GemmaInferenceSession:
         if not self.weights.available:
             raise FileNotFoundError(self.weights.model_dir)
 
-        state = self._new_state()
-        self._sessions[session_id] = state
         input_tokens = self.tokenizer.encode(prompt)
         if not input_tokens:
             input_tokens = [0]
+
+        if self.use_npu:
+            yield from self._generate_with_npu(
+                input_tokens,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                session_id=session_id,
+            )
+            return
+
+        state = self._new_state()
+        self._sessions[session_id] = state
 
         for token_id in input_tokens:
             self._forward_one_token(token_id, state)

--- a/sw/runtime/gemma/tests/test_backend_selection.py
+++ b/sw/runtime/gemma/tests/test_backend_selection.py
@@ -18,12 +18,12 @@ def test_auto_backend_uses_cpu_when_npu_results_are_not_ready() -> None:
     use_npu, backend, reason = _resolve_backend(
         "auto",
         None,
-        _readiness(hardware_results=False, reason="missing result readback"),
+        _readiness(hardware_results=False, reason="token backend disabled"),
     )
 
     assert use_npu is False
     assert backend == "cpu"
-    assert reason == "missing result readback"
+    assert reason == "token backend disabled"
 
 
 def test_strict_npu_backend_errors_when_results_are_not_ready() -> None:
@@ -31,7 +31,7 @@ def test_strict_npu_backend_errors_when_results_are_not_ready() -> None:
         _resolve_backend(
             "npu",
             None,
-            _readiness(hardware_results=False, reason="missing DMA ownership"),
+            _readiness(hardware_results=False, reason="token backend unavailable"),
         )
 
 

--- a/sw/runtime/gemma/tests/test_npu_token_generation.py
+++ b/sw/runtime/gemma/tests/test_npu_token_generation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from sw.runtime.gemma import inference
+from sw.runtime.gemma.arch import GEMMA_3N_E4B_DEFAULTS
+from sw.runtime.gemma.inference import BACKEND_NPU, GemmaInferenceSession
+
+
+class FakeWeights:
+    available = True
+    model_dir = "/tmp/fake-gemma"
+
+
+class FakeTokenizer:
+    def encode(self, prompt: str) -> list[int]:
+        assert prompt == "annyeong"
+        return [101, 102]
+
+    def decode_piece(self, tokens: list[int]) -> str:
+        return f"<{tokens[0]}>"
+
+
+def test_generate_npu_path_loads_prompt_and_reads_one_token(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+    token_iter = iter([777, 1])
+
+    def fake_load_weights(weights) -> None:
+        calls.append(("load_weights", weights.model_dir))
+
+    def fake_init_activation(tokens) -> None:
+        calls.append(("init_activation", list(tokens)))
+
+    def fake_run_one_token_step(**kwargs) -> int:
+        calls.append(("next_token", kwargs))
+        return next(token_iter)
+
+    monkeypatch.setattr(inference, "_runtime_npu_load_weights_to_l2", fake_load_weights)
+    monkeypatch.setattr(inference, "_runtime_npu_init_activation", fake_init_activation)
+    monkeypatch.setattr(inference, "_runtime_npu_run_one_token_step", fake_run_one_token_step)
+    monkeypatch.setattr(
+        inference,
+        "_runtime_npu_status",
+        lambda: {
+            "available": True,
+            "done": True,
+            "token_valid": True,
+            "last_token": 777,
+            "readback_bytes_last": 4,
+        },
+    )
+
+    session = GemmaInferenceSession.__new__(GemmaInferenceSession)
+    session.arch = GEMMA_3N_E4B_DEFAULTS
+    session.model_dir = "/tmp/fake-gemma"
+    session.backend_requested = BACKEND_NPU
+    session.npu_backend_readiness = {"hardware_results": True}
+    session.use_npu = True
+    session.backend = BACKEND_NPU
+    session.backend_reason = "test"
+    session.max_seq_len = 1024
+    session.dtype = "fp16"
+    session.weights = FakeWeights()
+    session.tokenizer = FakeTokenizer()
+    session.decoder = None
+    session._globals = None
+    session._sessions = {}
+    session._tokens_total = 0
+    session._tokens_per_sec_last = 0.0
+    session._npu_weights_loaded = False
+
+    generated = list(
+        session.generate(
+            "annyeong",
+            max_new_tokens=2,
+            temperature=0.0,
+            top_p=1.0,
+            session_id="s",
+        )
+    )
+
+    assert generated[0][0] == "<777>"
+    assert generated[0][1]["token_id"] == 777
+    assert generated[0][1]["readback_bytes"] == 4
+    assert calls[0] == ("load_weights", "/tmp/fake-gemma")
+    assert calls[1] == ("init_activation", [101, 102])
+    assert calls[2][0] == "next_token"
+    assert calls[3][0] == "next_token"
+    assert session._sessions["s"]["backend"] == BACKEND_NPU

--- a/sw/runtime/isa.py
+++ b/sw/runtime/isa.py
@@ -1,46 +1,46 @@
-"""pccx v002 ISA word encoders.
+"""pccx v002 high-level NPU command encoders.
 
-Layout (mirrors hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv):
+The host-visible SW contract is intentionally coarse grained: the host starts
+weight load, prompt load, KV reset, and next-token commands.  It does not issue
+per-layer GEMM/GEMV/CVO programs or read intermediate activations.
 
-  bits [63:60] = 4-bit opcode
-  bits [59:0]  = 60-bit instruction body, format depends on opcode
+SystemVerilog representation:
 
-KICK is special — pushed by writing any word to ADDR_KICK = 0x008; the RTL
-overrides the wdata with 0x8000_0000_0000_0000 internally, so KICK_MARKER is
-provided here only for symmetry / asserts.
+    typedef struct packed {
+        logic [7:0]  opcode;
+        logic [55:0] operand;
+    } pccx_host_cmd_t;
+
+This follows the packed-structure shape used by IEEE Std 1800-2023: the
+structure is a contiguous vector with no gaps, so Python packs the same fields
+as an unsigned 64-bit word.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import IntEnum
+from zlib import crc32
 
 
 class Opcode(IntEnum):
-    GEMV   = 0x0
-    GEMM   = 0x1
-    MEMCPY = 0x2
-    MEMSET = 0x3
-    CVO    = 0x4
+    RESET_KV_CACHE = 0x01
+    LOAD_WEIGHT = 0x02
+    LOAD_PROMPT = 0x03
+    NEXT_TOKEN = 0x04
 
 
-class CvoFunc(IntEnum):
-    EXP        = 0x0
-    SQRT       = 0x1
-    GELU       = 0x2
-    SIN        = 0x3
-    COS        = 0x4
-    REDUCE_SUM = 0x5
-    SCALE      = 0x6
-    RECIP      = 0x7
-
-
-# Address direction enums (memcpy)
-FROM_NPU, FROM_HOST = 0, 1
-TO_NPU,   TO_HOST   = 0, 1
-SYNC, ASYNC         = 0, 1
+class SamplingMode(IntEnum):
+    ARGMAX = 0x00
+    RANDOM = 0x01
 
 
 KICK_MARKER = 0x8000_0000_0000_0000
+
+STAT_BUSY_MASK = 0x1
+STAT_DONE_MASK = 0x2
+STAT_ERROR_MASK = 0x4
+STAT_TOKEN_VALID_MASK = 0x8
+STAT_TOKEN_SHIFT = 32
+STAT_TOKEN_MASK = 0xFFFF_FFFF
 
 
 def _mask(width: int) -> int:
@@ -54,124 +54,116 @@ def _check(val: int, width: int, name: str) -> int:
     return val & m
 
 
-def _pack_opcode(opcode: Opcode, body: int) -> int:
-    """body must already fit in 60 bits."""
-    body = _check(body, 60, "body")
-    return (int(opcode) & 0xF) << 60 | body
+def _pack_command(opcode: Opcode, operand: int = 0) -> int:
+    return (_check(int(opcode), 8, "opcode") << 56) | _check(operand, 56, "operand")
 
 
-@dataclass(frozen=True)
-class GemmFlags:
-    """6-bit GEMV/GEMM flags struct (isa_pkg.sv flags_t)."""
-    findemax: bool = False
-    accm:     bool = False
-    w_scale:  bool = False
-
-    def to_bits(self) -> int:
-        # bits: findemax[5] | accm[4] | w_scale[3] | reserved[2:0]
-        return ((int(self.findemax) << 5)
-                | (int(self.accm)     << 4)
-                | (int(self.w_scale)  << 3))
+def decode_command(word64: int) -> tuple[int, int]:
+    word64 = _check(word64, 64, "word64")
+    return (word64 >> 56) & 0xFF, word64 & _mask(56)
 
 
-def encode_gemm(
-    dest_reg: int,
-    src_addr: int,
-    flags: GemmFlags = GemmFlags(),
-    size_ptr_addr: int = 0,
-    shape_ptr_addr: int = 0,
-    parallel_lane: int = 0,
-) -> int:
-    """GEMM_op_x64_t — same layout as GEMV.
-
-    Body (60 bits, MSB first):
-      dest_reg[16:0] (17) | src_addr[16:0] (17) | flags (6) |
-      size_ptr (6) | shape_ptr (6) | parallel_lane (5) | reserved (3)
-    """
-    body = ((_check(dest_reg,        17, "dest_reg")       << 43)
-            | (_check(src_addr,       17, "src_addr")       << 26)
-            | (flags.to_bits()                              << 20)
-            | (_check(size_ptr_addr,   6, "size_ptr_addr")  << 14)
-            | (_check(shape_ptr_addr,  6, "shape_ptr_addr") <<  8)
-            | (_check(parallel_lane,   5, "parallel_lane")  <<  3))
-    return _pack_opcode(Opcode.GEMM, body)
+def encode_reset_kv_cache(*, session_id: int = 0) -> int:
+    """Reset NPU-resident KV cache and token-step activation state."""
+    return _pack_command(Opcode.RESET_KV_CACHE, _check(session_id, 32, "session_id"))
 
 
-def encode_gemv(
-    dest_reg: int,
-    src_addr: int,
-    flags: GemmFlags = GemmFlags(),
-    size_ptr_addr: int = 0,
-    shape_ptr_addr: int = 0,
-    parallel_lane: int = 0,
-) -> int:
-    """GEMV_op_x64_t — identical layout to GEMM, opcode differs."""
-    body = ((_check(dest_reg,        17, "dest_reg")       << 43)
-            | (_check(src_addr,       17, "src_addr")       << 26)
-            | (flags.to_bits()                              << 20)
-            | (_check(size_ptr_addr,   6, "size_ptr_addr")  << 14)
-            | (_check(shape_ptr_addr,  6, "shape_ptr_addr") <<  8)
-            | (_check(parallel_lane,   5, "parallel_lane")  <<  3))
-    return _pack_opcode(Opcode.GEMV, body)
+def decode_reset_kv_cache(word64: int) -> dict[str, int]:
+    opcode, operand = decode_command(word64)
+    if opcode != Opcode.RESET_KV_CACHE:
+        raise ValueError(
+            f"opcode {opcode:#x} is not RESET_KV_CACHE ({int(Opcode.RESET_KV_CACHE):#x})"
+        )
+    return {"session_id": operand & _mask(32)}
 
 
-def encode_memcpy(
-    from_device: int,
-    to_device: int,
-    dest_addr: int,
-    src_addr: int,
-    aux_addr: int = 0,
-    shape_ptr_addr: int = 0,
-    async_op: int = SYNC,
-) -> int:
-    """MEMCPY layout (60 bits): from(1) to(1) dest(17) src(17) aux(17) shape(6) async(1)."""
-    body = ((_check(from_device, 1, "from_device") << 59)
-            | (_check(to_device,   1, "to_device")   << 58)
-            | (_check(dest_addr,  17, "dest_addr")   << 41)
-            | (_check(src_addr,   17, "src_addr")    << 24)
-            | (_check(aux_addr,   17, "aux_addr")    <<  7)
-            | (_check(shape_ptr_addr, 6, "shape_ptr_addr") << 1)
-            | (_check(async_op,    1, "async_op")    <<  0))
-    return _pack_opcode(Opcode.MEMCPY, body)
-
-
-def encode_memset(
-    dest_cache: int,
-    dest_addr: int,
-    a_value: int,
-    b_value: int = 0,
-    c_value: int = 0,
-) -> int:
-    """MEMSET layout (60 bits): dest_cache(2) dest_addr(6) a(16) b(16) c(16) reserved(4)."""
-    body = ((_check(dest_cache, 2, "dest_cache") << 58)
-            | (_check(dest_addr,  6, "dest_addr")  << 52)
-            | (_check(a_value,   16, "a_value")    << 36)
-            | (_check(b_value,   16, "b_value")    << 20)
-            | (_check(c_value,   16, "c_value")    <<  4))
-    return _pack_opcode(Opcode.MEMSET, body)
-
-
-def encode_cvo(
-    cvo_func: CvoFunc,
-    src_addr: int,
-    dst_addr: int,
-    length: int,
+def encode_load_weight(
+    *,
+    weight_slot: int = 0,
+    descriptor_count: int = 0,
+    manifest_id: int = 0,
     flags: int = 0,
-    async_op: int = SYNC,
 ) -> int:
-    """CVO layout (60 bits): func(4) src(17) dst(17) length(16) flags(5) async(1)."""
-    body = ((_check(int(cvo_func), 4, "cvo_func")  << 56)
-            | (_check(src_addr,   17, "src_addr")    << 39)
-            | (_check(dst_addr,   17, "dst_addr")    << 22)
-            | (_check(length,     16, "length")      <<  6)
-            | (_check(flags,       5, "flags")       <<  1)
-            | (_check(async_op,    1, "async_op")    <<  0))
-    return _pack_opcode(Opcode.CVO, body)
+    """Start one host-to-L2 weight-load phase.
+
+    Operand layout:
+      weight_slot[55:48] | flags[47:40] | descriptor_count[39:32] |
+      manifest_id[31:0]
+
+    Bulk bytes are described by the DMA command stream.  This command only
+    starts the NPU-side weight-cache acceptance phase and never requests a
+    result buffer from PS memory.
+    """
+    operand = (
+        (_check(weight_slot, 8, "weight_slot") << 48)
+        | (_check(flags, 8, "flags") << 40)
+        | (_check(descriptor_count, 8, "descriptor_count") << 32)
+        | _check(manifest_id, 32, "manifest_id")
+    )
+    return _pack_command(Opcode.LOAD_WEIGHT, operand)
 
 
-# Status word (read from AXIL_STAT_OUT, 64-bit but only [31:0] is mmio_npu_stat)
-STAT_BUSY_MASK = 0x1
-STAT_DONE_MASK = 0x2
+def decode_load_weight(word64: int) -> dict[str, int]:
+    opcode, operand = decode_command(word64)
+    if opcode != Opcode.LOAD_WEIGHT:
+        raise ValueError(f"opcode {opcode:#x} is not LOAD_WEIGHT ({int(Opcode.LOAD_WEIGHT):#x})")
+    return {
+        "weight_slot": (operand >> 48) & _mask(8),
+        "flags": (operand >> 40) & _mask(8),
+        "descriptor_count": (operand >> 32) & _mask(8),
+        "manifest_id": operand & _mask(32),
+    }
+
+
+def encode_load_prompt(*, position: int, token_id: int) -> int:
+    """Load one prompt token into NPU-resident activation/KV state."""
+    operand = (_check(position, 24, "position") << 32) | _check(token_id, 32, "token_id")
+    return _pack_command(Opcode.LOAD_PROMPT, operand)
+
+
+def decode_load_prompt(word64: int) -> dict[str, int]:
+    opcode, operand = decode_command(word64)
+    if opcode != Opcode.LOAD_PROMPT:
+        raise ValueError(f"opcode {opcode:#x} is not LOAD_PROMPT ({int(Opcode.LOAD_PROMPT):#x})")
+    return {
+        "position": (operand >> 32) & _mask(24),
+        "token_id": operand & _mask(32),
+    }
+
+
+def q8_8(value: float) -> int:
+    """Quantize a non-negative scalar into unsigned Q8.8."""
+    return _check(int(round(float(value) * 256.0)), 16, "q8_8")
+
+
+def encode_next_token(
+    *,
+    request_id: int = 0,
+    sampling: SamplingMode = SamplingMode.ARGMAX,
+    temperature_q8_8: int = 0,
+    top_p_q8_8: int = 0x0100,
+) -> int:
+    """Run all NPU-resident layers and return one 32-bit token in status."""
+    operand = (
+        (_check(request_id, 16, "request_id") << 40)
+        | (_check(int(sampling), 8, "sampling") << 32)
+        | (_check(temperature_q8_8, 16, "temperature_q8_8") << 16)
+        | _check(top_p_q8_8, 16, "top_p_q8_8")
+    )
+    return _pack_command(Opcode.NEXT_TOKEN, operand)
+
+
+def decode_next_token(word64: int) -> dict[str, int | SamplingMode]:
+    opcode, operand = decode_command(word64)
+    if opcode != Opcode.NEXT_TOKEN:
+        raise ValueError(f"opcode {opcode:#x} is not NEXT_TOKEN ({int(Opcode.NEXT_TOKEN):#x})")
+    sampling_raw = (operand >> 32) & _mask(8)
+    return {
+        "request_id": (operand >> 40) & _mask(16),
+        "sampling": SamplingMode(sampling_raw),
+        "temperature_q8_8": (operand >> 16) & _mask(16),
+        "top_p_q8_8": operand & _mask(16),
+    }
 
 
 def status_busy(stat: int) -> bool:
@@ -182,103 +174,39 @@ def status_done(stat: int) -> bool:
     return bool(stat & STAT_DONE_MASK)
 
 
-# ============================================================================
-# Decoders — inverse of the encode_* functions. Used by test_isa.py round-trip
-# coverage and host-side debug tools that inspect the raw 64-bit words pulled
-# off /dev/mem traces.
-#
-# Each decoder takes a 64-bit ISA word and returns a dict of the named fields
-# (matching the encode_* signature). decode_x64() returns just the opcode and
-# raw body for callers that want to dispatch themselves.
-# ============================================================================
+def status_error(stat: int) -> bool:
+    return bool(stat & STAT_ERROR_MASK)
 
 
-def decode_x64(word64: int) -> tuple[int, int]:
-    """Split a 64-bit ISA word into (opcode, 60-bit body)."""
-    word64 = _check(word64, 64, "word64")
-    return ((word64 >> 60) & 0xF, word64 & ((1 << 60) - 1))
+def status_token_valid(stat: int) -> bool:
+    return bool(stat & STAT_TOKEN_VALID_MASK)
 
 
-def _decode_field(body: int, lsb: int, width: int) -> int:
-    """Extract `width` bits starting at `lsb` from a 60-bit body."""
-    return (body >> lsb) & _mask(width)
+def status_token(stat: int) -> int | None:
+    stat = _check(stat, 64, "stat")
+    if not status_token_valid(stat):
+        return None
+    return (stat >> STAT_TOKEN_SHIFT) & STAT_TOKEN_MASK
 
 
-def decode_gemm(word64: int) -> dict:
-    """Inverse of encode_gemm. Returns dict matching encode_gemm kwargs."""
-    op, body = decode_x64(word64)
-    if op != Opcode.GEMM:
-        raise ValueError(f"opcode {op:#x} is not GEMM ({int(Opcode.GEMM):#x})")
-    flags_bits = _decode_field(body, 20, 6)
-    return {
-        "dest_reg":       _decode_field(body, 43, 17),
-        "src_addr":       _decode_field(body, 26, 17),
-        "flags":          GemmFlags(
-                              findemax=bool(flags_bits & (1 << 5)),
-                              accm=    bool(flags_bits & (1 << 4)),
-                              w_scale= bool(flags_bits & (1 << 3))),
-        "size_ptr_addr":  _decode_field(body, 14, 6),
-        "shape_ptr_addr": _decode_field(body,  8, 6),
-        "parallel_lane":  _decode_field(body,  3, 5),
-    }
+def encode_status(
+    *,
+    busy: bool = False,
+    done: bool = False,
+    error: bool = False,
+    token: int | None = None,
+) -> int:
+    flags = (
+        (STAT_BUSY_MASK if busy else 0)
+        | (STAT_DONE_MASK if done else 0)
+        | (STAT_ERROR_MASK if error else 0)
+    )
+    if token is None:
+        return flags
+    return ((_check(token, 32, "token") << STAT_TOKEN_SHIFT)
+            | STAT_TOKEN_VALID_MASK
+            | flags)
 
 
-def decode_gemv(word64: int) -> dict:
-    """Inverse of encode_gemv (same layout as GEMM, opcode differs)."""
-    op, body = decode_x64(word64)
-    if op != Opcode.GEMV:
-        raise ValueError(f"opcode {op:#x} is not GEMV ({int(Opcode.GEMV):#x})")
-    flags_bits = _decode_field(body, 20, 6)
-    return {
-        "dest_reg":       _decode_field(body, 43, 17),
-        "src_addr":       _decode_field(body, 26, 17),
-        "flags":          GemmFlags(
-                              findemax=bool(flags_bits & (1 << 5)),
-                              accm=    bool(flags_bits & (1 << 4)),
-                              w_scale= bool(flags_bits & (1 << 3))),
-        "size_ptr_addr":  _decode_field(body, 14, 6),
-        "shape_ptr_addr": _decode_field(body,  8, 6),
-        "parallel_lane":  _decode_field(body,  3, 5),
-    }
-
-
-def decode_memcpy(word64: int) -> dict:
-    op, body = decode_x64(word64)
-    if op != Opcode.MEMCPY:
-        raise ValueError(f"opcode {op:#x} is not MEMCPY ({int(Opcode.MEMCPY):#x})")
-    return {
-        "from_device":    _decode_field(body, 59,  1),
-        "to_device":      _decode_field(body, 58,  1),
-        "dest_addr":      _decode_field(body, 41, 17),
-        "src_addr":       _decode_field(body, 24, 17),
-        "aux_addr":       _decode_field(body,  7, 17),
-        "shape_ptr_addr": _decode_field(body,  1,  6),
-        "async_op":       _decode_field(body,  0,  1),
-    }
-
-
-def decode_memset(word64: int) -> dict:
-    op, body = decode_x64(word64)
-    if op != Opcode.MEMSET:
-        raise ValueError(f"opcode {op:#x} is not MEMSET ({int(Opcode.MEMSET):#x})")
-    return {
-        "dest_cache": _decode_field(body, 58,  2),
-        "dest_addr":  _decode_field(body, 52,  6),
-        "a_value":    _decode_field(body, 36, 16),
-        "b_value":    _decode_field(body, 20, 16),
-        "c_value":    _decode_field(body,  4, 16),
-    }
-
-
-def decode_cvo(word64: int) -> dict:
-    op, body = decode_x64(word64)
-    if op != Opcode.CVO:
-        raise ValueError(f"opcode {op:#x} is not CVO ({int(Opcode.CVO):#x})")
-    return {
-        "cvo_func": CvoFunc(_decode_field(body, 56, 4)),
-        "src_addr": _decode_field(body, 39, 17),
-        "dst_addr": _decode_field(body, 22, 17),
-        "length":   _decode_field(body,  6, 16),
-        "flags":    _decode_field(body,  1,  5),
-        "async_op": _decode_field(body,  0,  1),
-    }
+def manifest_id_from_text(value: object) -> int:
+    return crc32(str(value).encode("utf-8")) & 0xFFFF_FFFF

--- a/sw/runtime/npu/README.md
+++ b/sw/runtime/npu/README.md
@@ -1,37 +1,38 @@
 # PS-Side NPU Dispatch
 
-This package exposes the Gemma-facing NumPy API for the pccx v002 KV260 NPU
-runtime.  The hardware path is experimental and golden-vector gated; the CPU
-fallback is always present so the daemon can run without a loaded bitstream.
+This package exposes the Gemma-facing API for the pccx v002 KV260 NPU runtime.
+The hardware backend is a self-contained token path: weights are loaded into
+NPU L2 once, prompt tokens initialize NPU-resident activation/KV state, and each
+NEXT_TOKEN command runs the full forward path inside the NPU.  The host reads
+back only one 32-bit token per generated token.
 
 ## Interface
 
-- `npu_gemm(W, X, layer_idx=None)` returns `X @ W` as float32 for
-  `W [K_in, M_out]` and `X [B, K_in]`.
-- `npu_gemv(W, x, layer_idx=None)` returns `x @ W` as float32 for
-  `W [K_in, M_out]` and `x [K_in]`.
-- `npu_cvo(op, x)` supports `EXP`, `SQRT`, `GELU`, `SIN`, `COS`,
-  `REDUCE_SUM`, `SCALE`, and `RECIP`.
+- `load_weights_to_l2(weights)` starts the one-time host-to-NPU L2 weight-load
+  phase.
+- `init_activation(prompt_tokens)` resets NPU-resident KV state and loads prompt
+  token IDs.
+- `run_one_token_step()` issues NEXT_TOKEN and returns the generated 32-bit
+  token from status.
+- `npu_gemm`, `npu_gemv`, and `npu_cvo` are CPU fallback compatibility helpers
+  for CPU-mode Gemma modules; they do not issue hardware matrix commands.
 - `npu_status()` returns `mmio_hex`, `busy`, `done`, `available`, and
-  `last_cycle_count`.
+  token-step status metadata.
 - `npu_available()` returns true only when `/dev/uio4` can be opened and
   mmapped and the deployed bitstream file hash matches the expected v12d list.
 
 ## NPU Path And CPU Fallback
 
 When `/dev/uio4` is absent, mmap fails, the bitstream hash is not in the
-expected list, or `PCCX_NPU_FORCE_FALLBACK=1` is set, all public calls use the
+expected list, or `PCCX_NPU_FORCE_FALLBACK=1` is set, CPU-mode calls use the
 NumPy reference implementation in `cpu_fallback.py`.
 
-If the board is present and `PCCX_NPU_EXPERIMENTAL_DISPATCH=1` is set, the
-runtime can submit the matching v002 ISA word through AXIL_CMD_IN and wait for
-AXIL_STAT_OUT `DONE`.  The returned tensor still uses the NumPy golden result
-until DMA buffer ownership and result-region reads are verified on KV260.
-This avoids claiming hardware numerical results before the golden-vector gate.
+The NPU backend is selected only when `PCCX_NPU_TOKEN_BACKEND=1` and token-step
+MMIO is available, or when `PCCX_NPU_SIM_BACKEND=1` enables the local
+MMIO-compatible token simulator.  There is no host tensor readback path for
+Gemma generation.
 
-For large matrix shapes the fallback path includes M/K/N tiling with
-conservative defaults.  The tile sizes are configurable through
-`PCCX_NPU_TILE_M`, `PCCX_NPU_TILE_K`, and `PCCX_NPU_TILE_N`.
+For large matrix shapes, CPU-mode fallback uses NumPy reference math.
 
 ## Command/Status AXIL FIFO Layout
 

--- a/sw/runtime/npu/__init__.py
+++ b/sw/runtime/npu/__init__.py
@@ -1,30 +1,37 @@
-"""PS-side dispatch helpers for the pccx v002 NPU.
+"""PS-side helpers for the pccx v002 self-contained NPU path.
 
-The v002 control path sends 64-bit ISA words through AXIL_CMD_IN and moves
-bulk tensor data through PS-issued AXI DataMover descriptors.  The six
-DataMover command/status helpers stage one 72-bit descriptor as three
-32-bit AXI-Lite writes, push it into a small FIFO, and expose the returned
-8-bit status stream through a matching FIFO.  High-level calls in this
-package keep a NumPy golden reference fallback so the Gemma daemon can run
-on hosts without the KV260 bitstream, while the hardware path remains
-experimental and golden-vector gated.
+The Gemma hardware backend sends high-level 64-bit commands through
+AXIL_CMD_IN: reset KV cache, load weights, load prompt tokens, and run one
+NEXT_TOKEN step.  Intermediate activations and accumulators stay inside the
+NPU.  The host reads back only the 32-bit generated token from the completion
+status word.
 """
 from __future__ import annotations
 
 from .npu_core import (
+    init_activation,
+    load_prompt_tokens,
+    load_weights_to_l2,
     npu_available,
     npu_backend_readiness,
     npu_cvo,
     npu_gemm,
     npu_gemv,
     npu_status,
+    reset_kv_cache,
+    run_one_token_step,
 )
 
 __all__ = [
+    "init_activation",
+    "load_prompt_tokens",
+    "load_weights_to_l2",
     "npu_available",
     "npu_backend_readiness",
     "npu_cvo",
     "npu_gemm",
     "npu_gemv",
     "npu_status",
+    "reset_kv_cache",
+    "run_one_token_step",
 ]

--- a/sw/runtime/npu/npu_core.py
+++ b/sw/runtime/npu/npu_core.py
@@ -1,10 +1,12 @@
-"""High-level NPU dispatch API with NumPy fallback."""
+"""High-level NPU token-step runtime with NumPy fallback helpers."""
 from __future__ import annotations
 
+from contextlib import nullcontext
 import logging
 import os
 from pathlib import Path
 import time
+from typing import Any, Callable
 
 import numpy as np
 
@@ -19,6 +21,7 @@ from .address_map import (
     bitstream_sha256_is_expected,
 )
 from .cpu_fallback import cpu_cvo, cpu_gemm, cpu_gemv
+from .sim_mmio import TokenSimMmio
 
 
 LOG = logging.getLogger(__name__)
@@ -28,16 +31,138 @@ UIO_DEVICE_DEFAULT = "/dev/uio4"
 NPU_TIMEOUT_SEC = 5.0
 
 _TRUTHY = {"1", "true", "yes", "on"}
-_CVO_FUNC_BY_NAME = {
-    "EXP": isa.CvoFunc.EXP,
-    "SQRT": isa.CvoFunc.SQRT,
-    "GELU": isa.CvoFunc.GELU,
-    "SIN": isa.CvoFunc.SIN,
-    "COS": isa.CvoFunc.COS,
-    "REDUCE_SUM": isa.CvoFunc.REDUCE_SUM,
-    "SCALE": isa.CvoFunc.SCALE,
-    "RECIP": isa.CvoFunc.RECIP,
-}
+_TOKEN_RUNTIME: "NpuTokenRuntime | None" = None
+
+
+class NpuTokenRuntime:
+    """Host control for the self-contained NPU next-token path.
+
+    The only value read back for generated text is the 32-bit token embedded in
+    the completion status word of NEXT_TOKEN.  Intermediate activations, layer
+    outputs, accumulators, and logits remain NPU-resident.
+    """
+
+    def __init__(
+        self,
+        *,
+        uio_device: str = UIO_DEVICE_DEFAULT,
+        timeout_sec: float = NPU_TIMEOUT_SEC,
+        poll_interval_sec: float = 0.001,
+        mmio_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self.uio_device = uio_device
+        self.timeout_sec = timeout_sec
+        self.poll_interval_sec = poll_interval_sec
+        self._mmio_factory = mmio_factory
+        self._sim_mmio: TokenSimMmio | None = None
+        self.command_count = 0
+        self.last_status_word = 0
+        self.weights_loaded = False
+
+    def load_weights_to_l2(self, weights: Any = None) -> None:
+        descriptor_count = _descriptor_count(weights)
+        manifest_id = _manifest_id(weights)
+        word = isa.encode_load_weight(
+            descriptor_count=descriptor_count,
+            manifest_id=manifest_id,
+        )
+        self._submit_command(word)
+        self.weights_loaded = True
+
+    def reset_kv_cache(self, *, session_id: int = 0) -> None:
+        self._submit_command(isa.encode_reset_kv_cache(session_id=session_id))
+
+    def init_activation(self, prompt_tokens: list[int] | tuple[int, ...]) -> None:
+        self.reset_kv_cache()
+        self.load_prompt_tokens(prompt_tokens)
+
+    def load_prompt_tokens(self, prompt_tokens: list[int] | tuple[int, ...]) -> None:
+        for position, token_id in enumerate(prompt_tokens):
+            self._submit_command(
+                isa.encode_load_prompt(position=position, token_id=int(token_id))
+            )
+
+    def run_one_token_step(
+        self,
+        *,
+        request_id: int | None = None,
+        sampling: isa.SamplingMode = isa.SamplingMode.ARGMAX,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+    ) -> int:
+        rid = self.command_count & 0xFFFF if request_id is None else int(request_id)
+        word = isa.encode_next_token(
+            request_id=rid,
+            sampling=sampling,
+            temperature_q8_8=isa.q8_8(temperature),
+            top_p_q8_8=isa.q8_8(top_p),
+        )
+        status = self._submit_command(word)
+        token = isa.status_token(status)
+        if token is None:
+            raise RuntimeError("NEXT_TOKEN completed without a token-valid status word")
+        return token
+
+    def _submit_command(self, word64: int) -> int:
+        with self._open_mmio() as mmio:
+            mmio.write64(AXIL_CMD_IN, word64)
+            mmio.write64(AXIL_CMD_KICK, 0x1)
+            self.command_count += 1
+            deadline = time.monotonic() + self.timeout_sec
+            while time.monotonic() < deadline:
+                status = _read_status_word(mmio)
+                self.last_status_word = status
+                if isa.status_error(status):
+                    raise RuntimeError(f"NPU command failed: status=0x{status:016x}")
+                if isa.status_done(status):
+                    return status
+                time.sleep(self.poll_interval_sec)
+        raise TimeoutError("NPU command did not report DONE")
+
+    def _open_mmio(self):
+        if self._mmio_factory is not None:
+            return self._mmio_factory()
+        if _env_truthy("PCCX_NPU_SIM_BACKEND"):
+            if self._sim_mmio is None:
+                self._sim_mmio = TokenSimMmio.from_env()
+            return nullcontext(self._sim_mmio)
+        return NpuMmio(uio=self.uio_device)
+
+
+def load_weights_to_l2(weights: Any = None) -> None:
+    token_runtime().load_weights_to_l2(weights)
+
+
+def reset_kv_cache(*, session_id: int = 0) -> None:
+    token_runtime().reset_kv_cache(session_id=session_id)
+
+
+def init_activation(prompt_tokens: list[int] | tuple[int, ...]) -> None:
+    token_runtime().init_activation(prompt_tokens)
+
+
+def load_prompt_tokens(prompt_tokens: list[int] | tuple[int, ...]) -> None:
+    token_runtime().load_prompt_tokens(prompt_tokens)
+
+
+def run_one_token_step(
+    *,
+    temperature: float = 0.0,
+    top_p: float = 1.0,
+    sampling: isa.SamplingMode = isa.SamplingMode.ARGMAX,
+) -> int:
+    return token_runtime().run_one_token_step(
+        temperature=temperature,
+        top_p=top_p,
+        sampling=sampling,
+    )
+
+
+def token_runtime() -> NpuTokenRuntime:
+    global _TOKEN_RUNTIME
+    if _TOKEN_RUNTIME is None:
+        _TOKEN_RUNTIME = NpuTokenRuntime()
+    return _TOKEN_RUNTIME
 
 
 def npu_gemm(
@@ -46,25 +171,14 @@ def npu_gemm(
     *,
     layer_idx: int | None = None,
 ) -> np.ndarray:
-    """W [K_in, M_out], X [B, K_in] -> [B, M_out] float32."""
-    Wf = np.asarray(W, dtype=np.float32)
-    Xf = np.asarray(X, dtype=np.float32)
-    if not _can_attempt_hardware():
-        return cpu_gemm(Wf, Xf)
+    """CPU fallback for legacy tensor-call sites.
 
-    try:
-        _submit_experimental_program([
-            isa.encode_gemm(
-                dest_reg=0,
-                src_addr=0,
-                size_ptr_addr=_shape_ptr_for_layer(layer_idx),
-                shape_ptr_addr=_shape_ptr_for_layer(layer_idx),
-                parallel_lane=_parallel_lane_for_shape(Wf.shape),
-            )
-        ])
-    except Exception as exc:
-        LOG.warning("NPU GEMM dispatch failed; using CPU fallback: %s", exc)
-    return _tiled_gemm_fallback(Wf, Xf)
+    Hardware Gemma generation uses run_one_token_step(), not per-matrix
+    dispatch.  This wrapper remains so CPU-mode code can keep sharing the
+    Gemma math modules.
+    """
+    del layer_idx
+    return cpu_gemm(np.asarray(W, dtype=np.float32), np.asarray(X, dtype=np.float32))
 
 
 def npu_gemv(
@@ -73,101 +187,63 @@ def npu_gemv(
     *,
     layer_idx: int | None = None,
 ) -> np.ndarray:
-    """W [K_in, M_out], x [K_in] -> [M_out] float32."""
-    Wf = np.asarray(W, dtype=np.float32)
-    xf = np.asarray(x, dtype=np.float32)
-    if not _can_attempt_hardware():
-        return cpu_gemv(Wf, xf)
-
-    try:
-        _submit_experimental_program([
-            isa.encode_gemv(
-                dest_reg=0,
-                src_addr=0,
-                size_ptr_addr=_shape_ptr_for_layer(layer_idx),
-                shape_ptr_addr=_shape_ptr_for_layer(layer_idx),
-                parallel_lane=_parallel_lane_for_shape(Wf.shape),
-            )
-        ])
-    except Exception as exc:
-        LOG.warning("NPU GEMV dispatch failed; using CPU fallback: %s", exc)
-    return cpu_gemv(Wf, xf)
+    del layer_idx
+    return cpu_gemv(np.asarray(W, dtype=np.float32), np.asarray(x, dtype=np.float32))
 
 
 def npu_cvo(op: str, x: np.ndarray) -> np.ndarray:
-    """op in {EXP, SQRT, GELU, SIN, COS, REDUCE_SUM, SCALE, RECIP}."""
-    xf = np.asarray(x, dtype=np.float32)
-    op_norm = op.upper()
-    if op_norm not in _CVO_FUNC_BY_NAME:
-        return cpu_cvo(op_norm, xf)
-    if not _can_attempt_hardware():
-        return cpu_cvo(op_norm, xf)
-
-    try:
-        _submit_experimental_program([
-            isa.encode_cvo(
-                _CVO_FUNC_BY_NAME[op_norm],
-                src_addr=0,
-                dst_addr=0,
-                length=min(int(xf.size), 0xFFFF),
-            )
-        ])
-    except Exception as exc:
-        LOG.warning("NPU CVO dispatch failed; using CPU fallback: %s", exc)
-    return cpu_cvo(op_norm, xf)
+    return cpu_cvo(str(op).upper(), np.asarray(x, dtype=np.float32))
 
 
 def npu_status() -> dict:
-    """Return status bits exposed through AXIL_STAT_OUT."""
-    available = npu_available()
-    status_word = 0
-    if available:
-        try:
-            with NpuMmio(uio=UIO_DEVICE_DEFAULT) as mmio:
-                status_word = mmio.read32(AXIL_STAT_OUT)
-        except Exception as exc:
-            LOG.warning("could not read NPU status; reporting unavailable: %s", exc)
-            available = False
-            status_word = 0
-
+    """Return the last observed token-step status without popping a FIFO."""
+    runtime = _TOKEN_RUNTIME
+    status_word = runtime.last_status_word if runtime is not None else 0
+    token = isa.status_token(status_word)
     return {
         "mmio_hex": f"0x{status_word & 0xFFFF_FFFF:08x}",
         "busy": isa.status_busy(status_word),
         "done": isa.status_done(status_word),
-        "available": available,
+        "error": isa.status_error(status_word),
+        "token_valid": token is not None,
+        "last_token": token,
+        "available": npu_available(),
         "last_cycle_count": 0,
+        "axil_command_count": runtime.command_count if runtime is not None else 0,
+        "readback_bytes_last": 4 if token is not None else 0,
     }
 
 
 def npu_backend_readiness() -> dict:
-    """Return whether the NPU path can produce Gemma tensor results."""
+    """Return whether the high-level token backend can produce token results."""
     available = npu_available()
-    experimental_axil = _env_truthy("PCCX_NPU_EXPERIMENTAL_DISPATCH")
-    hardware_results = False
-    if not available:
-        reason = (
-            "NPU UIO/bitstream is not available; Gemma tensor dispatch would "
-            "use CPU fallback"
-        )
+    token_path_enabled = (
+        _env_truthy("PCCX_NPU_TOKEN_BACKEND")
+        or _env_truthy("PCCX_NPU_SIM_BACKEND")
+    )
+    hardware_results = bool(available and token_path_enabled)
+    if hardware_results:
+        reason = "NPU self-contained token backend is ready"
+    elif not token_path_enabled:
+        reason = "NPU self-contained token backend is disabled; CPU backend selected"
     else:
-        reason = (
-            "NPU UIO/bitstream is available, but high-level Gemma tensor "
-            "dispatch still returns NumPy golden results; DMA buffer ownership "
-            "and result readback are not implemented"
-        )
+        reason = "NPU self-contained token backend is enabled but UIO/sim access is unavailable"
     return {
         "npu_available": available,
         "hardware_results": hardware_results,
-        "experimental_axil_dispatch": experimental_axil,
+        "token_backend": token_path_enabled,
+        "experimental_axil_dispatch": False,
         "reason": reason,
     }
 
 
 def npu_available() -> bool:
-    """True iff /dev/uio4 opens and the loaded bitstream hash is expected."""
+    """True when token-step MMIO is available or the local sim backend is enabled."""
     global NPU_AVAILABLE
     if _fallback_requested():
         return False
+    if _env_truthy("PCCX_NPU_SIM_BACKEND"):
+        return True
     if NPU_AVAILABLE is not None:
         return bool(NPU_AVAILABLE)
     if not bitstream_sha256_is_expected(BITSTREAM_PATH_DEFAULT):
@@ -183,72 +259,28 @@ def npu_available() -> bool:
     return True
 
 
-def _can_attempt_hardware() -> bool:
-    if not npu_available():
-        return False
-    if _env_truthy("PCCX_NPU_EXPERIMENTAL_DISPATCH"):
-        return True
-    LOG.info(
-        "NPU is present but high-level dispatch is using CPU fallback until "
-        "DMA buffer ownership is golden-vector gated"
-    )
-    return False
+def _read_status_word(mmio: Any) -> int:
+    read64 = getattr(mmio, "read64", None)
+    if read64 is not None:
+        return int(read64(AXIL_STAT_OUT)) & 0xFFFF_FFFF_FFFF_FFFF
+    return int(mmio.read32(AXIL_STAT_OUT)) & 0xFFFF_FFFF
 
 
-def _submit_experimental_program(words: list[int]) -> None:
-    if len(words) > 8:
-        raise ValueError("AXIL_CMD_IN FIFO accepts at most 8 words per program")
-    with NpuMmio(uio=UIO_DEVICE_DEFAULT) as mmio:
-        for word in words:
-            mmio.write64(AXIL_CMD_IN, word)
-        mmio.write64(AXIL_CMD_KICK, 0x1)
-        deadline = time.monotonic() + NPU_TIMEOUT_SEC
-        while time.monotonic() < deadline:
-            status = mmio.read32(AXIL_STAT_OUT)
-            if isa.status_done(status):
-                return
-            time.sleep(0.001)
-    raise TimeoutError("NPU program did not report DONE")
+def _descriptor_count(weights: Any) -> int:
+    if isinstance(weights, dict):
+        descriptors = weights.get("descriptors")
+        if descriptors is not None:
+            return min(len(descriptors), 0xFF)
+    return 0
 
 
-def _tiled_gemm_fallback(W: np.ndarray, X: np.ndarray) -> np.ndarray:
-    Wf = np.asarray(W, dtype=np.float32)
-    Xf = np.asarray(X, dtype=np.float32)
-    if Wf.ndim != 2 or Xf.ndim != 2:
-        return cpu_gemm(Wf, Xf)
-    batch, kin = Xf.shape
-    if Wf.shape[0] != kin:
-        return cpu_gemm(Wf, Xf)
-
-    tile_m = int(os.getenv("PCCX_NPU_TILE_M", "32"))
-    tile_k = int(os.getenv("PCCX_NPU_TILE_K", "128"))
-    tile_n = int(os.getenv("PCCX_NPU_TILE_N", "128"))
-    if batch <= tile_m and kin <= tile_k and Wf.shape[1] <= tile_n:
-        return cpu_gemm(Wf, Xf)
-
-    out = np.zeros((batch, Wf.shape[1]), dtype=np.float32)
-    for m0 in range(0, batch, tile_m):
-        m1 = min(m0 + tile_m, batch)
-        for n0 in range(0, Wf.shape[1], tile_n):
-            n1 = min(n0 + tile_n, Wf.shape[1])
-            acc = np.zeros((m1 - m0, n1 - n0), dtype=np.float32)
-            for k0 in range(0, kin, tile_k):
-                k1 = min(k0 + tile_k, kin)
-                acc += np.dot(Xf[m0:m1, k0:k1], Wf[k0:k1, n0:n1])
-            out[m0:m1, n0:n1] = acc
-    return out
-
-
-def _parallel_lane_for_shape(shape: tuple[int, ...]) -> int:
-    if not shape:
-        return 1
-    return max(1, min(31, int(shape[-1] if len(shape) > 1 else shape[0])))
-
-
-def _shape_ptr_for_layer(layer_idx: int | None) -> int:
-    if layer_idx is None:
+def _manifest_id(weights: Any) -> int:
+    if weights is None:
         return 0
-    return int(layer_idx) & 0x3F
+    model_dir = getattr(weights, "model_dir", None)
+    if model_dir is not None:
+        return isa.manifest_id_from_text(model_dir)
+    return isa.manifest_id_from_text(weights)
 
 
 def _fallback_requested() -> bool:
@@ -260,3 +292,9 @@ def _fallback_requested() -> bool:
 
 def _env_truthy(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _reset_token_runtime_for_tests() -> None:
+    global _TOKEN_RUNTIME, NPU_AVAILABLE
+    _TOKEN_RUNTIME = None
+    NPU_AVAILABLE = None

--- a/sw/runtime/npu/sim_mmio.py
+++ b/sw/runtime/npu/sim_mmio.py
@@ -1,0 +1,70 @@
+"""Small MMIO-compatible token-step simulator for local runtime tests."""
+from __future__ import annotations
+
+from collections import deque
+import os
+
+from sw.runtime import isa
+
+from .address_map import AXIL_CMD_IN, AXIL_CMD_KICK, AXIL_STAT_OUT
+
+
+class TokenSimMmio:
+    """MMIO shim that accepts high-level NPU commands and returns tokens.
+
+    The class is intentionally narrow: it validates the host command sequence
+    and returns one 32-bit token only after a NEXT_TOKEN command.  It does not
+    expose tensor result buffers.
+    """
+
+    def __init__(self, tokens: list[int] | None = None) -> None:
+        self.tokens = deque(int(token) & isa.STAT_TOKEN_MASK for token in (tokens or [1]))
+        self.commands: list[int] = []
+        self.command_count = 0
+        self.status_word = isa.encode_status(done=True)
+
+    @classmethod
+    def from_env(cls) -> "TokenSimMmio":
+        raw = os.getenv("PCCX_NPU_SIM_TOKENS", "1")
+        tokens = [int(part.strip(), 0) for part in raw.split(",") if part.strip()]
+        return cls(tokens or [1])
+
+    def __enter__(self) -> "TokenSimMmio":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def write64(self, offset: int, value: int) -> None:
+        if offset == AXIL_CMD_IN:
+            self.commands.append(value & 0xFFFF_FFFF_FFFF_FFFF)
+            return
+        if offset == AXIL_CMD_KICK:
+            if not self.commands:
+                self.status_word = isa.encode_status(done=True, error=True)
+                return
+            self._execute(self.commands[-1])
+
+    def read64(self, offset: int) -> int:
+        if offset != AXIL_STAT_OUT:
+            return 0
+        return self.status_word
+
+    def read32(self, offset: int) -> int:
+        return self.read64(offset) & 0xFFFF_FFFF
+
+    def _execute(self, word64: int) -> None:
+        opcode, _operand = isa.decode_command(word64)
+        self.command_count += 1
+        if opcode == isa.Opcode.NEXT_TOKEN:
+            token = self.tokens.popleft() if self.tokens else 1
+            self.status_word = isa.encode_status(done=True, token=token)
+            return
+        if opcode in (
+            isa.Opcode.RESET_KV_CACHE,
+            isa.Opcode.LOAD_WEIGHT,
+            isa.Opcode.LOAD_PROMPT,
+        ):
+            self.status_word = isa.encode_status(done=True)
+            return
+        self.status_word = isa.encode_status(done=True, error=True)

--- a/sw/runtime/npu/tests/test_npu_dispatch.py
+++ b/sw/runtime/npu/tests/test_npu_dispatch.py
@@ -4,6 +4,7 @@ import struct
 
 import numpy as np
 
+from sw.runtime import isa
 from sw.runtime.npu import address_map
 from sw.runtime.npu import npu_core
 from sw.runtime.npu.cpu_fallback import cpu_gemm
@@ -118,3 +119,61 @@ def test_datamover_issue_command_writes_three_words_then_push():
         (0x1000 + CMD_EXT, (word >> 64) & 0xFFFF_FFFF),
         (0x1000 + CMD_PUSH, 0x1),
     ]
+
+
+def test_token_runtime_emits_self_contained_commands_only():
+    class FakeMmio:
+        def __init__(self) -> None:
+            self.commands: list[int] = []
+            self.reads = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def write64(self, offset: int, value: int) -> None:
+            if offset == address_map.AXIL_CMD_IN:
+                self.commands.append(value)
+
+        def read64(self, offset: int) -> int:
+            assert offset == address_map.AXIL_STAT_OUT
+            self.reads += 1
+            last_opcode, _ = isa.decode_command(self.commands[-1])
+            if last_opcode == isa.Opcode.NEXT_TOKEN:
+                return isa.encode_status(done=True, token=0x1234)
+            return isa.encode_status(done=True)
+
+    fake = FakeMmio()
+    runtime = npu_core.NpuTokenRuntime(mmio_factory=lambda: fake)
+
+    runtime.load_weights_to_l2({"descriptors": [{"slot": 0}]})
+    runtime.init_activation([11, 22])
+    token = runtime.run_one_token_step()
+
+    assert token == 0x1234
+    opcodes = [isa.decode_command(word)[0] for word in fake.commands]
+    assert opcodes == [
+        isa.Opcode.LOAD_WEIGHT,
+        isa.Opcode.RESET_KV_CACHE,
+        isa.Opcode.LOAD_PROMPT,
+        isa.Opcode.LOAD_PROMPT,
+        isa.Opcode.NEXT_TOKEN,
+    ]
+    assert len(fake.commands) == 5
+    assert fake.reads == 5
+
+
+def test_sim_backend_returns_configured_tokens(monkeypatch):
+    monkeypatch.setenv("PCCX_NPU_SIM_BACKEND", "1")
+    monkeypatch.setenv("PCCX_NPU_SIM_TOKENS", "77,88")
+    monkeypatch.setenv("PCCX_NPU_TOKEN_BACKEND", "1")
+    npu_core._reset_token_runtime_for_tests()
+
+    runtime = npu_core.token_runtime()
+    runtime.init_activation([101, 102])
+
+    assert runtime.run_one_token_step() == 77
+    assert runtime.run_one_token_step() == 88
+    assert npu_core.npu_backend_readiness()["hardware_results"] is True

--- a/sw/runtime/server/app.py
+++ b/sw/runtime/server/app.py
@@ -341,6 +341,9 @@ def status_payload(state: ServerState) -> Dict[str, Any]:
         "npu_done": npu["npu_done"],
         "npu_available": npu["npu_available"],
         "npu_axil_command_count": npu["npu_axil_command_count"],
+        "npu_token_valid": npu["npu_token_valid"],
+        "npu_last_token": npu["npu_last_token"],
+        "npu_readback_bytes_last": npu["npu_readback_bytes_last"],
         "npu_mmio_stat_changed": npu["npu_mmio_stat_changed"],
         "backend": state.backend,
         "backend_requested": state.backend_requested,
@@ -363,6 +366,9 @@ def read_npu_status() -> Dict[str, Any]:
         "npu_available": False,
         "npu_axil_command_count": 0,
         "npu_last_cycle_count": 0,
+        "npu_token_valid": False,
+        "npu_last_token": None,
+        "npu_readback_bytes_last": 0,
     }
     try:
         module = importlib.import_module("sw.runtime.npu")
@@ -378,9 +384,12 @@ def read_npu_status() -> Dict[str, Any]:
             "npu_available": True,
             "npu_axil_command_count": 0,
             "npu_last_cycle_count": 0,
+            "npu_token_valid": False,
+            "npu_last_token": None,
+            "npu_readback_bytes_last": 0,
         }
     if isinstance(raw, dict):
-        stat_value = raw.get("npu_mmio_stat_hex", raw.get("mmio_stat_hex"))
+        stat_value = raw.get("npu_mmio_stat_hex", raw.get("mmio_stat_hex", raw.get("mmio_hex")))
         if stat_value is None:
             stat_value = raw.get("npu_mmio_stat", raw.get("mmio_stat", 0))
         stat = _parse_stat_value(stat_value)
@@ -397,6 +406,13 @@ def read_npu_status() -> Dict[str, Any]:
             ),
             "npu_last_cycle_count": _parse_int_value(
                 raw.get("npu_last_cycle_count", raw.get("last_cycle_count", 0))
+            ),
+            "npu_token_valid": bool(raw.get("npu_token_valid", raw.get("token_valid", False))),
+            "npu_last_token": _parse_optional_int_value(
+                raw.get("npu_last_token", raw.get("last_token"))
+            ),
+            "npu_readback_bytes_last": _parse_int_value(
+                raw.get("npu_readback_bytes_last", raw.get("readback_bytes_last", 0))
             ),
         }
     return fallback
@@ -457,6 +473,15 @@ def _parse_int_value(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def _parse_optional_int_value(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _percentile(values: List[float], quantile: float) -> float:

--- a/sw/runtime/server/routes_ws.py
+++ b/sw/runtime/server/routes_ws.py
@@ -299,6 +299,11 @@ def _invoke_generate(session: Any, **values: Any) -> Any:
 
 
 def _token_text(item: Any) -> tuple[Optional[str], Optional[str]]:
+    if isinstance(item, tuple) and item:
+        text, finish = _token_text(item[0])
+        if finish is None and len(item) > 1 and isinstance(item[1], dict):
+            finish = item[1].get("finish_reason")
+        return text, finish
     if isinstance(item, str):
         return item, None
     if isinstance(item, bytes):

--- a/sw/runtime/server/tests/test_status_parse.py
+++ b/sw/runtime/server/tests/test_status_parse.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from sw.runtime.server import app as server_app
+
+
+def test_status_dict_accepts_runtime_mmio_hex_and_token_metadata() -> None:
+    class FakeNpuModule:
+        @staticmethod
+        def npu_status():
+            return {
+                "mmio_hex": "0x0000000a",
+                "available": True,
+                "token_valid": True,
+                "last_token": 1043,
+                "readback_bytes_last": 4,
+            }
+
+    with mock.patch.object(server_app.importlib, "import_module", return_value=FakeNpuModule):
+        payload = server_app.read_npu_status()
+
+    assert payload["npu_mmio_stat_hex"] == "0x0000000a"
+    assert payload["npu_done"] is True
+    assert payload["npu_token_valid"] is True
+    assert payload["npu_last_token"] == 1043
+    assert payload["npu_readback_bytes_last"] == 4

--- a/sw/runtime/test_isa.py
+++ b/sw/runtime/test_isa.py
@@ -1,329 +1,106 @@
-"""Unit tests for sw/runtime/isa.py encoders.
-
-Validates that each encoder produces the exact bit pattern the RTL decoder
-expects per hw/rtl/NPU_Controller/NPU_Control_Unit/ISA_PACKAGE/isa_pkg.sv.
-"""
+"""Unit tests for high-level sw/runtime/isa.py command encoders."""
 from __future__ import annotations
+
+import pytest
 
 from sw.runtime import isa
 
 
 def _opcode_of(word64: int) -> int:
-    return (word64 >> 60) & 0xF
+    return (word64 >> 56) & 0xFF
 
 
-def _body_of(word64: int) -> int:
-    return word64 & ((1 << 60) - 1)
+def _operand_of(word64: int) -> int:
+    return word64 & ((1 << 56) - 1)
 
 
-def test_opcode_placement():
-    """Opcode is in bits [63:60]; body fills [59:0]."""
-    w = isa.encode_gemm(dest_reg=0, src_addr=0)
-    assert _opcode_of(w) == isa.Opcode.GEMM
-    w = isa.encode_gemv(dest_reg=0, src_addr=0)
-    assert _opcode_of(w) == isa.Opcode.GEMV
-    w = isa.encode_memcpy(0, 0, 0, 0)
-    assert _opcode_of(w) == isa.Opcode.MEMCPY
-    w = isa.encode_memset(0, 0, 0)
-    assert _opcode_of(w) == isa.Opcode.MEMSET
-    w = isa.encode_cvo(isa.CvoFunc.EXP, 0, 0, 0)
-    assert _opcode_of(w) == isa.Opcode.CVO
+def test_opcode_placement() -> None:
+    assert _opcode_of(isa.encode_reset_kv_cache()) == isa.Opcode.RESET_KV_CACHE
+    assert _opcode_of(isa.encode_load_weight()) == isa.Opcode.LOAD_WEIGHT
+    assert _opcode_of(isa.encode_load_prompt(position=0, token_id=0)) == isa.Opcode.LOAD_PROMPT
+    assert _opcode_of(isa.encode_next_token()) == isa.Opcode.NEXT_TOKEN
 
 
-def test_gemm_fields_at_known_offsets():
-    """Verify each GEMM field lands at the bit offset isa_pkg.sv declares."""
-    # dest_reg [17 bits] at [59:43]
-    w = isa.encode_gemm(dest_reg=0x1FFFF, src_addr=0)
-    assert (_body_of(w) >> 43) & 0x1FFFF == 0x1FFFF
-    # src_addr [17 bits] at [42:26]
-    w = isa.encode_gemm(dest_reg=0, src_addr=0x1FFFF)
-    assert (_body_of(w) >> 26) & 0x1FFFF == 0x1FFFF
-    # size_ptr_addr [6 bits] at [19:14]
-    w = isa.encode_gemm(0, 0, size_ptr_addr=0x3F)
-    assert (_body_of(w) >> 14) & 0x3F == 0x3F
-    # shape_ptr_addr [6 bits] at [13:8]
-    w = isa.encode_gemm(0, 0, shape_ptr_addr=0x3F)
-    assert (_body_of(w) >> 8) & 0x3F == 0x3F
-    # parallel_lane [5 bits] at [7:3]
-    w = isa.encode_gemm(0, 0, parallel_lane=0x1F)
-    assert (_body_of(w) >> 3) & 0x1F == 0x1F
+def test_no_per_matmul_opcode_surface() -> None:
+    assert not hasattr(isa.Opcode, "GEMM")
+    assert not hasattr(isa.Opcode, "GEMV")
+    assert not hasattr(isa, "encode_gemm")
+    assert not hasattr(isa, "encode_gemv")
 
 
-def test_gemm_flags():
-    """flags_t: findemax[5] | accm[4] | w_scale[3] | reserved[2:0]."""
-    f = isa.GemmFlags(findemax=True, accm=False, w_scale=False)
-    assert f.to_bits() == 0b100_000
-    f = isa.GemmFlags(findemax=False, accm=True, w_scale=False)
-    assert f.to_bits() == 0b010_000
-    f = isa.GemmFlags(findemax=True, accm=True, w_scale=True)
-    assert f.to_bits() == 0b111_000
-    # When passed to encode_gemm, flags occupies bits [25:20] of body
-    w = isa.encode_gemm(0, 0, flags=isa.GemmFlags(findemax=True, accm=True, w_scale=True))
-    assert (_body_of(w) >> 20) & 0x3F == 0b111_000
-
-
-def test_memcpy_fields():
-    """memcpy: from(1) to(1) dest(17) src(17) aux(17) shape(6) async(1)."""
-    w = isa.encode_memcpy(
-        from_device=isa.FROM_HOST,
-        to_device=isa.TO_NPU,
-        dest_addr=0x1FFFF,
-        src_addr=0x12345,
-        aux_addr=0x0,
-        shape_ptr_addr=0x2A,
-        async_op=isa.ASYNC,
+def test_load_weight_fields() -> None:
+    word = isa.encode_load_weight(
+        weight_slot=0x12,
+        flags=0x34,
+        descriptor_count=0x56,
+        manifest_id=0x89AB_CDEF,
     )
-    assert _opcode_of(w) == isa.Opcode.MEMCPY
-    assert (_body_of(w) >> 59) & 0x1 == 1   # from_device
-    assert (_body_of(w) >> 58) & 0x1 == 0   # to_device
-    assert (_body_of(w) >> 41) & 0x1FFFF == 0x1FFFF  # dest_addr
-    assert (_body_of(w) >> 24) & 0x1FFFF == 0x12345  # src_addr
-    assert (_body_of(w) >> 1)  & 0x3F == 0x2A         # shape_ptr_addr
-    assert _body_of(w) & 0x1 == 1                     # async
+
+    assert _operand_of(word) == 0x12345689ABCDEF
+    assert isa.decode_load_weight(word) == {
+        "weight_slot": 0x12,
+        "flags": 0x34,
+        "descriptor_count": 0x56,
+        "manifest_id": 0x89AB_CDEF,
+    }
 
 
-def test_memset_fields():
-    """memset: dest_cache(2) dest_addr(6) a(16) b(16) c(16) reserved(4)."""
-    w = isa.encode_memset(
-        dest_cache=0x2,
-        dest_addr=0x3F,
-        a_value=0xAAAA,
-        b_value=0xBBBB,
-        c_value=0xCCCC,
+def test_load_prompt_fields() -> None:
+    word = isa.encode_load_prompt(position=0x00ABCD, token_id=0x12345678)
+
+    assert _operand_of(word) == 0x00ABCD12345678
+    assert isa.decode_load_prompt(word) == {
+        "position": 0x00ABCD,
+        "token_id": 0x12345678,
+    }
+
+
+def test_next_token_fields() -> None:
+    word = isa.encode_next_token(
+        request_id=0x1234,
+        sampling=isa.SamplingMode.RANDOM,
+        temperature_q8_8=isa.q8_8(0.75),
+        top_p_q8_8=isa.q8_8(0.95),
     )
-    assert _opcode_of(w) == isa.Opcode.MEMSET
-    assert (_body_of(w) >> 58) & 0x3 == 0x2
-    assert (_body_of(w) >> 52) & 0x3F == 0x3F
-    assert (_body_of(w) >> 36) & 0xFFFF == 0xAAAA
-    assert (_body_of(w) >> 20) & 0xFFFF == 0xBBBB
-    assert (_body_of(w) >> 4)  & 0xFFFF == 0xCCCC
+
+    assert isa.decode_next_token(word) == {
+        "request_id": 0x1234,
+        "sampling": isa.SamplingMode.RANDOM,
+        "temperature_q8_8": 0x00C0,
+        "top_p_q8_8": 0x00F3,
+    }
 
 
-def test_cvo_fields():
-    """cvo: func(4) src(17) dst(17) length(16) flags(5) async(1)."""
-    w = isa.encode_cvo(
-        cvo_func=isa.CvoFunc.GELU,
-        src_addr=0x1ABCD,
-        dst_addr=0x12345,
-        length=0xBEEF,
-        flags=0x1F,
-        async_op=isa.ASYNC,
-    )
-    assert _opcode_of(w) == isa.Opcode.CVO
-    assert (_body_of(w) >> 56) & 0xF == int(isa.CvoFunc.GELU)
-    assert (_body_of(w) >> 39) & 0x1FFFF == 0x1ABCD
-    assert (_body_of(w) >> 22) & 0x1FFFF == 0x12345
-    assert (_body_of(w) >> 6)  & 0xFFFF == 0xBEEF
-    assert (_body_of(w) >> 1)  & 0x1F == 0x1F
-    assert _body_of(w) & 0x1 == 1
+def test_reset_kv_cache_fields() -> None:
+    word = isa.encode_reset_kv_cache(session_id=0xCAFE_BABE)
+    assert isa.decode_reset_kv_cache(word) == {"session_id": 0xCAFE_BABE}
 
 
-def test_out_of_range_raises():
-    import pytest
+def test_decode_command_split_and_kick_marker() -> None:
+    assert isa.decode_command(isa.KICK_MARKER) == (0x80, 0)
+    assert _opcode_of(isa.KICK_MARKER) not in [int(op) for op in isa.Opcode]
+
+
+def test_status_token_helpers() -> None:
+    empty_done = isa.encode_status(done=True)
+    assert isa.status_done(empty_done) is True
+    assert isa.status_token(empty_done) is None
+
+    token_done = isa.encode_status(done=True, token=0x1234_5678)
+    assert isa.status_done(token_done) is True
+    assert isa.status_token_valid(token_done) is True
+    assert isa.status_token(token_done) == 0x1234_5678
+    assert (token_done >> isa.STAT_TOKEN_SHIFT) & isa.STAT_TOKEN_MASK == 0x1234_5678
+
+
+def test_out_of_range_raises() -> None:
     with pytest.raises(ValueError):
-        isa.encode_gemm(dest_reg=0x20000, src_addr=0)   # > 17 bits
+        isa.encode_load_prompt(position=1 << 24, token_id=0)
     with pytest.raises(ValueError):
-        isa.encode_memset(dest_cache=4, dest_addr=0, a_value=0)  # > 2 bits
-
-
-def test_kick_marker_bit63_only():
-    assert isa.KICK_MARKER == 0x8000_0000_0000_0000
-    assert (isa.KICK_MARKER >> 63) & 0x1 == 1
-    assert isa.KICK_MARKER & ((1 << 63) - 1) == 0
-
-
-def test_status_helpers():
-    assert isa.status_busy(0b00) is False
-    assert isa.status_busy(0b01) is True
-    assert isa.status_busy(0b11) is True
-    assert isa.status_done(0b00) is False
-    assert isa.status_done(0b10) is True
-    assert isa.status_done(0b11) is True
-
-
-# ----------------------------------------------------------------------------
-# Decoder + round-trip coverage
-# ----------------------------------------------------------------------------
-
-def test_decode_x64_split():
-    assert isa.decode_x64(0xF000_0000_0000_0000) == (0xF, 0)
-    assert isa.decode_x64(0x0000_0000_0000_0001) == (0x0, 1)
-    assert isa.decode_x64(0x8000_0000_0000_0000) == (0x8, 0)  # KICK marker
-    # Reject out-of-range
-    import pytest
+        isa.encode_load_prompt(position=0, token_id=1 << 32)
     with pytest.raises(ValueError):
-        isa.decode_x64(1 << 64)
-
-
-def test_decode_gemm_round_trip():
-    args = dict(
-        dest_reg=0x1ABCD,
-        src_addr=0x12345,
-        flags=isa.GemmFlags(findemax=True, accm=False, w_scale=True),
-        size_ptr_addr=0x2A,
-        shape_ptr_addr=0x15,
-        parallel_lane=0x0F,
-    )
-    w = isa.encode_gemm(**args)
-    decoded = isa.decode_gemm(w)
-    assert decoded == args
-
-
-def test_decode_gemv_round_trip():
-    args = dict(
-        dest_reg=0x0DEAD,
-        src_addr=0x1BEEF,
-        flags=isa.GemmFlags(findemax=False, accm=True, w_scale=False),
-        size_ptr_addr=0x00,
-        shape_ptr_addr=0x3F,
-        parallel_lane=0x1F,
-    )
-    w = isa.encode_gemv(**args)
-    decoded = isa.decode_gemv(w)
-    assert decoded == args
-
-
-def test_decode_memcpy_round_trip():
-    args = dict(
-        from_device=isa.FROM_HOST,
-        to_device=isa.TO_NPU,
-        dest_addr=0x1FFFF,
-        src_addr=0x10000,
-        aux_addr=0x05555,
-        shape_ptr_addr=0x2A,
-        async_op=isa.ASYNC,
-    )
-    w = isa.encode_memcpy(**args)
-    decoded = isa.decode_memcpy(w)
-    assert decoded == args
-
-
-def test_decode_memset_round_trip():
-    args = dict(
-        dest_cache=0x3,
-        dest_addr=0x3F,
-        a_value=0xAAAA,
-        b_value=0xBBBB,
-        c_value=0xCCCC,
-    )
-    w = isa.encode_memset(**args)
-    decoded = isa.decode_memset(w)
-    assert decoded == args
-
-
-def test_decode_cvo_round_trip():
-    args = dict(
-        cvo_func=isa.CvoFunc.GELU,
-        src_addr=0x1ABCD,
-        dst_addr=0x12345,
-        length=0xBEEF,
-        flags=0x1F,
-        async_op=isa.ASYNC,
-    )
-    w = isa.encode_cvo(**args)
-    decoded = isa.decode_cvo(w)
-    assert decoded == args
-
-
-def test_decoder_opcode_mismatch_raises():
-    import pytest
-    gemm_word = isa.encode_gemm(0, 0)
-    with pytest.raises(ValueError, match="not GEMV"):
-        isa.decode_gemv(gemm_word)
-    with pytest.raises(ValueError, match="not MEMCPY"):
-        isa.decode_memcpy(gemm_word)
-    with pytest.raises(ValueError, match="not MEMSET"):
-        isa.decode_memset(gemm_word)
-    with pytest.raises(ValueError, match="not CVO"):
-        isa.decode_cvo(gemm_word)
-    memcpy_word = isa.encode_memcpy(0, 0, 0, 0)
-    with pytest.raises(ValueError, match="not GEMM"):
-        isa.decode_gemm(memcpy_word)
-
-
-# ----------------------------------------------------------------------------
-# Boundary + adversarial cases
-# ----------------------------------------------------------------------------
-
-def test_max_fields_no_overflow_between_neighbors():
-    """When every field is at its max, no field bleeds into a neighbor.
-
-    Detects off-by-one bit shifts that would let a saturated field overwrite
-    the adjacent one.
-    """
-    # GEMM: every field max
-    w = isa.encode_gemm(
-        dest_reg=0x1FFFF,
-        src_addr=0x1FFFF,
-        flags=isa.GemmFlags(findemax=True, accm=True, w_scale=True),
-        size_ptr_addr=0x3F,
-        shape_ptr_addr=0x3F,
-        parallel_lane=0x1F,
-    )
-    d = isa.decode_gemm(w)
-    assert d["dest_reg"]       == 0x1FFFF
-    assert d["src_addr"]       == 0x1FFFF
-    assert d["flags"]          == isa.GemmFlags(findemax=True, accm=True, w_scale=True)
-    assert d["size_ptr_addr"]  == 0x3F
-    assert d["shape_ptr_addr"] == 0x3F
-    assert d["parallel_lane"]  == 0x1F
-
-    # MEMCPY: every field max
-    w = isa.encode_memcpy(
-        from_device=1, to_device=1,
-        dest_addr=0x1FFFF, src_addr=0x1FFFF, aux_addr=0x1FFFF,
-        shape_ptr_addr=0x3F, async_op=1,
-    )
-    d = isa.decode_memcpy(w)
-    assert d["from_device"]    == 1
-    assert d["to_device"]      == 1
-    assert d["dest_addr"]      == 0x1FFFF
-    assert d["src_addr"]       == 0x1FFFF
-    assert d["aux_addr"]       == 0x1FFFF
-    assert d["shape_ptr_addr"] == 0x3F
-    assert d["async_op"]       == 1
-
-
-def test_negative_value_rejected():
-    """Unsigned fields must reject negatives; the encoder check uses `< 0`."""
-    import pytest
+        isa.encode_load_weight(descriptor_count=1 << 8)
     with pytest.raises(ValueError):
-        isa.encode_gemm(dest_reg=-1, src_addr=0)
+        isa.encode_next_token(request_id=1 << 16)
     with pytest.raises(ValueError):
-        isa.encode_memcpy(0, 0, dest_addr=-1, src_addr=0)
-    with pytest.raises(ValueError):
-        isa.encode_memset(dest_cache=0, dest_addr=0, a_value=-1)
-    with pytest.raises(ValueError):
-        isa.encode_cvo(isa.CvoFunc.EXP, src_addr=-1, dst_addr=0, length=0)
-
-
-def test_off_by_one_max_plus_one_rejected():
-    """Each field exactly one past its max must raise."""
-    import pytest
-    with pytest.raises(ValueError):
-        isa.encode_gemm(dest_reg=0x20000, src_addr=0)            # 17-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_gemm(0, 0, size_ptr_addr=0x40)                # 6-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_gemm(0, 0, parallel_lane=0x20)                # 5-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_memset(dest_cache=0x4, dest_addr=0, a_value=0)  # 2-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_memset(0, 0x40, 0)                            # 6-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_memset(0, 0, 0x10000)                         # 16-bit + 1
-    with pytest.raises(ValueError):
-        isa.encode_cvo(isa.CvoFunc.EXP, 0, 0, length=0x10000)    # 16-bit + 1
-
-
-def test_kick_marker_is_not_a_valid_opcode_body():
-    """KICK_MARKER decodes to opcode 0x8 with body 0 - confirms it can't be
-    mistaken for any of the 5 real ops (0..4)."""
-    op, body = isa.decode_x64(isa.KICK_MARKER)
-    assert op == 0x8
-    assert body == 0
-    assert op not in (int(isa.Opcode.GEMV),
-                       int(isa.Opcode.GEMM),
-                       int(isa.Opcode.MEMCPY),
-                       int(isa.Opcode.MEMSET),
-                       int(isa.Opcode.CVO))
+        isa.encode_status(token=1 << 32)

--- a/sw/runtime/uio.py
+++ b/sw/runtime/uio.py
@@ -12,9 +12,10 @@ NPU register layout (mirrors hw/rtl/NPU_Controller/NPU_frontend):
                         is the right call.
 - 0x008  ADDR_KICK    — write only.  Any word triggers the hardware to push
                         0x8000_0000_0000_0000 into the FIFO (decoder kick marker).
-- any    AXIL_STAT_OUT — read returns the head of the status FIFO (64-bit). With
-                        status backflow connected (commit c3fea5e), bits [31:0]
-                        carry the live mmio_npu_stat (bit 0 BUSY, bit 1 DONE).
+- any    AXIL_STAT_OUT — read returns the head of the status FIFO (64-bit).
+                        bits [31:0] carry status flags. For NEXT_TOKEN,
+                        bits [63:32] carry exactly one generated token when
+                        TOKEN_VALID is set.
                         Reads before the FIFO has data block forever — only safe
                         once status backflow RTL is in the loaded bitstream.
 
@@ -114,7 +115,8 @@ class NpuMmio:
     def read_status(self) -> int:
         """Return the lower 32 bits of the head AXIL_STAT_OUT word.
 
-        Bit 0 BUSY, Bit 1 DONE per NPU_top.sv mmio_npu_stat.
+        Bit 0 BUSY, Bit 1 DONE. Token-step callers that need the generated
+        token should read the full 64-bit status word instead.
         """
         return self.read32(ADDR_STAT)
 


### PR DESCRIPTION
## Summary
- Replace the runtime ISA surface with high-level RESET_KV_CACHE, LOAD_WEIGHT, LOAD_PROMPT, and NEXT_TOKEN commands.
- Route the NPU backend through weight load, prompt load, and one NEXT_TOKEN command per streamed token.
- Keep tensor GEMM/GEMV/CVO helpers as CPU fallback compatibility paths only, and add a local MMIO-compatible token simulator.
- Extend server status parsing so token-valid status carries the 32-bit generated token metadata.

## Validation
- `python3 -m pytest -q sw/runtime/test_isa.py sw/runtime/npu/tests/test_npu_dispatch.py sw/runtime/gemma/tests/test_backend_selection.py sw/runtime/gemma/tests/test_npu_token_generation.py tests/test_gemma_port_offline.py` -> 24 passed
- `PYTHONPATH="$PWD" /tmp/pccx-v002-sw-test-venv/bin/python -m pytest -q tests/test_server_smoke.py sw/runtime/server/tests/test_status_parse.py` -> 7 passed
- `PCCX_RUNTIME_ROOT=/home/hwkim/Desktop/pccxai-private/codex-control/worktrees/pccx-FPGA-NPU-LLM-kv260-v002-sw-correct-arch ./run.sh` in `pccx-fixtures-public-pilot/fixtures/fix-002-v002-token-smoke` -> token 1043 match
- GCP VM token-sim smoke -> token 1043 match; VM stopped after validation

## Notes
- No RTL files changed.
- Host readback in the NPU backend is limited to the final 32-bit token status for each generated token.
