### PR TITLE
feat: add bare-metal Gemma standalone skeleton

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,3 +110,16 @@ jobs:
             python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f" \
               || { echo "::error::YAML parse error in $f"; exit 1; }
           done
+
+      - name: Bare-metal standalone build
+        run: |
+          set -e
+          if ! command -v aarch64-none-elf-gcc >/dev/null 2>&1; then
+            echo "::notice::aarch64-none-elf-gcc not available; skipping Vitis BSP ELF build"
+            exit 0
+          fi
+          if [ -z "${PCCX_VITIS_BSP:-}" ]; then
+            echo "::notice::PCCX_VITIS_BSP not set; skipping Vitis BSP ELF build"
+            exit 0
+          fi
+          make -C sw/baremetal BSP_ROOT="${PCCX_VITIS_BSP}" all check-elf

--- a/sw/baremetal/Makefile
+++ b/sw/baremetal/Makefile
@@ -1,0 +1,95 @@
+# PCCX(TM) - reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
+CROSS_COMPILE ?= aarch64-none-elf-
+CC := $(CROSS_COMPILE)gcc
+READELF ?= $(CROSS_COMPILE)readelf
+SIZE ?= $(CROSS_COMPILE)size
+
+BSP_ROOT ?=
+BSP_INCLUDE ?= $(if $(BSP_ROOT),$(BSP_ROOT)/include,)
+BSP_LIB_DIR ?= $(if $(BSP_ROOT),$(BSP_ROOT)/lib,)
+
+BUILD_DIR ?= build
+TARGET ?= gemma_inference
+ELF := $(BUILD_DIR)/$(TARGET).elf
+MAP := $(BUILD_DIR)/$(TARGET).map
+
+SRCS := startup.S gemma_inference.c npu_driver/npu_driver.c
+OBJS := $(addprefix $(BUILD_DIR)/,$(SRCS:=.o))
+DEPS := $(OBJS:.o=.d)
+
+CPPFLAGS := -I. -Inpu_driver
+ifneq ($(BSP_INCLUDE),)
+CPPFLAGS += -I$(BSP_INCLUDE)
+endif
+
+CFLAGS := -Wall -Wextra -Werror -Os -g \
+          -mcpu=cortex-a53 \
+          -ffreestanding -fno-builtin -fno-stack-protector \
+          -ffunction-sections -fdata-sections \
+          -MMD -MP
+ASFLAGS := -mcpu=cortex-a53 -MMD -MP
+LDARCHFLAGS := -mcpu=cortex-a53
+LDFLAGS := -T linker.ld -nostartfiles -Wl,--gc-sections -Wl,-Map,$(MAP)
+LDLIBS := -Wl,--start-group -lxil -lgcc -Wl,--end-group
+
+ifneq ($(BSP_LIB_DIR),)
+LDFLAGS += -L$(BSP_LIB_DIR)
+endif
+
+.PHONY: all check-toolchain check-bsp check-elf clean
+
+all: check-toolchain check-bsp $(ELF)
+
+check-toolchain:
+	@command -v $(CC) >/dev/null || { \
+		echo "error: $(CC) not found; install/source the Vitis standalone AArch64 toolchain" >&2; \
+		exit 1; \
+	}
+
+check-bsp:
+	@test -n "$(BSP_INCLUDE)" || { \
+		echo "error: BSP_INCLUDE or BSP_ROOT is required for Vitis BSP headers" >&2; \
+		exit 1; \
+	}
+	@test -f "$(BSP_INCLUDE)/xil_io.h" || { \
+		echo "error: xil_io.h not found under BSP_INCLUDE=$(BSP_INCLUDE)" >&2; \
+		exit 1; \
+	}
+	@test -n "$(BSP_LIB_DIR)" || { \
+		echo "error: BSP_LIB_DIR or BSP_ROOT is required for libxil.a" >&2; \
+		exit 1; \
+	}
+	@test -f "$(BSP_LIB_DIR)/libxil.a" || { \
+		echo "error: libxil.a not found under BSP_LIB_DIR=$(BSP_LIB_DIR)" >&2; \
+		exit 1; \
+	}
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)/npu_driver
+
+$(BUILD_DIR)/%.S.o: %.S | $(BUILD_DIR)
+	$(CC) $(ASFLAGS) $(CPPFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/%.c.o: %.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+
+$(ELF): $(OBJS) linker.ld
+	$(CC) $(LDARCHFLAGS) $(OBJS) $(LDFLAGS) $(LDLIBS) -o $@
+	$(SIZE) $@
+
+check-elf: $(ELF)
+	@$(READELF) -h $(ELF) | grep -q 'Machine:[[:space:]]*AArch64'
+	@$(READELF) -S $(ELF) | grep -q '\.text'
+	@$(READELF) -S $(ELF) | grep -q '\.data'
+	@$(READELF) -S $(ELF) | grep -q '\.pccx_weights'
+	@$(READELF) -S $(ELF) | grep -q '\.pccx_activations'
+	@$(READELF) -s $(ELF) | grep -q '__pccx_weight_buffer_start'
+	@$(READELF) -s $(ELF) | grep -q '__pccx_activation_buffer_start'
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+-include $(DEPS)

--- a/sw/baremetal/gemma_inference.c
+++ b/sw/baremetal/gemma_inference.c
@@ -1,0 +1,181 @@
+// PCCX(TM) - reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
+#include "npu_driver/npu_driver.h"
+
+#include "xil_types.h"
+
+#define GEMMA_WEIGHT_DESC_COUNT       4U
+#define GEMMA_WEIGHT_STAGE_BYTES      (4U * 1024U * 1024U)
+#define GEMMA_ACTIVATION_STAGE_BYTES  (1U * 1024U * 1024U)
+#define GEMMA_MAX_PROMPT_TOKENS       16U
+#define GEMMA_MAX_NEW_TOKENS          1U
+#define GEMMA_SESSION_ID              1U
+#define GEMMA_MANIFEST_ID             0x000e4b00U
+#define GEMMA_POLL_LIMIT              1000000U
+
+extern u8 __pccx_weight_buffer_start[];
+extern u8 __pccx_weight_buffer_end[];
+extern u8 __pccx_activation_buffer_start[];
+extern u8 __pccx_activation_buffer_end[];
+
+static u8 g_weight_stage[GEMMA_WEIGHT_STAGE_BYTES]
+    __attribute__((section(".pccx_weights"), aligned(64)));
+static u8 g_activation_stage[GEMMA_ACTIVATION_STAGE_BYTES]
+    __attribute__((section(".pccx_activations"), aligned(64)));
+static pccx_npu_dma_desc g_weight_desc[GEMMA_WEIGHT_DESC_COUNT]
+    __attribute__((section(".pccx_activations"), aligned(64)));
+static u32 g_prompt_tokens[GEMMA_MAX_PROMPT_TOKENS]
+    __attribute__((section(".pccx_activations"), aligned(64)));
+static u32 g_generated_tokens[GEMMA_MAX_NEW_TOKENS]
+    __attribute__((section(".pccx_activations"), aligned(64)));
+static volatile u32 g_boot_cookie = 0x50434358U;
+
+static int gemma_check_memory_layout(void)
+{
+    UINTPTR weight_start = (UINTPTR)__pccx_weight_buffer_start;
+    UINTPTR weight_end = (UINTPTR)__pccx_weight_buffer_end;
+    UINTPTR activation_start = (UINTPTR)__pccx_activation_buffer_start;
+    UINTPTR activation_end = (UINTPTR)__pccx_activation_buffer_end;
+
+    if ((weight_start + GEMMA_WEIGHT_STAGE_BYTES) > weight_end) {
+        return -1;
+    }
+    if ((activation_start + GEMMA_ACTIVATION_STAGE_BYTES) > activation_end) {
+        return -2;
+    }
+    return 0;
+}
+
+static u32 gemma_tokenize_ascii_prompt(const char *prompt, u32 *tokens, u32 max_tokens)
+{
+    u32 count = 0U;
+    while ((prompt[count] != '\0') && (count < max_tokens)) {
+        tokens[count] = (u32)(u8)prompt[count];
+        count++;
+    }
+    return count;
+}
+
+static void gemma_prepare_weight_descriptors(void)
+{
+    u32 chunk = GEMMA_WEIGHT_STAGE_BYTES / GEMMA_WEIGHT_DESC_COUNT;
+    u32 index;
+
+    for (index = 0U; index < GEMMA_WEIGHT_DESC_COUNT; index++) {
+        UINTPTR src = (UINTPTR)&g_weight_stage[index * chunk];
+        UINTPTR dst = (UINTPTR)&__pccx_weight_buffer_start[index * chunk];
+        pccx_npu_dma_desc_setup(&g_weight_desc[index],
+                                src,
+                                dst,
+                                chunk,
+                                PCCX_NPU_DMA_TO_NPU,
+                                index);
+    }
+}
+
+static int gemma_reset_session(const pccx_npu *npu)
+{
+    u64 command = pccx_npu_encode_reset_kv_cache(GEMMA_SESSION_ID);
+    pccx_npu_issue_word(npu, command);
+    return pccx_npu_wait_idle(npu, GEMMA_POLL_LIMIT);
+}
+
+static int gemma_load_weights(const pccx_npu *npu)
+{
+    u64 command;
+
+    pccx_npu_flush_range(g_weight_stage, GEMMA_WEIGHT_STAGE_BYTES);
+    pccx_npu_flush_range(g_weight_desc, (u32)sizeof(g_weight_desc));
+
+    command = pccx_npu_encode_load_weight(0U,
+                                          (u8)GEMMA_WEIGHT_DESC_COUNT,
+                                          GEMMA_MANIFEST_ID,
+                                          0U);
+    pccx_npu_issue_word(npu, command);
+    return pccx_npu_wait_idle(npu, GEMMA_POLL_LIMIT);
+}
+
+static int gemma_load_prompt(const pccx_npu *npu, const u32 *tokens, u32 token_count)
+{
+    u32 index;
+
+    pccx_npu_flush_range(tokens, token_count * (u32)sizeof(tokens[0]));
+
+    for (index = 0U; index < token_count; index++) {
+        u64 command = pccx_npu_encode_load_prompt(index, tokens[index]);
+        pccx_npu_issue_word(npu, command);
+        if (pccx_npu_wait_idle(npu, GEMMA_POLL_LIMIT) != 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int gemma_forward_one_token(const pccx_npu *npu, u32 request_id, u32 *token_out)
+{
+    u64 command = pccx_npu_encode_next_token((u16)request_id,
+                                             0U,
+                                             0U,
+                                             0x0100U);
+    pccx_npu_issue_word(npu, command);
+    if (pccx_npu_wait_idle(npu, GEMMA_POLL_LIMIT) != 0) {
+        return -1;
+    }
+    return pccx_npu_read_token(npu, token_out);
+}
+
+static int gemma_readback(const pccx_npu *npu)
+{
+    (void)npu;
+    pccx_npu_invalidate_range(g_generated_tokens, (u32)sizeof(g_generated_tokens));
+    pccx_npu_invalidate_range(g_activation_stage, GEMMA_ACTIVATION_STAGE_BYTES);
+    return 0;
+}
+
+int main(void)
+{
+    pccx_npu npu;
+    u32 token_count;
+    int rc;
+
+    rc = pccx_npu_init(&npu, &pccx_npu_default_config);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (g_boot_cookie != 0x50434358U) {
+        return -1;
+    }
+
+    rc = gemma_check_memory_layout();
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = gemma_reset_session(&npu);
+    if (rc != 0) {
+        return rc;
+    }
+
+    gemma_prepare_weight_descriptors();
+
+    rc = gemma_load_weights(&npu);
+    if (rc != 0) {
+        return rc;
+    }
+
+    token_count = gemma_tokenize_ascii_prompt("PCCX", g_prompt_tokens, GEMMA_MAX_PROMPT_TOKENS);
+    rc = gemma_load_prompt(&npu, g_prompt_tokens, token_count);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = gemma_forward_one_token(&npu, 0U, &g_generated_tokens[0]);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return gemma_readback(&npu);
+}

--- a/sw/baremetal/linker.ld
+++ b/sw/baremetal/linker.ld
@@ -1,0 +1,75 @@
+/* PCCX(TM) - reusable AI accelerator project.
+ * SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ENTRY(_start)
+
+MEMORY
+{
+    DDR_CODE       (rwx) : ORIGIN = 0x00100000, LENGTH = 64M
+    DDR_WEIGHTS    (rw)  : ORIGIN = 0x10000000, LENGTH = 256M
+    DDR_ACTIVATION (rw)  : ORIGIN = 0x20000000, LENGTH = 128M
+}
+
+PROVIDE(__pccx_weight_buffer_start = ORIGIN(DDR_WEIGHTS));
+PROVIDE(__pccx_weight_buffer_end = ORIGIN(DDR_WEIGHTS) + LENGTH(DDR_WEIGHTS));
+PROVIDE(__pccx_activation_buffer_start = ORIGIN(DDR_ACTIVATION));
+PROVIDE(__pccx_activation_buffer_end = ORIGIN(DDR_ACTIVATION) + LENGTH(DDR_ACTIVATION));
+
+SECTIONS
+{
+    .text : ALIGN(64)
+    {
+        KEEP(*(.text.startup))
+        *(.text*)
+        *(.rodata*)
+    } > DDR_CODE
+
+    .data : ALIGN(64)
+    {
+        __data_start = .;
+        *(.data*)
+        __data_end = .;
+    } > DDR_CODE
+
+    .bss (NOLOAD) : ALIGN(64)
+    {
+        __bss_start = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end = .;
+    } > DDR_CODE
+
+    .heap_stack (NOLOAD) : ALIGN(64)
+    {
+        __heap_start = .;
+        . = . + 0x00100000;
+        __heap_end = .;
+        __stack_limit = .;
+        . = . + 0x00100000;
+        _stack_top = .;
+    } > DDR_CODE
+
+    .pccx_weights (NOLOAD) : ALIGN(64)
+    {
+        __pccx_weight_section_start = .;
+        KEEP(*(.pccx_weights))
+        . = ALIGN(64);
+        __pccx_weight_section_end = .;
+    } > DDR_WEIGHTS
+
+    .pccx_activations (NOLOAD) : ALIGN(64)
+    {
+        __pccx_activation_section_start = .;
+        KEEP(*(.pccx_activations))
+        . = ALIGN(64);
+        __pccx_activation_section_end = .;
+    } > DDR_ACTIVATION
+
+    /DISCARD/ :
+    {
+        *(.note*)
+        *(.comment*)
+    }
+}

--- a/sw/baremetal/npu_driver/npu_driver.c
+++ b/sw/baremetal/npu_driver/npu_driver.c
@@ -1,0 +1,162 @@
+// PCCX(TM) - reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
+#include "npu_driver.h"
+
+#include "xil_cache.h"
+#include "xil_io.h"
+
+const pccx_npu_config pccx_npu_default_config = {
+    .npu_base = PCCX_NPU_AXIL_BASE,
+    .cmdsts_hp0_base = PCCX_NPU_CMDSTS_HP0_BASE,
+    .cmdsts_hp1_base = PCCX_NPU_CMDSTS_HP1_BASE,
+    .cmdsts_hp2_base = PCCX_NPU_CMDSTS_HP2_BASE,
+    .cmdsts_hp3_base = PCCX_NPU_CMDSTS_HP3_BASE,
+    .cmdsts_acp_fmap_base = PCCX_NPU_CMDSTS_ACP_FMAP_BASE,
+    .cmdsts_acp_result_base = PCCX_NPU_CMDSTS_ACP_RESULT_BASE,
+};
+
+static UINTPTR npu_addr(const pccx_npu *npu, u32 offset)
+{
+    return npu->cfg->npu_base + (UINTPTR)offset;
+}
+
+static u64 pack_host_command(u8 opcode, u64 operand)
+{
+    return ((u64)(opcode & 0xffU) << 56) | (operand & 0x00ffffffffffffffULL);
+}
+
+int pccx_npu_init(pccx_npu *npu, const pccx_npu_config *cfg)
+{
+    npu->cfg = cfg ? cfg : &pccx_npu_default_config;
+    return 0;
+}
+
+void pccx_npu_write32(const pccx_npu *npu, u32 offset, u32 value)
+{
+    Xil_Out32(npu_addr(npu, offset), value);
+}
+
+u32 pccx_npu_read32(const pccx_npu *npu, u32 offset)
+{
+    return Xil_In32(npu_addr(npu, offset));
+}
+
+void pccx_npu_write64(const pccx_npu *npu, u32 offset, u64 value)
+{
+#if defined(__aarch64__)
+    Xil_Out64(npu_addr(npu, offset), value);
+#else
+    Xil_Out32(npu_addr(npu, offset), (u32)(value & 0xffffffffULL));
+    Xil_Out32(npu_addr(npu, offset + 4U), (u32)(value >> 32));
+#endif
+}
+
+u64 pccx_npu_read64(const pccx_npu *npu, u32 offset)
+{
+#if defined(__aarch64__)
+    return Xil_In64(npu_addr(npu, offset));
+#else
+    u64 lo = Xil_In32(npu_addr(npu, offset));
+    u64 hi = Xil_In32(npu_addr(npu, offset + 4U));
+    return lo | (hi << 32);
+#endif
+}
+
+void pccx_npu_issue_word(const pccx_npu *npu, u64 word)
+{
+    pccx_npu_write64(npu, PCCX_NPU_REG_INSTRUCTION, word);
+    pccx_npu_write64(npu, PCCX_NPU_REG_KICK, PCCX_NPU_KICK_WORD);
+}
+
+u64 pccx_npu_read_status(const pccx_npu *npu)
+{
+    return pccx_npu_read64(npu, PCCX_NPU_REG_STATUS);
+}
+
+int pccx_npu_wait_idle(const pccx_npu *npu, u32 poll_limit)
+{
+    while (poll_limit > 0U) {
+        u64 status = pccx_npu_read_status(npu);
+        if ((status & PCCX_NPU_STATUS_ERROR) != 0ULL) {
+            return -2;
+        }
+        if ((status & PCCX_NPU_STATUS_BUSY) == 0ULL) {
+            return 0;
+        }
+        poll_limit--;
+    }
+    return -1;
+}
+
+int pccx_npu_read_token(const pccx_npu *npu, u32 *token_out)
+{
+    u64 status = pccx_npu_read_status(npu);
+    if ((status & PCCX_NPU_STATUS_TOKEN_VALID) == 0ULL) {
+        return -1;
+    }
+    *token_out = (u32)(status >> PCCX_NPU_STATUS_TOKEN_SHIFT);
+    return 0;
+}
+
+void pccx_npu_flush_range(const void *addr, u32 bytes)
+{
+    Xil_DCacheFlushRange((UINTPTR)addr, bytes);
+}
+
+void pccx_npu_invalidate_range(const void *addr, u32 bytes)
+{
+    Xil_DCacheInvalidateRange((UINTPTR)addr, bytes);
+}
+
+void pccx_npu_dma_desc_setup(pccx_npu_dma_desc *desc,
+                             UINTPTR src_addr,
+                             UINTPTR dst_addr,
+                             u32 bytes,
+                             pccx_npu_dma_direction direction,
+                             u32 tag)
+{
+    desc->src_addr = (u64)src_addr;
+    desc->dst_addr = (u64)dst_addr;
+    desc->bytes = bytes;
+    desc->flags = (direction == PCCX_NPU_DMA_TO_NPU) ? 0U : 1U;
+    desc->route = (direction == PCCX_NPU_DMA_TO_NPU) ? 0U : 1U;
+    desc->tag = tag;
+    pccx_npu_flush_range(desc, (u32)sizeof(*desc));
+}
+
+u64 pccx_npu_encode_reset_kv_cache(u32 session_id)
+{
+    return pack_host_command(PCCX_HOST_OPCODE_RESET_KV, (u64)session_id);
+}
+
+u64 pccx_npu_encode_load_weight(u8 weight_slot,
+                                u8 descriptor_count,
+                                u32 manifest_id,
+                                u8 flags)
+{
+    u64 operand = ((u64)weight_slot << 48)
+                | ((u64)flags << 40)
+                | ((u64)descriptor_count << 32)
+                | (u64)manifest_id;
+    return pack_host_command(PCCX_HOST_OPCODE_LOAD_WEIGHT, operand);
+}
+
+u64 pccx_npu_encode_load_prompt(u32 position, u32 token_id)
+{
+    u64 operand = (((u64)position & 0x00ffffffULL) << 32) | (u64)token_id;
+    return pack_host_command(PCCX_HOST_OPCODE_LOAD_PROMPT, operand);
+}
+
+u64 pccx_npu_encode_next_token(u16 request_id,
+                               u8 sampling,
+                               u16 temperature_q8_8,
+                               u16 top_p_q8_8)
+{
+    u64 operand = ((u64)request_id << 40)
+                | ((u64)sampling << 32)
+                | ((u64)temperature_q8_8 << 16)
+                | (u64)top_p_q8_8;
+    return pack_host_command(PCCX_HOST_OPCODE_NEXT_TOKEN, operand);
+}

--- a/sw/baremetal/npu_driver/npu_driver.h
+++ b/sw/baremetal/npu_driver/npu_driver.h
@@ -1,0 +1,98 @@
+// PCCX(TM) - reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PCCX_BAREMETAL_NPU_DRIVER_H
+#define PCCX_BAREMETAL_NPU_DRIVER_H
+
+#include "xil_types.h"
+
+#define PCCX_NPU_AXIL_BASE             0xA0000000UL
+#define PCCX_NPU_CMDSTS_HP0_BASE       0xA0001000UL
+#define PCCX_NPU_CMDSTS_HP1_BASE       0xA0002000UL
+#define PCCX_NPU_CMDSTS_HP2_BASE       0xA0003000UL
+#define PCCX_NPU_CMDSTS_HP3_BASE       0xA0004000UL
+#define PCCX_NPU_CMDSTS_ACP_FMAP_BASE  0xA0005000UL
+#define PCCX_NPU_CMDSTS_ACP_RESULT_BASE 0xA0006000UL
+
+#define PCCX_NPU_REG_INSTRUCTION       0x000U
+#define PCCX_NPU_REG_KICK              0x008U
+#define PCCX_NPU_REG_STATUS            0x010U
+#define PCCX_NPU_CMDSTS_FLAGS          0x014U
+
+#define PCCX_NPU_KICK_WORD             0x8000000000000000ULL
+#define PCCX_NPU_STATUS_BUSY           (1ULL << 0)
+#define PCCX_NPU_STATUS_DONE           (1ULL << 1)
+#define PCCX_NPU_STATUS_ERROR          (1ULL << 2)
+#define PCCX_NPU_STATUS_TOKEN_VALID    (1ULL << 3)
+#define PCCX_NPU_STATUS_TOKEN_SHIFT    32U
+
+#define PCCX_HOST_OPCODE_RESET_KV      0x01U
+#define PCCX_HOST_OPCODE_LOAD_WEIGHT   0x02U
+#define PCCX_HOST_OPCODE_LOAD_PROMPT   0x03U
+#define PCCX_HOST_OPCODE_NEXT_TOKEN    0x04U
+
+typedef enum {
+    PCCX_NPU_DMA_TO_NPU = 0,
+    PCCX_NPU_DMA_FROM_NPU = 1,
+} pccx_npu_dma_direction;
+
+typedef struct {
+    UINTPTR npu_base;
+    UINTPTR cmdsts_hp0_base;
+    UINTPTR cmdsts_hp1_base;
+    UINTPTR cmdsts_hp2_base;
+    UINTPTR cmdsts_hp3_base;
+    UINTPTR cmdsts_acp_fmap_base;
+    UINTPTR cmdsts_acp_result_base;
+} pccx_npu_config;
+
+typedef struct {
+    const pccx_npu_config *cfg;
+} pccx_npu;
+
+typedef struct __attribute__((aligned(64))) {
+    u64 src_addr;
+    u64 dst_addr;
+    u32 bytes;
+    u32 flags;
+    u32 route;
+    u32 tag;
+} pccx_npu_dma_desc;
+
+extern const pccx_npu_config pccx_npu_default_config;
+
+int pccx_npu_init(pccx_npu *npu, const pccx_npu_config *cfg);
+
+void pccx_npu_write32(const pccx_npu *npu, u32 offset, u32 value);
+u32 pccx_npu_read32(const pccx_npu *npu, u32 offset);
+void pccx_npu_write64(const pccx_npu *npu, u32 offset, u64 value);
+u64 pccx_npu_read64(const pccx_npu *npu, u32 offset);
+
+void pccx_npu_issue_word(const pccx_npu *npu, u64 word);
+u64 pccx_npu_read_status(const pccx_npu *npu);
+int pccx_npu_wait_idle(const pccx_npu *npu, u32 poll_limit);
+int pccx_npu_read_token(const pccx_npu *npu, u32 *token_out);
+
+void pccx_npu_flush_range(const void *addr, u32 bytes);
+void pccx_npu_invalidate_range(const void *addr, u32 bytes);
+
+void pccx_npu_dma_desc_setup(pccx_npu_dma_desc *desc,
+                             UINTPTR src_addr,
+                             UINTPTR dst_addr,
+                             u32 bytes,
+                             pccx_npu_dma_direction direction,
+                             u32 tag);
+
+u64 pccx_npu_encode_reset_kv_cache(u32 session_id);
+u64 pccx_npu_encode_load_weight(u8 weight_slot,
+                                u8 descriptor_count,
+                                u32 manifest_id,
+                                u8 flags);
+u64 pccx_npu_encode_load_prompt(u32 position, u32 token_id);
+u64 pccx_npu_encode_next_token(u16 request_id,
+                               u8 sampling,
+                               u16 temperature_q8_8,
+                               u16 top_p_q8_8);
+
+#endif

--- a/sw/baremetal/startup.S
+++ b/sw/baremetal/startup.S
@@ -1,0 +1,17 @@
+// PCCX(TM) - reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
+    .section .text.startup, "ax"
+    .align 7
+    .global _start
+    .type _start, %function
+
+_start:
+    ldr x0, =_stack_top
+    mov sp, x0
+    bl main
+
+1:
+    wfe
+    b 1b


### PR DESCRIPTION
## Summary

- Adds sw/baremetal Vitis BSP standalone driver scaffolding for AXI-Lite read/write, command issue, status polling, cache maintenance, and DMA descriptor setup.
- Adds gemma_inference.c skeleton covering reset, weight descriptor load, prompt tokenization, one-token forward, and readback without Linux/uio dependencies.
- Adds linker.ld DDR layout with text/data/heap/stack plus explicit weight and activation regions.
- Adds a Makefile for aarch64-none-elf-gcc and a validate workflow gate that builds when the Vitis BSP/toolchain are present.

## Validation

- PASS: gcc -fsyntax-only with temporary Vitis BSP stubs for the new C sources.
- PASS: workflow YAML parse.
- PASS: git diff --check.
- PASS: scripts/v002/claim-scan.sh.
- BLOCKED locally: make -C sw/baremetal all, because this host does not have aarch64-none-elf-gcc or a Vitis BSP path installed.
- Pre-existing blocker: scripts/v002/artifact-safety-check.sh fails on tracked absolute paths outside this change.

## Checklist

- [x] Scope is limited to the stated change.
- [x] Documentation is updated when public behavior changes.
- [x] Security-sensitive changes are called out for review.
