### PR TITLE
docs: add v30 dual-MAC recovery evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Pages, bilingual EN / KO).
   [VIVADO_LOG_POLICY.md](VIVADO_LOG_POLICY.md)
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
+- v0.2.0 v30 dual-MAC recovery evidence:
+  [releases/v0.2.0-v30-dualmac-evidence.md](releases/v0.2.0-v30-dualmac-evidence.md)
 - M01 v002 correctness & bring-up close criteria:
   [spec/m01-v002-close-criteria.md](spec/m01-v002-close-criteria.md)
 - Documentation root (language picker):

--- a/docs/releases/v0.2.0-v30-dualmac-evidence.md
+++ b/docs/releases/v0.2.0-v30-dualmac-evidence.md
@@ -1,0 +1,60 @@
+# v0.2.0 v30 Dual-MAC Recovery Evidence
+
+Date: 2026-06-03
+
+This note records the current public v0.2.0 KV260 bring-up evidence after the
+v30 packed dual-MAC GEMM result recovery fix.
+
+## Public RTL
+
+- `pccxai/pccx-v002#16` merged to `main`.
+- Merge commit: `fda63a37f11ebba761c67eb7cda611bef3f3d11b`.
+- Change scope:
+  - add `GEMM_dual_mac_recover`
+  - recover packed W4A8 DSP lower/upper lane sums before BF16 normalization
+  - route `pccx_npu_top` result normalizers through the recovered signed sum
+  - add the new module to `LLM/scripts/filelist.f`
+
+## Verification Summary
+
+| Gate | Result |
+|---|---|
+| Targeted xsim | PASS |
+| Full xsim regression | PASS 30 / FAIL 0 |
+| Full-BD implementation | `FULL_TOP_FLOW_IMPL_MET` |
+| Bitstream status | `BITSTREAM_REQUESTED` |
+| Timing | WNS `2.895 ns`, TNS `0.000 ns`, WHS `0.010 ns`, THS `0.000 ns` |
+| DRC | 0 errors |
+| Pre-deploy | PASS, canonical LE-swapped `.bit.bin` |
+| KV260 Step00 | PASS |
+| KV260 repeated Stage0 | PASS fresh reload / no reload / fresh reload |
+| KV260 Stage1A | PASS HP0/HP1 INT4 weight ingress |
+| KV260 post-Stage1 Stage0 | PASS |
+
+## Artifact Fingerprints
+
+```text
+.bit SHA-256     74632e8ead9bd9e7a284c9843bc4bc10d7bc402bee6da82c68ac8c1e2da5a835
+.bit md5         0aa7562e4f36ba2f3dd96c68fc7a4b16
+
+.bit.bin SHA-256 ff45a44649569212a912cf524da26ac3390b93b7e321303a6a629ccb8ddde0d7
+.bit.bin md5     2e1f77c51882aeaddde9c6074f00f4e0
+
+.dtbo SHA-256    2f2259e2409afa4ac50a7e6a1fa71004cb8d4fd6ba5de956d541d9a37971a46c
+shell.json SHA   a13dbd0a508de4656c3ba22aa9f8a41494a5082bcd585589fc366a56cc5ba1c1
+```
+
+## GitHub Tracking
+
+- v0.2.0 evidence tracker: `pccxai/pccx-FPGA-NPU-LLM-kv260#58`
+- v002 bring-up epic: `pccxai/pccx-FPGA-NPU-LLM-kv260#43`
+- remaining full Stage1 GEMM runtime harness tracker:
+  `pccxai/pccx-FPGA-NPU-LLM-kv260#154`
+
+## Remaining Boundary
+
+Full Stage1 GEMM numeric silicon validation remains a runtime harness task.
+The current guard in `stage1_gemm_silicon.py` intentionally returns RC=3 until
+the harness coordinates HP0/HP1 weight streams with fmap/GEMM instruction issue
+and adds a deterministic scoreboard.
+


### PR DESCRIPTION
## Summary

- add a public v0.2.0 v30 dual-MAC recovery evidence note
- link it from the repo-local docs index

## Evidence Covered

- pccxai/pccx-v002#16 merge commit
- GCP xsim PASS 30 / FAIL 0
- full-BD timing and bitstream status
- pre-deploy canonical `.bit.bin` check
- KV260 Step00, repeated Stage0, Stage1A, and post-Stage1 Stage0 results

## Remaining Boundary

Full Stage1 GEMM numeric silicon validation remains tracked by #154 as a runtime harness and scoreboard task.
