### PR TITLE
docs: add KV260 SD card reset runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ formal/sail/build/
 build/
 hw/build/
 hw/sim/work/
+sw/dtbo/build/
 *.jou
 *.log
 .Xil/

--- a/docs/KV260_SD_CARD_RESET.md
+++ b/docs/KV260_SD_CARD_RESET.md
@@ -1,0 +1,230 @@
+# KV260 SD Card Reset Procedure
+
+This runbook resets the KV260 boot media, then rebuilds the repo-local
+firmware bundle expected by `xmutil` after first boot. It records setup
+steps only; board smoke, model runtime, throughput, and timing evidence
+still come from the existing evidence flow.
+
+## Success Criteria
+
+- The existing SD card state is preserved well enough to recover login and
+  network access.
+- A known-good Ubuntu or PetaLinux image is written to the microSD card.
+- First boot reaches SSH or UART login.
+- `pccx_npu_bd.bit.bin`, `pccx_npu_bd.dtbo`, and `shell.json` are generated
+  under `sw/dtbo/build/pccx_npu_bd/`.
+- When the user chooses to register the bundle on the board,
+  `/lib/firmware/xilinx/pccx_npu_bd/` contains matching bundle filenames and
+  `xmutil listapps` can discover the application entry.
+
+## Before Wiping The Card
+
+1. Photograph the current microSD card, carrier board, boot switches, cable
+   layout, and any label on the card adapter.
+2. Save a host-side copy of the current public SSH key and `known_hosts`
+   entries used for the board. Private keys must stay outside the repository,
+   issue tracker, screenshots, and logs.
+3. If the current card still boots, collect read-only notes:
+
+   ```bash
+   uname -a
+   cat /etc/os-release
+   command -v xmutil || true
+   xmutil listapps 2>&1 || true
+   ls -la /lib/firmware/xilinx 2>/dev/null || true
+   ip addr
+   ```
+
+4. If the card has files that only exist on the board, copy them to a private
+   backup location before flashing. Do not put board dumps, keys, or generated
+   bitstreams into this repository.
+
+## Image Download Links
+
+Use one route per reset.
+
+| Route | When to use | Link |
+| --- | --- | --- |
+| Ubuntu Server 24.04 LTS | Default clean reset for current KV260/K26 work | [Ubuntu Kria images](https://ubuntu.com/download/amd) |
+| Ubuntu Desktop 22.04 LTS | Desktop image when a local GUI is required | [Ubuntu Kria images](https://ubuntu.com/download/amd) |
+| PetaLinux pre-built image | Legacy Kria application package flow or BSP parity checks | [KV260 PetaLinux SD image setup](https://xilinx.github.io/kria-apps-docs/kv260/2021.1/linux_boot/petalinux_2021.1/build/html/docs/sdcard.html) |
+| PetaLinux tools / embedded downloads | Rebuilding a PetaLinux image or BSP locally | [embedded downloads](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/embedded-design-tools.html) |
+| Vitis / Vivado 2025.2 installer | Exporting the XSA and using `bootgen`, `xsct`, and Vitis | [tool downloads](https://www.xilinx.com/support/download.html) |
+
+The PetaLinux starter-kit image path is useful for older application-package
+flows. For new SD-card reset work, prefer the current Ubuntu image unless a
+specific BSP regression needs to be reproduced.
+
+## Flash With balenaEtcher
+
+1. Install the flasher from <https://etcher.balena.io/>.
+2. Insert the microSD card into the host.
+3. Select `Flash from file` and choose the downloaded `.img`, `.wic`, or
+   compressed image file.
+4. Select the microSD card as the target. Verify the capacity and drive name
+   before continuing.
+5. Select `Flash` and wait for validation to complete.
+6. Eject the card from the host before removing it.
+
+## Flash With Win32 Disk Imager
+
+1. Install the tool from <https://sourceforge.net/projects/win32diskimager/>.
+2. If the image is compressed, extract it first so the selected file is the raw
+   `.img` or `.wic` file.
+3. Start the tool, choose the raw image, and select the removable drive letter
+   for the microSD card.
+4. Use `Write`, confirm the destructive prompt, and wait until the write
+   finishes.
+5. Eject the card from Windows before removing it.
+
+## First Boot Checklist
+
+1. Insert the card, connect UART and Ethernet, then power the board.
+2. Wait for the first boot resize/setup path to settle before interrupting.
+3. Confirm basic access:
+
+   ```bash
+   uname -a
+   cat /etc/os-release
+   ip addr
+   command -v xmutil || true
+   xmutil listapps 2>&1 || true
+   ```
+
+4. Install host utilities on the board only when needed:
+
+   ```bash
+   sudo apt update
+   sudo apt install -y device-tree-compiler openssh-server rsync
+   ```
+
+5. Reinstall the saved public SSH key into the board user's
+   `~/.ssh/authorized_keys` if SSH access is required.
+
+## Vitis 2025.2 Hardware Platform Export
+
+Run these steps on the development host after the Vivado project has an
+implemented design and an intended `.bit` artifact.
+
+1. Source the tool environment:
+
+   ```bash
+   source <Vitis_Installation_Directory>/settings64.sh
+   ```
+
+2. Export the hardware platform from Vivado with the bitstream included:
+
+   ```tcl
+   open_project <project>.xpr
+   open_run impl_1
+   write_hw_platform -fixed -include_bit -force \
+     -file build/pccx_v002_kv260.xsa
+   ```
+
+   The GUI path is `File -> Export -> Export Hardware`, then select the
+   include-bitstream option.
+
+3. Generate a device-tree overlay source from the XSA when DTG is available:
+
+   ```tcl
+   hsi open_hw_design build/pccx_v002_kv260.xsa
+   hsi set_repo_path <device-tree-xlnx>
+   hsi create_sw_design device-tree -os device_tree -proc psu_cortexa53_0
+   hsi set_property CONFIG.dt_overlay true [hsi::get_os]
+   hsi generate_target -dir build/dt
+   hsi close_hw_design [hsi current_hw_design]
+   ```
+
+4. Launch the unified IDE only if software workspace work is needed:
+
+   ```bash
+   vitis -w build/vitis-workspace
+   ```
+
+## Generate The Post-Reimage Platform Bundle
+
+The repo now provides:
+
+```bash
+scripts/kv260/generate_sd_platform_bundle.sh
+sw/dtbo/Makefile
+```
+
+Preferred flow with a DTG-generated `pl.dtsi`:
+
+```bash
+scripts/kv260/generate_sd_platform_bundle.sh \
+  --bit build/pccx_v002_kv260.bit \
+  --dts build/dt/pl.dtsi \
+  --overlay pccx_npu_bd
+```
+
+Fallback flow when a DTG output is not available yet:
+
+```bash
+scripts/kv260/generate_sd_platform_bundle.sh \
+  --bit build/pccx_v002_kv260.bit \
+  --overlay pccx_npu_bd
+```
+
+The fallback overlay uses the compiled v002 AXI-Lite aperture
+`0xA0000000` with a `0x00010000` generic-UIO window. Prefer the DTG
+overlay once the XSA is available because it mirrors the actual Vivado
+address map.
+
+The existing deploy script can regenerate the bundle through the Makefile:
+
+```bash
+PCCX_BIT=build/pccx_v002_kv260.bit \
+hw/scripts/deploy_to_kv260.sh --dry-run
+```
+
+## Register The Bundle On The Reimaged Board
+
+Copy the generated directory to the board, then register it locally:
+
+```bash
+sudo mkdir -p /lib/firmware/xilinx/pccx_npu_bd
+sudo install -m 0644 pccx_npu_bd.bit.bin /lib/firmware/xilinx/pccx_npu_bd/
+sudo install -m 0644 pccx_npu_bd.dtbo /lib/firmware/xilinx/pccx_npu_bd/
+sudo install -m 0644 shell.json /lib/firmware/xilinx/pccx_npu_bd/
+xmutil listapps
+```
+
+If the repo and build tools are available on the board, the script can do the
+same registration:
+
+```bash
+scripts/kv260/generate_sd_platform_bundle.sh \
+  --bit build/pccx_v002_kv260.bit \
+  --dts build/dt/pl.dtsi \
+  --overlay pccx_npu_bd \
+  --register /lib/firmware/xilinx
+```
+
+Loading the application changes board state. Run it only when the intended
+bitstream and device-tree overlay are ready for that board session:
+
+```bash
+sudo xmutil unloadapp
+sudo xmutil loadapp pccx_npu_bd
+```
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `bootgen not found` | Source the Vitis/Vivado `settings64.sh` on the host. |
+| `dtc not found` | Install `device-tree-compiler`. |
+| App missing from `xmutil listapps` | Confirm the directory is `/lib/firmware/xilinx/pccx_npu_bd/` and the files are named `pccx_npu_bd.bit.bin`, `pccx_npu_bd.dtbo`, and `shell.json`. |
+| DTBO compile fails | Use the DTG-generated `pl.dtsi`; the fallback overlay assumes the standard `fpga_full` label exists in the boot image. |
+| `/dev/uio*` is missing after load | Confirm the boot image enables `generic-uio` binding for `compatible = "generic-uio"` or use a DTG overlay with the board's intended driver binding. |
+| SSH changed after reimage | Reinstall only the public key and update the host `known_hosts` entry deliberately. |
+
+## References
+
+- Ubuntu Kria image page: <https://ubuntu.com/download/amd>
+- KV260 PetaLinux SD image setup: <https://xilinx.github.io/kria-apps-docs/kv260/2021.1/linux_boot/petalinux_2021.1/build/html/docs/sdcard.html>
+- Kria on-target firmware layout: <https://xilinx.github.io/kria-apps-docs/creating_applications/2022.1/build/html/docs/target.html>
+- Vitis 2025.2 installation: <https://docs.amd.com/r/en-US/ug1742-vitis-release-notes/Installing-the-Vitis-Software-Platform>
+- Vitis 2025.2 IDE launch: <https://docs.amd.com/r/en-US/ug1399-vitis-hls/Launching-the-Vitis-Unified-IDE>

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ Pages, bilingual EN / KO).
   <https://pccx.pages.dev/en/docs/v002/index.html>
 - Repo-local KV260 bring-up checklist:
   [KV260_BRINGUP.md](KV260_BRINGUP.md)
+- Repo-local KV260 SD card reset procedure:
+  [KV260_SD_CARD_RESET.md](KV260_SD_CARD_RESET.md)
 - Repo-local Gemma 3N handoff boundary:
   [GEMMA3N_HANDOFF.md](GEMMA3N_HANDOFF.md)
 - Repo-local W4A8 golden-vector gate:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ architecture and ISA reference remains the pccx documentation site:
 | Area | Document |
 | --- | --- |
 | KV260 bring-up | [KV260 bring-up evidence checklist](KV260_BRINGUP.md) |
+| KV260 reset | [KV260 SD card reset procedure](KV260_SD_CARD_RESET.md) |
 | Model handoff | [Gemma 3N E4B target-model handoff boundary](GEMMA3N_HANDOFF.md) |
 | Verification | [xsim evidence workflow](SIMULATION.md) |
 | Timing evidence | [Vivado timing evidence checklist](TIMING_EVIDENCE.md) |

--- a/hw/vivado/README.md
+++ b/hw/vivado/README.md
@@ -83,8 +83,9 @@ for the tracked-vs-ignored log policy and PR evidence format.
    - Clock Wizard for the 400 MHz core clock
 3. **`write_bitstream`** — only run after (1) and (2) are green; otherwise
    you burn an hour for nothing.
-4. **Device-tree overlay** — see `sw/dtbo/` (to be created) for the
-   Ubuntu 22.04 FPGA Manager flow. Files: `pccx_npu.dtsi`,
+4. **Device-tree overlay** — see `sw/dtbo/` and
+   `scripts/kv260/generate_sd_platform_bundle.sh` for the Ubuntu FPGA
+   Manager flow. Files: `<overlay>.dtbo`, `<overlay>.bit.bin`,
    `shell.json`, `Makefile`.
 5. **KV260 deploy**:
    ```bash

--- a/scripts/kv260/generate_sd_platform_bundle.sh
+++ b/scripts/kv260/generate_sd_platform_bundle.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate the KV260 firmware bundle expected by xmutil/dfx-mgr after an SD
+# card reimage.  Defaults are host-side only; board registration happens only
+# when --register is supplied.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OVERLAY="pccx_npu_bd"
+BIT_SRC=""
+DTS_SRC=""
+BUILD_DIR=""
+NPU_BASE="0xA0000000"
+NPU_SIZE="0x00010000"
+REGISTER_ROOT=""
+LOAD_APP=0
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+usage: scripts/kv260/generate_sd_platform_bundle.sh --bit <system.bit> [options]
+
+Options:
+  --bit <path>          Vivado-generated .bit file to convert to .bit.bin
+  --dts <path>          Optional device-tree overlay source from DTG/XSCT
+  --overlay <name>      Application/overlay name (default: pccx_npu_bd)
+  --build <dir>         Output directory (default: sw/dtbo/build/<overlay>)
+  --npu-base <hex>      Generic-UIO fallback base address (default: 0xA0000000)
+  --npu-size <hex>      Generic-UIO fallback aperture size (default: 0x00010000)
+  --register <dir>      Install bundle into <dir>/<overlay>, normally /lib/firmware/xilinx
+  --load                After --register, run xmutil unloadapp/loadapp <overlay>
+  --dry-run             Print register/load commands instead of executing them
+  -h, --help            Print this help
+
+The generated bundle contains:
+  <overlay>.bit.bin
+  <overlay>.dtbo
+  shell.json
+  manifest.json
+
+Prefer --dts with a DTG/XSCT-generated pl.dtsi.  Without --dts, the script
+creates a minimal full-bitstream + generic-uio overlay for the compiled v002
+address-map default.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --bit)
+      [[ $# -ge 2 ]] || { echo "error: --bit requires a value" >&2; exit 2; }
+      BIT_SRC="$2"
+      shift 2
+      ;;
+    --dts)
+      [[ $# -ge 2 ]] || { echo "error: --dts requires a value" >&2; exit 2; }
+      DTS_SRC="$2"
+      shift 2
+      ;;
+    --overlay)
+      [[ $# -ge 2 ]] || { echo "error: --overlay requires a value" >&2; exit 2; }
+      OVERLAY="$2"
+      shift 2
+      ;;
+    --build)
+      [[ $# -ge 2 ]] || { echo "error: --build requires a value" >&2; exit 2; }
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --npu-base)
+      [[ $# -ge 2 ]] || { echo "error: --npu-base requires a value" >&2; exit 2; }
+      NPU_BASE="$2"
+      shift 2
+      ;;
+    --npu-size)
+      [[ $# -ge 2 ]] || { echo "error: --npu-size requires a value" >&2; exit 2; }
+      NPU_SIZE="$2"
+      shift 2
+      ;;
+    --register)
+      [[ $# -ge 2 ]] || { echo "error: --register requires a value" >&2; exit 2; }
+      REGISTER_ROOT="$2"
+      shift 2
+      ;;
+    --load)
+      LOAD_APP=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${BIT_SRC}" ]]; then
+  echo "error: --bit is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "${OVERLAY}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "error: --overlay must contain only letters, numbers, '.', '_' or '-'" >&2
+  exit 2
+fi
+
+if [[ ! -f "${BIT_SRC}" ]]; then
+  echo "error: bitstream not found: ${BIT_SRC}" >&2
+  exit 1
+fi
+
+if [[ -n "${DTS_SRC}" && ! -f "${DTS_SRC}" ]]; then
+  echo "error: dts source not found: ${DTS_SRC}" >&2
+  exit 1
+fi
+
+if ! command -v bootgen >/dev/null 2>&1; then
+  echo "error: bootgen not found; source the Vitis/Vivado settings64.sh first" >&2
+  exit 1
+fi
+
+if ! command -v dtc >/dev/null 2>&1; then
+  echo "error: dtc not found; install device-tree-compiler on the host or board" >&2
+  exit 1
+fi
+
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/sw/dtbo/build/${OVERLAY}}"
+mkdir -p "${BUILD_DIR}"
+
+BIT_SRC_ABS="$(readlink -f "${BIT_SRC}")"
+DTS_SRC_ABS=""
+if [[ -n "${DTS_SRC}" ]]; then
+  DTS_SRC_ABS="$(readlink -f "${DTS_SRC}")"
+fi
+
+BITBIN="${BUILD_DIR}/${OVERLAY}.bit.bin"
+DTS_OUT="${BUILD_DIR}/${OVERLAY}.dts"
+DTBO="${BUILD_DIR}/${OVERLAY}.dtbo"
+SHELL_JSON="${BUILD_DIR}/shell.json"
+MANIFEST_JSON="${BUILD_DIR}/manifest.json"
+BIF="${BUILD_DIR}/${OVERLAY}.bootgen.bif"
+
+printf '[1/4] convert .bit to .bit.bin\n'
+cat >"${BIF}" <<BIF
+all:
+{
+    [destination_device=pl] "${BIT_SRC_ABS}"
+}
+BIF
+bootgen -w -arch zynqmp -process_bitstream bin -image "${BIF}" -o "${BITBIN}"
+
+printf '[2/4] generate dtbo\n'
+if [[ -n "${DTS_SRC_ABS}" ]]; then
+  if grep -q 'firmware-name[[:space:]]*=' "${DTS_SRC_ABS}"; then
+    sed -E "s/firmware-name[[:space:]]*=[[:space:]]*\"[^\"]*\"/firmware-name = \"${OVERLAY}.bit.bin\"/" \
+      "${DTS_SRC_ABS}" >"${DTS_OUT}"
+  else
+    cp "${DTS_SRC_ABS}" "${DTS_OUT}"
+    printf 'warning: %s has no firmware-name property; copied unchanged\n' "${DTS_SRC_ABS}" >&2
+  fi
+else
+  node_addr="$(printf '%s' "${NPU_BASE#0x}" | tr 'A-F' 'a-f')"
+  cat >"${DTS_OUT}" <<DTS
+/dts-v1/;
+/plugin/;
+
+/ {
+    fragment@0 {
+        target = <&fpga_full>;
+        __overlay__ {
+            firmware-name = "${OVERLAY}.bit.bin";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/amba";
+        __overlay__ {
+            #address-cells = <2>;
+            #size-cells = <2>;
+
+            pccx_npu_uio: fabric@${node_addr} {
+                compatible = "generic-uio";
+                reg = <0x0 ${NPU_BASE} 0x0 ${NPU_SIZE}>;
+            };
+        };
+    };
+};
+DTS
+fi
+dtc -@ -O dtb -o "${DTBO}" "${DTS_OUT}"
+
+printf '[3/4] write shell.json and manifest\n'
+cat >"${SHELL_JSON}" <<JSON
+{
+  "shell_type": "XRT_FLAT",
+  "num_slots": "1"
+}
+JSON
+
+bit_sha256="$(sha256sum "${BIT_SRC_ABS}" | awk '{print $1}')"
+bundle_sha256="$(sha256sum "${BITBIN}" | awk '{print $1}')"
+git_commit="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+bitstream_source_name="$(basename "${BIT_SRC_ABS}")"
+dt_source_name="generated-generic-uio"
+if [[ -n "${DTS_SRC_ABS}" ]]; then
+  dt_source_name="$(basename "${DTS_SRC_ABS}")"
+fi
+cat >"${MANIFEST_JSON}" <<JSON
+{
+  "overlay": "${OVERLAY}",
+  "generated_at_utc": "${generated_at}",
+  "git_commit": "${git_commit}",
+  "bitstream_source": "${bitstream_source_name}",
+  "bitstream_sha256": "${bit_sha256}",
+  "bitbin_sha256": "${bundle_sha256}",
+  "dt_source": "${dt_source_name}",
+  "npu_base": "${NPU_BASE}",
+  "npu_size": "${NPU_SIZE}",
+  "files": [
+    "${OVERLAY}.bit.bin",
+    "${OVERLAY}.dtbo",
+    "shell.json"
+  ]
+}
+JSON
+
+run_or_print() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf 'DRY:'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+printf '[4/4] bundle ready: %s\n' "${BUILD_DIR}"
+if [[ -n "${REGISTER_ROOT}" ]]; then
+  APP_DIR="${REGISTER_ROOT%/}/${OVERLAY}"
+  printf 'register bundle: %s\n' "${APP_DIR}"
+  run_or_print sudo mkdir -p "${APP_DIR}"
+  run_or_print sudo install -m 0644 "${BITBIN}" "${APP_DIR}/${OVERLAY}.bit.bin"
+  run_or_print sudo install -m 0644 "${DTBO}" "${APP_DIR}/${OVERLAY}.dtbo"
+  run_or_print sudo install -m 0644 "${SHELL_JSON}" "${APP_DIR}/shell.json"
+  if [[ "${LOAD_APP}" -eq 1 ]]; then
+    run_or_print sudo xmutil unloadapp
+    run_or_print sudo xmutil loadapp "${OVERLAY}"
+  else
+    printf 'next: sudo xmutil listapps\n'
+    printf 'load only when intended: sudo xmutil loadapp %s\n' "${OVERLAY}"
+  fi
+fi
+
+printf 'bitbin=%s\n' "${BITBIN}"
+printf 'dtbo=%s\n' "${DTBO}"
+printf 'shell_json=%s\n' "${SHELL_JSON}"
+printf 'manifest=%s\n' "${MANIFEST_JSON}"

--- a/sw/dtbo/Makefile
+++ b/sw/dtbo/Makefile
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OVERLAY ?= pccx_npu_bd
+BUILD ?= $(CURDIR)/build/$(OVERLAY)
+BIT_SRC ?=
+DTS_SRC ?=
+GEN_SCRIPT ?= ../../scripts/kv260/generate_sd_platform_bundle.sh
+
+.PHONY: all bundle bitbin dtbo shell-json clean
+
+all: bundle
+
+bundle bitbin dtbo shell-json:
+	@test -n "$(BIT_SRC)" || { echo "BIT_SRC=<system.bit> is required"; exit 2; }
+	"$(GEN_SCRIPT)" --bit "$(BIT_SRC)" --overlay "$(OVERLAY)" --build "$(BUILD)" $(if $(DTS_SRC),--dts "$(DTS_SRC)")
+
+clean:
+	rm -rf build


### PR DESCRIPTION
## Summary

- Add a KV260 SD card reset runbook covering backups, image download routes, flashing tools, first boot checks, and Vitis 2025.2 hardware platform export.
- Add `scripts/kv260/generate_sd_platform_bundle.sh` and `sw/dtbo/Makefile` to generate the `pccx_npu_bd` firmware bundle expected by `xmutil`.
- Link the runbook from repo-local documentation indexes and update the Vivado README pointer now that `sw/dtbo` exists.

Closes #147.

## Validation

- `bash -n scripts/kv260/generate_sd_platform_bundle.sh`
- `git diff --check`
- `scripts/v002/claim-scan.sh`
- `public_surface_scan.py --strict`
- local visual preview screenshot generated for the runbook

## Not run

- Full bundle generation, because this shell does not have `bootgen` or `dtc` on `PATH`.
