### PR TITLE
Document v31 Stage1 GEMM evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Pages, bilingual EN / KO).
   [VIVADO_LOG_POLICY.md](VIVADO_LOG_POLICY.md)
 - Repo-local release evidence checklist:
   [RELEASE_EVIDENCE_CHECKLIST.md](RELEASE_EVIDENCE_CHECKLIST.md)
+- v0.2.1 v31 Stage1 GEMM contract evidence:
+  [releases/v0.2.1-v31-stage1-gemm-evidence.md](releases/v0.2.1-v31-stage1-gemm-evidence.md)
 - v0.2.0 v30 dual-MAC recovery evidence:
   [releases/v0.2.0-v30-dualmac-evidence.md](releases/v0.2.0-v30-dualmac-evidence.md)
 - M01 v002 correctness & bring-up close criteria:

--- a/docs/releases/v0.2.1-v31-stage1-gemm-evidence.md
+++ b/docs/releases/v0.2.1-v31-stage1-gemm-evidence.md
@@ -1,0 +1,120 @@
+# v0.2.1 v31 Stage1 GEMM Contract Evidence
+
+Date: 2026-06-03
+
+This note records the v31 KV260 bring-up evidence after the Stage1 GEMM timing
+contract fixes. v31 keeps the v30 packed dual-MAC recovery path and adds two
+contract fixes found during full-diagnose:
+
+- DSP MAC P-register clock enable is gated by activation valid:
+  `dsp_ce_p = (current_inst[0] & i_valid) | is_flushing`.
+- The HP0/HP1 INT4 weight dispatcher keeps one pending beat per lane, so a
+  one-cycle upper/lower valid skew is paired instead of silently starving the
+  systolic array.
+
+## Public RTL
+
+Public source sync is split across:
+
+- `pccxai/pccx-v002#17`: RTL and testbench contract changes.
+- `pccxai/pccx-FPGA-NPU-LLM-kv260`: KV260 evidence and bring-up tracking.
+
+## Verification Summary
+
+| Gate | Result |
+|---|---|
+| DSP CE targeted xsim | PASS |
+| DSP CE full xsim regression | PASS 31 / FAIL 0 |
+| Weight pairer targeted xsim | PASS |
+| Weight pairer full xsim regression | PASS 31 / FAIL 0 |
+| HP FIFO to weight pairer skew xsim | PASS 46 / FAIL 0 |
+| Final full xsim regression | PASS 32 / FAIL 0 |
+| Public `pccx-v002` full runner | PASS 14 / FAIL 0 |
+| Full-BD implementation | `FULL_TOP_FLOW_IMPL_MET` |
+| Bitstream status | `BITSTREAM_REQUESTED` |
+| Timing | WNS `2.486 ns`, TNS `0.000 ns`, WHS `0.010 ns`, THS `0.000 ns` |
+| DRC | 0 errors |
+| Pre-deploy | PASS, canonical LE-swapped `.bit.bin` |
+| KV260 deploy | PASS, FPGA manager `operating`, UIO `pccx-npu` |
+| KV260 Stage0 | PASS |
+| KV260 Stage1A | PASS HP0/HP1 INT4 weight ingress |
+| KV260 post-Stage1A Stage0 | PASS |
+| KV260 Stage1 GEMM guard | Expected RC=3 until the numeric harness is implemented |
+
+## Artifact Fingerprints
+
+```text
+.bit SHA-256     e047ee1fbad08bdf9e71fa69e35e158c348ecde9425681963247854684452050
+.bit md5         db63540cb8b9257947a830ff36981c6c
+
+.bit.bin SHA-256 7dc1d6004aff1159cfd44ca987156561fbda0c850fc919575cf814a969d27db2
+.bit.bin md5     89e3c4e238c30cf02db537fd232dc5d3
+```
+
+## Evidence Logs
+
+```text
+debug/results/gcp_v31_dsp_ce_targeted_20260603T095505Z.log
+sha256 fa7a6927ad47e6d58cba72cb6d5c3bdb40ad12c119dff5c6b39de8ecd7c690c9
+
+debug/results/gcp_v31_dsp_ce_run_all_20260603T095651Z.log
+sha256 9ba1fa1496a0cce8b925abbe27bdb2752b131d334b84e96f46cb7829729cc4fa
+
+debug/results/gcp_v31_pairer_targeted_20260603T100625Z.log
+sha256 0f98769db97fc0ce7910c914cb252b4936d17967809724ee6030d5e3dafd3654
+
+debug/results/gcp_v31_pairer_run_all_20260603T100816Z.log
+sha256 03c99be572a2ec8110dfc1bac46e0114a37074976564da18fe5d5ceeae99c201
+
+debug/results/gcp_v31_hp_pairer_skew_targeted_20260603T101944Z.log
+sha256 1f11ea2168d0133d13640f362f4812e0476c9f79c1c2d0a77bdf11534616dd94
+
+debug/results/gcp_v31_with_hp_pairer_skew_run_all_20260603T102012Z.log
+sha256 40fcdd020e8318984ed1d86a3e60e4da89483859d38599ed6721fd7addd0cde0
+
+debug/results/gcp_v31_with_hp_pairer_skew_RESULTS_20260603T102012Z.md
+sha256 713191969c94313eec0366754f2e6051524bc89e9899deab517483e412c7f725
+
+debug/results/gcp_v31_full_bd_bitstream_20260603T103103Z.log
+sha256 e09f5a6bf280528dc8cd30d7104e2ee97e151ae421d1c3e4a9d9ab94049829a2
+
+debug/results/gcp_v31_stage1_gemm_pre_deploy_check_20260603T103103Z.log
+sha256 6ac755effb3143ed9e8cf5cb37c3393752dabba6c4baa39ba3957764dd4e47bb
+
+debug/results/board_v31_stage1_gemm_deploy_20260603T111946Z.log
+sha256 df33a39588ea4e7f6d1828d43a68bdb6f30e09d4bafe44c13386e25906ac4907
+
+debug/results/board_v31_stage0_roundtrip_20260603T112052Z.log
+sha256 b3ea675f7a66d3ebade6db499cc18f3bc5bc7a6e95685fd8cd5e52d3268914f1
+
+debug/results/board_v31_stage1_weight_ingress_20260603T112111Z.log
+sha256 53e4da14fce3949731942fd6854b891e2f13b06205e0ce8474795839569b396e
+
+debug/results/board_v31_post_stage1_stage0_20260603T112200Z.log
+sha256 b3ea675f7a66d3ebade6db499cc18f3bc5bc7a6e95685fd8cd5e52d3268914f1
+
+debug/results/board_v31_stage1_gemm_blocked_20260603T112220Z.log
+sha256 59bcad293b76cf68fc73ee53742c5c969fe2bc9ccf1536e3f554e1946d31eda2
+
+debug/results/board_v31_final_cleanup_reload_20260603T112242Z.log
+sha256 4b9f74c7fa154e64aee6dbd5c8c4922fac11bf9e4860c9ca904559631e2e7e1e
+```
+
+Public `pccx-v002#17` runner check:
+
+```text
+cd /home/hwkim/public-v002-v31
+export XILINX_VIVADO=/tools/Xilinx/2025.2/Vivado
+export PATH=/tools/Xilinx/2025.2/Vivado/bin:$PATH
+export PCCX_SMOKE_PROGRAM_TOOL=/home/hwkim/v002-rtl/tools/v002/generate_smoke_program.py
+LLM/sim/run_verification.sh --full
+
+==> Summary: 14 passed, 0 failed
+```
+
+## Remaining Boundary
+
+Full Stage1 GEMM numeric silicon validation remains a runtime harness task, not
+a v31 bitstream failure. The next required work is a deterministic harness that
+packs HP0/HP1 INT4 weight streams, coordinates fmap and GEMM instruction issue,
+and compares the KV260 result against a golden scoreboard.

--- a/docs/spec/milestone-tracker.md
+++ b/docs/spec/milestone-tracker.md
@@ -3,6 +3,15 @@
 Snapshot source: `gh issue list --state open --limit 200`, captured
 2026-05-07.
 
+Latest evidence update: v31 Stage1 GEMM contract evidence was captured on
+2026-06-03 and is tracked in
+[`docs/releases/v0.2.1-v31-stage1-gemm-evidence.md`](../releases/v0.2.1-v31-stage1-gemm-evidence.md).
+The public RTL/testbench sync is
+[`pccxai/pccx-v002#17`](https://github.com/pccxai/pccx-v002/pull/17).
+The remaining active hardware boundary is full Stage1 GEMM numeric silicon
+validation, tracked by issue
+[#154](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/issues/154).
+
 This tracker maps every currently open issue into the active planning
 milestones:
 


### PR DESCRIPTION
## Summary

- Add v0.2.1 v31 Stage1 GEMM contract evidence with GCP, full-BD, timing, pre-deploy, and KV260 board smoke results.
- Link the public RTL/testbench sync PR: pccxai/pccx-v002#17.
- Update docs read order and milestone tracker so #154 remains the explicit full Stage1 GEMM numeric harness boundary.

## Evidence Captured

- v31 final deploy-suite xsim: PASS 32 / FAIL 0.
- public pccx-v002 runner: PASS 14 / FAIL 0 on GCP Vivado 2025.2.
- full-BD implementation: `FULL_TOP_FLOW_IMPL_MET`.
- timing: WNS `2.486 ns`, TNS `0.000 ns`, WHS `0.010 ns`, THS `0.000 ns`.
- KV260 board smoke: deploy PASS, Stage0 PASS, Stage1A HP0/HP1 weight ingress PASS, post-Stage1A Stage0 PASS.

## Remaining Boundary

Full Stage1 GEMM numeric silicon validation remains open and is tracked by #154. The current board script intentionally returns RC=3 until HP0/HP1 INT4 weight packing/timing and a deterministic scoreboard are implemented.
